### PR TITLE
Fix the issue #216: tvOS - UI Layout is incorrect for TVFocusGuideView.

### DIFF
--- a/Libraries/Components/AppleTV/TVFocusGuideView.js
+++ b/Libraries/Components/AppleTV/TVFocusGuideView.js
@@ -42,9 +42,19 @@ class TVFocusGuideView extends React.Component<FocusGuideProps> {
     return (
       // Container view must have nonzero size
       <ReactNative.View style={[{minHeight: 1, minWidth: 1}, this.props.style]}>
+        {
+          /**
+           * The client specified layout(using 'style' prop) should be applied the container view ReactNative.View.
+           * And the focusGuide's layout shoule be overrided to wrap it fully inside the container view.
+           * For example, if the client specifies 'marginLeft' property in the style prop, 
+           * then the TVFocusGuideView will apply the 'marginLeft' for both the parentView and the focusGuideView.
+           * and so, the left margin is getting added twice and UI becomes incorrect. 
+           * The same is applicable for other layout properties.
+           */
+        }
         {Platform.isTVOS ? (
           <RNFocusGuide
-            style={this.props.style}
+            style={[this.props.style, styles.focusGuideLayout]}
             ref={ref => (this._focusGuideRef = ref)}
             destinationTags={this._destinationTags}>
             {this.props.children}
@@ -55,6 +65,19 @@ class TVFocusGuideView extends React.Component<FocusGuideProps> {
       </ReactNative.View>)
   }
 }
+
+const styles = ReactNative.StyleSheet.create({
+  focusGuideLayout: {
+    left: 0,
+    top: 0,
+    right: 0,
+    bottom: 0,
+    marginLeft: 0,
+    marginTop: 0,
+    marginRight: 0,
+    marginBottom: 0,
+  },
+});
 
 const RNFocusGuide = requireNativeComponent('RCTTVFocusGuideView');
 


### PR DESCRIPTION
UI Layout is incorrect whenever we use TVFocusGuideView in tvOS projects. For details, see #216 

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary
The TVFocusGuideView is using two views internally to properly set up the FocusGuide. But the problem is that, if the client specifies any layout related properties in the 'style' prop, TVFocusGuideView will apply the same props to both parent and child views, which is causing the UI issue.
For example, if the client specifies 'marginLeft' property in the style prop, then the TVFocusGuideView will apply the 'marginLeft' for both parent and child, and so, left margin is getting added twice and UI becomes incorrect. The same is applicable for other layout properties.

**React Native version:**
react-native-tvos@0.64.2-2


<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[tvOS] [Fixed] - Fix UI issue in **TVFocusGuideView**

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
UI Layout should be correct for FocusGuide even when client passed layout related properties like **'marginLeft'**, **'marginRight'**, in the **'style'** prop to the **TVFocusGuideView**
