### PR TITLE
Only import RCTTVRemoteHandler in TV builds

### DIFF
--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -19,7 +19,9 @@
 #import "UIView+Private.h"
 #import "UIView+React.h"
 
+#if TARGET_OS_TV
 #import "RCTTVRemoteHandler.h"
+#endif
 
 #if !TARGET_OS_TV
 #import "RCTRefreshControl.h"


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

We have a monorepo with two separate apps for iOS and tvOS respectively. `react-native-tvos` is used throughout to avoid hoisting issues. Without this change the build succeeds for the tvOS build, but not for the iOS build because the `RCTTVRemoteHandler.h` is imported regardless of the build target.

## Changelog

[iOS] [Fixed] - RCTScrollView only imports RCTTVRemoteHandler for TV builds

## Test Plan

Built the app for iOS without this change: Build failed
Built the app for iOS with this change: Build succeeded
Built the app for tvOS with this change: Build succeeded