### PR TITLE
Fix for scrolling issue #128

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.java
@@ -77,6 +77,10 @@ public class ReactHorizontalScrollViewManager extends ViewGroupManager<ReactHori
   @ReactProp(name = "scrollEnabled", defaultBoolean = true)
   public void setScrollEnabled(ReactHorizontalScrollView view, boolean value) {
     view.setScrollEnabled(value);
+    
+    /*Set focusable to match whether scroll is enabled. This improves keyboarding
+    experience by not making scrollview to scroll when scroll enabled is to false.*/
+    view.setFocusable(value);
   }
 
   @ReactProp(name = "showsHorizontalScrollIndicator")


### PR DESCRIPTION
Fix horizontal scroll view scrolling using DPad even when scrollEnabled is set to false

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

A scrollview with the scrollEnabled prop set to false still scrolls on tv remote dpad input on androidTV.
This effect can be seen when a Vertical ScrollView with scrollEnabled={false} have multiple HorizontalScrollView with scrollEnabled={false}. When Dpad up down is pressed HorizontalScrollview which is present inside Vertical ScrillView moves like listview.

React Native version:
##0.63.1-2

Expected Results
The scrollview should not scroll when scrollEnabled is set to false, regardless of touch, mouse or DPad input.

## Changelog

This change is continuation of PR  [#25105](https://github.com/facebook/react-native/pull/25105) which had handled scroll events for vertical scroll view but missed to had changes in `ReactHorizontalScrollViewManager.java`

[Android] [TV] - HorizontalScrollView

## Test Plan

Horizontal scroll view should scroll when scrollEnabled ={true} and should not scroll when set to false  regardless of touch, mouse or dpad input. 
