### PR TITLE
Pressable support for TV

### DIFF
--- a/Libraries/Components/AppleTV/useTVEventHandler.js
+++ b/Libraries/Components/AppleTV/useTVEventHandler.js
@@ -1,3 +1,4 @@
+// @flow
 import React from 'react';
 import TVEventHandler from './TVEventHandler';
 

--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -244,13 +244,9 @@ function Pressable(props: Props, forwardedRef): React.Node {
       if (viewRef.current._nativeTag === evt.target) {
         if (evt?.eventType === 'focus') {
           setFocused(true);
-          setPressed(true);
-          onPressIn && onPressIn(evt);
           onFocus && onFocus(evt);
         } else if (evt.eventType === 'blur') {
           onBlur && onBlur(evt);
-          onPressOut && onPressOut(evt);
-          setPressed(false);
           setFocused(false);
         }
       }

--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -28,11 +28,24 @@ import {normalizeRect, type RectOrSize} from '../../StyleSheet/Rect';
 import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';
 import type {LayoutEvent, PressEvent} from '../../Types/CoreEventTypes';
 import View from '../View/View';
+import Platform from '../../Utilities/Platform';
+import typeof TVParallaxPropertiesType from '../AppleTV/TVViewPropTypes';
 
 type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
 
 export type StateCallbackType = $ReadOnly<{|
   pressed: boolean,
+|}>;
+
+type TVProps = $ReadOnly<{|
+  hasTVPreferredFocus?: ?boolean,
+  isTVSelectable?: ?boolean,
+  tvParallaxProperties?: ?TVParallaxPropertiesType,
+  nextFocusDown?: ?number,
+  nextFocusForward?: ?number,
+  nextFocusLeft?: ?number,
+  nextFocusRight?: ?number,
+  nextFocusUp?: ?number,
 |}>;
 
 type Props = $ReadOnly<{|
@@ -131,6 +144,10 @@ type Props = $ReadOnly<{|
    * Used only for documentation or testing (e.g. snapshot testing).
    */
   testOnly_pressed?: ?boolean,
+  /**
+   * Props needed for Apple TV and Android TV
+   */
+  ...TVProps,
 |}>;
 
 /**
@@ -146,6 +163,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
     delayLongPress,
     disabled,
     focusable,
+    isTVSelectable,
     onLongPress,
     onPress,
     onPressIn,
@@ -217,6 +235,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
       {...android_rippleConfig?.viewProps}
       accessible={accessible !== false}
       focusable={focusable !== false}
+      isTVSelectable={isTVSelectable !== false && accessible !== false}
       hitSlop={hitSlop}
       ref={viewRef}
       style={typeof style === 'function' ? style({pressed}) : style}>

--- a/Libraries/Components/Pressable/Pressable.js
+++ b/Libraries/Components/Pressable/Pressable.js
@@ -36,6 +36,7 @@ type ViewStyleProp = $ElementType<React.ElementConfig<typeof View>, 'style'>;
 
 export type StateCallbackType = $ReadOnly<{|
   pressed: boolean,
+  focused: boolean,
 |}>;
 
 type TVProps = $ReadOnly<{|
@@ -251,8 +252,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
         } else if (evt.eventType === 'blur') {
           onBlur && onBlur(evt);
           onPressOut && onPressOut(evt);
-          setPressed(false);
           setFocused(false);
+          setPressed(false);
         }
       }
       if (focused && evt.eventType === 'select') {
@@ -275,8 +276,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
       isTVSelectable={isTVSelectable !== false && accessible !== false}
       hitSlop={hitSlop}
       ref={viewRef}
-      style={typeof style === 'function' ? style({pressed}) : style}>
-      {typeof children === 'function' ? children({pressed}) : children}
+      style={typeof style === 'function' ? style({pressed, focused}) : style}>
+      {typeof children === 'function' ? children({pressed, focused}) : children}
       {__DEV__ ? <PressabilityDebugView color="red" hitSlop={hitSlop} /> : null}
     </View>
   );

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ class Game2048 extends React.Component {
 
 - _LogBox_: The new LogBox error/warning display (which replaced YellowBox in 0.63) is working as expected in tvOS, after a few adjustments to make the controls accessible to the focus engine.
 
-- _Pressable_: The new `Pressable` API for React Native 0.63 works with TV.  Additional `onFocus` and `onBlur` props are provided to allow you to customize behavior when a Pressable enters or leaves focus. The existing `onPressIn` and `onPressOut` will also fire when entering or leaving focus, and the `pressed` and `focused` states will be true while focused.  `PressableExample` in RNTester has been modified appropriately.
+- _Pressable_: The new `Pressable` API for React Native 0.63 works with TV.  Additional `onFocus` and `onBlur` props are provided to allow you to customize behavior when a Pressable enters or leaves focus. Similar to the `pressed` state that is true while a user is pressing the component on a touchscreen, the `focused` state will be true when it is focused on TV.  `PressableExample` in RNTester has been modified appropriately.
 
 - _Dev Menu support_: On the simulator, cmd-D will bring up the developer menu, just like on iOS. To bring it up on a real Apple TV device, make a long press on the play/pause button on the remote. (Please do not shake the Apple TV device, that will not work :) )
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,7 @@ class Game2048 extends React.Component {
 
 - _LogBox_: The new LogBox error/warning display (which replaced YellowBox in 0.63) is working as expected in tvOS, after a few adjustments to make the controls accessible to the focus engine.
 
-- _Pressable_: The new Pressable API in 0.63 has not yet been adapted for tvOS.
+- _Pressable_: The new `Pressable` API for React Native 0.63 works with TV.  Additional `onFocus` and `onBlur` props are provided to allow you to customize behavior when a Pressable enters or leaves focus. The existing `onPressIn` and `onPressOut` will also fire when entering or leaving focus, and the `pressed` and `focused` states will be true while focused.  `PressableExample` in RNTester has been modified appropriately.
 
 - _Dev Menu support_: On the simulator, cmd-D will bring up the developer menu, just like on iOS. To bring it up on a real Apple TV device, make a long press on the play/pause button on the remote. (Please do not shake the Apple TV device, that will not work :) )
 

--- a/RNTester/js/examples/Pressable/PressableExample.js
+++ b/RNTester/js/examples/Pressable/PressableExample.js
@@ -54,6 +54,34 @@ function ContentPress() {
   );
 }
 
+function TVFocusContentPress() {
+  const [timesPressed, setTimesPressed] = useState(0);
+
+  let textLog = '';
+  if (timesPressed > 1) {
+    textLog = timesPressed + 'x onPress';
+  } else if (timesPressed > 0) {
+    textLog = 'onPress';
+  }
+
+  return (
+    <>
+      <View style={styles.row}>
+        <Pressable
+          onPress={() => {
+            setTimesPressed(current => current + 1);
+          }}>
+          {({focused}) => (
+            <Text style={styles.text}>{focused ? 'Focused!' : 'Press Me'}</Text>
+          )}
+        </Pressable>
+      </View>
+      <View style={styles.logBox}>
+        <Text testID="focusable_press_console">{textLog}</Text>
+      </View>
+    </>
+  );
+}
 function TextOnPressBox() {
   const [timesPressed, setTimesPressed] = useState(0);
 
@@ -322,6 +350,12 @@ exports.examples = [
     title: 'Change content based on Press',
     render(): React.Node {
       return <ContentPress />;
+    },
+  },
+  {
+    title: 'Change content based on focus',
+    render(): React.Node {
+      return <TVFocusContentPress />;
     },
   },
   {

--- a/RNTester/js/examples/Pressable/PressableExample.js
+++ b/RNTester/js/examples/Pressable/PressableExample.js
@@ -127,6 +127,8 @@ function PressableFeedbackEvents() {
           testID="pressable_feedback_events_button"
           accessibilityLabel="pressable feedback events"
           accessibilityRole="button"
+          onBlur={() => appendEvent('blur')}
+          onFocus={() => appendEvent('focus')}
           onPress={() => appendEvent('press')}
           onPressIn={() => appendEvent('pressIn')}
           onPressOut={() => appendEvent('pressOut')}

--- a/RNTester/js/examples/Pressable/PressableExample.js
+++ b/RNTester/js/examples/Pressable/PressableExample.js
@@ -267,6 +267,10 @@ function PressableDisabled() {
 
       <Pressable
         disabled={false}
+        tvParallaxProperties={{
+          enabled: true,
+          pressMagnification: 1.1,
+        }}
         style={({pressed}) => [
           {opacity: pressed ? 0.5 : 1},
           styles.row,
@@ -364,6 +368,10 @@ exports.examples = [
       return (
         <View style={styles.row}>
           <Pressable
+            tvParallaxProperties={{
+              enabled: true,
+              pressMagnification: 1.1,
+            }}
             style={({pressed}) => [
               {
                 backgroundColor: pressed ? 'rgb(210, 230, 255)' : 'white',

--- a/RNTester/js/examples/Pressable/PressableExample.js
+++ b/RNTester/js/examples/Pressable/PressableExample.js
@@ -365,7 +365,7 @@ exports.examples = [
     },
   },
   {
-    title: 'Change style based on Press',
+    title: 'Change style based on Press and Focus',
     render(): React.Node {
       return (
         <View style={styles.row}>
@@ -374,9 +374,13 @@ exports.examples = [
               enabled: true,
               pressMagnification: 1.1,
             }}
-            style={({pressed}) => [
+            style={({pressed, focused}) => [
               {
-                backgroundColor: pressed ? 'rgb(210, 230, 255)' : 'white',
+                backgroundColor: pressed
+                  ? 'rgb(210, 230, 255)'
+                  : focused
+                  ? 'rgb(255, 230, 210)'
+                  : 'white',
               },
               styles.wrapperCustom,
             ]}>

--- a/RNTester/js/examples/TVEventHandler/TVEventHandlerExample.js
+++ b/RNTester/js/examples/TVEventHandler/TVEventHandlerExample.js
@@ -17,9 +17,17 @@ const {Platform, View, Text, TouchableOpacity, useTVEventHandler} = ReactNative;
 
 const TVEventHandlerView: () => React.Node = () => {
   const [lastEventType, setLastEventType] = React.useState('');
+  const [eventLog, setEventLog] = React.useState([]);
+
+  function appendEvent(eventName) {
+    const limit = 6;
+    const newEventLog = eventLog.slice(0, limit - 1);
+    newEventLog.unshift(eventName);
+    setEventLog(newEventLog);
+  }
 
   const myTVEventHandler = evt => {
-    setLastEventType(evt.eventType);
+    appendEvent(evt.eventType);
   };
 
   if (Platform.isTV) {
@@ -32,7 +40,11 @@ const TVEventHandlerView: () => React.Node = () => {
             event detected from the Apple TV Siri remote or from a keyboard.
           </Text>
         </TouchableOpacity>
-        <Text style={{color: 'blue'}}>{lastEventType}</Text>
+        {eventLog.map((e, ii) => (
+          <Text style={{color: 'blue'}} key={ii}>
+            {e}
+          </Text>
+        ))}
       </View>
     );
   } else {

--- a/RNTester/js/utils/RNTesterList.android.js
+++ b/RNTester/js/utils/RNTesterList.android.js
@@ -233,6 +233,19 @@ const APIExamples: Array<RNTesterExample> = [
     module: require('../examples/Transform/TransformExample'),
   },
   {
+    key: 'TVEventHandlerExample',
+    module: require('../examples/TVEventHandler/TVEventHandlerExample'),
+  },
+  {
+    key: 'DirectionalNextFocusExample',
+    module: require('../examples/DirectionalNextFocus/DirectionalNextFocusExample'),
+  },
+  {
+    key: 'TVFocusGuideExample',
+    module: require('../examples/TVFocusGuide/TVFocusGuideExample'),
+  },
+
+  {
     key: 'VibrationExample',
     module: require('../examples/Vibration/VibrationExample'),
   },

--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -117,12 +117,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   }
 }
 
-- (void)sendSelectNotification:(__unused UIGestureRecognizer *)recognizer
-{
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-                                                      object:@{@"eventType":@"select",@"tag":self.reactTag}];
-}
-
 - (BOOL)isUserInteractionEnabled
 {
   return YES;
@@ -295,14 +289,27 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 
 - (void)sendFocusNotification:(__unused UIFocusUpdateContext *)context
 {
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-                                                      object:@{@"eventType":@"focus",@"tag":self.reactTag}];
+    [self sendNotificationWithEventType:@"focus"];
 }
 
 - (void)sendBlurNotification:(__unused UIFocusUpdateContext *)context
 {
+    [self sendNotificationWithEventType:@"blur"];
+}
+
+- (void)sendSelectNotification:(UIGestureRecognizer *)recognizer
+{
+    [self sendNotificationWithEventType:@"select"];
+}
+
+- (void)sendNotificationWithEventType:(NSString * __nonnull)eventType
+{
   [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-                                                      object:@{@"eventType":@"blur",@"tag":self.reactTag}];
+                                                      object:@{
+                                                          @"eventType":eventType,
+                                                          @"tag":self.reactTag,
+                                                          @"target":self.reactTag
+                                                      }];
 }
 
 - (RCTTVView *)getViewById:(NSNumber *)viewId {

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
@@ -51,7 +51,7 @@ public class ReactAndroidHWInputDeviceHelper {
   public void handleKeyEvent(KeyEvent ev) {
     int eventKeyCode = ev.getKeyCode();
     int eventKeyAction = ev.getAction();
-    if ((eventKeyAction == KeyEvent.ACTION_UP || eventKeyAction == KeyEvent.ACTION_DOWN)
+    if (eventKeyAction == KeyEvent.ACTION_UP
         && KEY_EVENTS_ACTIONS.containsKey(eventKeyCode)) {
       dispatchEvent(KEY_EVENTS_ACTIONS.get(eventKeyCode), mLastFocusedViewId, eventKeyAction);
     }
@@ -87,6 +87,7 @@ public class ReactAndroidHWInputDeviceHelper {
     event.putInt("eventKeyAction", eventKeyAction);
     if (targetViewId != View.NO_ID) {
       event.putInt("tag", targetViewId);
+      event.putInt("target", targetViewId);
     }
     mReactRootView.sendEvent("onHWKeyEvent", event);
   }


### PR DESCRIPTION
# Summary

Allow `Pressable` to be functional on Apple TV and Android TV.  Fixes #125 .

- add `focusable` and `isTVSelectable` view props
- add `onFocus()` and `onBlur()`
- export `focused` as a component state as well as `pressed`
- fire `onLongPress()` when Apple TV remote select button gets a long press

## Test Plan

Added examples and made changes in `PressableExample` in RNTester.
