### PR TITLE
Focus guide exception fix

### DIFF
--- a/React/Views/RCTTVFocusGuideView.m
+++ b/React/Views/RCTTVFocusGuideView.m
@@ -44,7 +44,7 @@
 - (void)addFocusGuide:(NSArray*)destinations {
   
   UIView *origin = [self reactSuperview];
-  if (self.focusGuide == nil) {
+  if (self.focusGuide == nil && origin != nil) {
     self.focusGuide = [UIFocusGuide new];
     [self addLayoutGuide:self.focusGuide];
     


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

TVFocusGuideView's reactSuperView is nil

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

I observed that in some cases, in first render, `reactSuperview` of `TVFocusGuideView` is nil which causes and exception with constraint. adding check for nil superview fixes the issue.
![FocusGuide-constraint-issue](https://user-images.githubusercontent.com/21258014/130551419-dae55ea5-78e4-4f0b-9549-913bf7fca0fb.png)



<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[CATEGORY] [TYPE] - Message

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
