### PR TITLE
Fix multiple firing of onPress callback on single press on androidtv remote

### DIFF
--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -280,7 +280,7 @@ class TouchableOpacity extends React.Component<Props, State> {
           }
         },
         onPress: event => {
-          if (this.props.onPress != null) {
+          if (this.props.onPress != null && Platform.OS !== "android") {
             this.props.onPress(event);
           }
         },


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
fixes #138
This PR fixes the issue of multiple firing of `onPress` callback on single press on remote on androidTV

Tested on Amazon FireTV and AndroidTV emulator
