### PR TITLE
Fix Xcode bundler in staging and release

### DIFF
--- a/scripts/react-native-xcode.sh
+++ b/scripts/react-native-xcode.sh
@@ -54,17 +54,11 @@ case "$CONFIGURATION" in
     ;;
 esac
 
-# Setting up a project root was a workaround to enable support for non-standard
-# structures, including monorepos. Today, CLI supports that out of the box
-# and setting custom `PROJECT_ROOT` only makes it confusing. 
-#
-# As a backwards-compatible change, I am leaving "PROJECT_ROOT" support for those
-# who already use it - it is likely a non-breaking removal.
-#
-# For new users, we default to $PWD - not changing things all.
-#
-# For context: https://github.com/facebook/react-native/commit/9ccde378b6e6379df61f9d968be6346ca6be7ead#commitcomment-37914902
-PROJECT_ROOT=${PROJECT_ROOT:-$PWD}
+# Path to react-native folder inside node_modules
+REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# The project should be located next to where react-native is installed
+# in node_modules.
+PROJECT_ROOT=${PROJECT_ROOT:-"$REACT_NATIVE_DIR/../.."}
 
 cd "$PROJECT_ROOT" || exit
 
@@ -101,9 +95,6 @@ if [[ ! -x node && -d ${HOME}/.anyenv/bin ]]; then
     eval "$(anyenv init -)"
   fi
 fi
-
-# Path to react-native folder inside node_modules
-REACT_NATIVE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 # check and assign NODE_BINARY env
 # shellcheck source=/dev/null


### PR DESCRIPTION
Apply changes to react-native-xcode.sh script as per changes made under https://github.com/facebook/react-native/pull/29477

## Summary
This PR reverts the commit number: https://github.com/react-native-tvos/react-native-tvos/commit/a8e85026cfa60056b1bcbcd39cde789e4d65f9cb

This code was already reverted from RN under https://github.com/facebook/react-native/pull/29477 and all details could be found in there.
Thanks to @makarkotlov for the fix

## Changelog
[iOS] [Fixed] - fix "main.jsbundle does not exist" issue
