### PR TITLE
Android TV: fire focus events in Modals (fix #115)

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
@@ -9,9 +9,13 @@ package com.facebook.react;
 
 import android.view.KeyEvent;
 import android.view.View;
+
+import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
+import com.facebook.react.modules.core.DeviceEventManagerModule;
+
 import java.util.Map;
 
 /** Responsible for dispatching events specific for hardware inputs. */
@@ -46,9 +50,16 @@ public class ReactAndroidHWInputDeviceHelper {
   private int mLastFocusedViewId = View.NO_ID;
 
   private final ReactRootView mReactRootView;
+  private final ReactContext mReactContext;
 
   ReactAndroidHWInputDeviceHelper(ReactRootView mReactRootView) {
     this.mReactRootView = mReactRootView;
+    this.mReactContext = null;
+  }
+
+  public ReactAndroidHWInputDeviceHelper(ReactContext mReactContext) {
+    this.mReactRootView = null;
+    this.mReactContext = mReactContext;
   }
 
   /** Called from {@link ReactRootView}. This is the main place the key events are handled. */
@@ -93,6 +104,11 @@ public class ReactAndroidHWInputDeviceHelper {
       event.putInt("tag", targetViewId);
       event.putInt("target", targetViewId);
     }
-    mReactRootView.sendEvent("onHWKeyEvent", event);
+    if (mReactRootView != null) {
+      mReactRootView.sendEvent("onHWKeyEvent", event);
+    } else {
+      mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+        .emit("onHWKeyEvent", event);
+    }
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
@@ -52,11 +52,13 @@ public class ReactAndroidHWInputDeviceHelper {
   private final ReactRootView mReactRootView;
   private final ReactContext mReactContext;
 
+  // Constructor used by ReactRootView
   ReactAndroidHWInputDeviceHelper(ReactRootView mReactRootView) {
     this.mReactRootView = mReactRootView;
     this.mReactContext = null;
   }
 
+  // Constructor used by ReactModalHostView.DialogRootViewGroup
   public ReactAndroidHWInputDeviceHelper(ReactContext mReactContext) {
     this.mReactRootView = null;
     this.mReactContext = mReactContext;
@@ -105,8 +107,10 @@ public class ReactAndroidHWInputDeviceHelper {
       event.putInt("target", targetViewId);
     }
     if (mReactRootView != null) {
+      // Sending event from root view
       mReactRootView.sendEvent("onHWKeyEvent", event);
     } else {
+      // Sending event from modal
       mReactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
         .emit("onHWKeyEvent", event);
     }

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.java
@@ -97,8 +97,10 @@ public class ReactAndroidHWInputDeviceHelper {
   }
 
   public void emitNamedEvent(String eventName, WritableMap event, ReactContext context) {
-    context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-           .emit(eventName, event);
+    if (context != null) {
+      context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+        .emit(eventName, event);
+    }
   }
 
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -90,7 +90,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
   private boolean mShouldLogContentAppeared;
   private @Nullable JSTouchDispatcher mJSTouchDispatcher;
   private final ReactAndroidHWInputDeviceHelper mAndroidHWInputDeviceHelper =
-      new ReactAndroidHWInputDeviceHelper(this);
+      new ReactAndroidHWInputDeviceHelper();
   private boolean mWasMeasured = false;
   private int mWidthMeasureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED);
   private int mHeightMeasureSpec = MeasureSpec.makeMeasureSpec(0, MeasureSpec.UNSPECIFIED);
@@ -230,7 +230,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       FLog.w(TAG, "Unable to handle key event as the catalyst instance has not been attached");
       return super.dispatchKeyEvent(ev);
     }
-    mAndroidHWInputDeviceHelper.handleKeyEvent(ev);
+    mAndroidHWInputDeviceHelper.handleKeyEvent(ev, mReactInstanceManager.getCurrentReactContext());
     return super.dispatchKeyEvent(ev);
   }
 
@@ -245,7 +245,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
       return;
     }
-    mAndroidHWInputDeviceHelper.clearFocus();
+    mAndroidHWInputDeviceHelper.clearFocus(mReactInstanceManager.getCurrentReactContext());
     super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
   }
 
@@ -260,7 +260,7 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
       super.requestChildFocus(child, focused);
       return;
     }
-    mAndroidHWInputDeviceHelper.onFocusChanged(focused);
+    mAndroidHWInputDeviceHelper.onFocusChanged(focused, mReactInstanceManager.getCurrentReactContext());
     super.requestChildFocus(child, focused);
   }
 
@@ -683,10 +683,11 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
 
   /* package */ void sendEvent(String eventName, @Nullable WritableMap params) {
     if (mReactInstanceManager != null) {
-      mReactInstanceManager
-          .getCurrentReactContext()
-          .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
-          .emit(eventName, params);
+      mAndroidHWInputDeviceHelper.emitNamedEvent(
+        eventName,
+        params,
+        mReactInstanceManager.getCurrentReactContext()
+      );
     }
   }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -43,7 +43,6 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.annotations.VisibleForTesting;
 import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.react.modules.appregistry.AppRegistry;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 import com.facebook.react.modules.deviceinfo.DeviceInfoModule;
 import com.facebook.react.surface.ReactStage;
 import com.facebook.react.uimanager.DisplayMetricsHolder;
@@ -56,6 +55,7 @@ import com.facebook.react.uimanager.UIManagerHelper;
 import com.facebook.react.uimanager.UIManagerModule;
 import com.facebook.react.uimanager.common.UIManagerType;
 import com.facebook.react.uimanager.events.EventDispatcher;
+import com.facebook.react.modules.core.ReactAndroidHWInputDeviceHelper;
 import com.facebook.systrace.Systrace;
 
 /**

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
@@ -5,7 +5,7 @@
  * LICENSE file in the root directory of this source tree.
  */
 
-package com.facebook.react;
+package com.facebook.react.modules.core;
 
 import android.view.KeyEvent;
 import android.view.View;
@@ -14,7 +14,6 @@ import com.facebook.react.bridge.ReactContext;
 import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
-import com.facebook.react.modules.core.DeviceEventManagerModule;
 
 import java.util.Map;
 
@@ -51,7 +50,7 @@ public class ReactAndroidHWInputDeviceHelper {
 
   public ReactAndroidHWInputDeviceHelper() {}
 
-  /** Called from {@link ReactRootView}. This is the main place the key events are handled. */
+  /** Called from {@link com.facebook.react.ReactRootView}. This is the main place the key events are handled. */
   public void handleKeyEvent(KeyEvent ev, ReactContext context) {
     int eventKeyCode = ev.getKeyCode();
     int eventKeyAction = ev.getAction();
@@ -61,7 +60,7 @@ public class ReactAndroidHWInputDeviceHelper {
     }
   }
 
-  /** Called from {@link ReactRootView} when focused view changes. */
+  /** Called from {@link com.facebook.react.ReactRootView} when focused view changes. */
   public void onFocusChanged(View newFocusedView, ReactContext context) {
     if (mLastFocusedViewId == newFocusedView.getId()) {
       return;
@@ -73,7 +72,7 @@ public class ReactAndroidHWInputDeviceHelper {
     dispatchEvent("focus", newFocusedView.getId(), context);
   }
 
-  /** Called from {@link ReactRootView} when the whole view hierarchy looses focus. */
+  /** Called from {@link com.facebook.react.ReactRootView} when the whole view hierarchy looses focus. */
   public void clearFocus(ReactContext context) {
     if (mLastFocusedViewId != View.NO_ID) {
       dispatchEvent("blur", mLastFocusedViewId, context);

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/BUCK
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/BUCK
@@ -19,6 +19,7 @@ rn_android_library(
         react_native_target("java/com/facebook/react/bridge:bridge"),
         react_native_target("java/com/facebook/react/common:common"),
         react_native_target("java/com/facebook/react/module/annotations:annotations"),
+        react_native_target("java/com/facebook/react/modules/core:core"),
         react_native_target("java/com/facebook/react/touch:touch"),
         react_native_target("java/com/facebook/react/uimanager:uimanager"),
         react_native_target("java/com/facebook/react/uimanager/annotations:annotations"),

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -12,6 +12,7 @@ import android.app.Activity;
 import android.app.Dialog;
 import android.content.Context;
 import android.content.DialogInterface;
+import android.graphics.Rect;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
@@ -23,8 +24,11 @@ import android.view.accessibility.AccessibilityEvent;
 import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
+
+import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.R;
+import com.facebook.react.ReactAndroidHWInputDeviceHelper;
 import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;
@@ -398,8 +402,11 @@ public class ReactModalHostView extends ViewGroup
 
     private final JSTouchDispatcher mJSTouchDispatcher = new JSTouchDispatcher(this);
 
+    private final ReactAndroidHWInputDeviceHelper mAndroidHWInputDeviceHelper;
+
     public DialogRootViewGroup(Context context) {
       super(context);
+      mAndroidHWInputDeviceHelper = new ReactAndroidHWInputDeviceHelper((ReactContext) context);
     }
 
     @Override
@@ -408,6 +415,18 @@ public class ReactModalHostView extends ViewGroup
       viewWidth = w;
       viewHeight = h;
       updateFirstChildView();
+    }
+
+    @Override
+    protected void onFocusChanged(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
+      mAndroidHWInputDeviceHelper.clearFocus();
+      super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
+    }
+
+    @Override
+    public void requestChildFocus(View child, View focused) {
+      mAndroidHWInputDeviceHelper.onFocusChanged(focused);
+      super.requestChildFocus(child, focused);
     }
 
     private void updateFirstChildView() {

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -404,9 +404,12 @@ public class ReactModalHostView extends ViewGroup
 
     private final ReactAndroidHWInputDeviceHelper mAndroidHWInputDeviceHelper;
 
+    private final ReactContext mReactContext;
+
     public DialogRootViewGroup(Context context) {
       super(context);
-      mAndroidHWInputDeviceHelper = new ReactAndroidHWInputDeviceHelper((ReactContext) context);
+      mReactContext = (ReactContext)context;
+      mAndroidHWInputDeviceHelper = new ReactAndroidHWInputDeviceHelper();
     }
 
     @Override
@@ -419,13 +422,13 @@ public class ReactModalHostView extends ViewGroup
 
     @Override
     protected void onFocusChanged(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
-      mAndroidHWInputDeviceHelper.clearFocus();
+      mAndroidHWInputDeviceHelper.clearFocus(mReactContext);
       super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
     }
 
     @Override
     public void requestChildFocus(View child, View focused) {
-      mAndroidHWInputDeviceHelper.onFocusChanged(focused);
+      mAndroidHWInputDeviceHelper.onFocusChanged(focused, mReactContext);
       super.requestChildFocus(child, focused);
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -25,10 +25,9 @@ import android.widget.FrameLayout;
 import androidx.annotation.Nullable;
 import androidx.annotation.UiThread;
 
-import com.facebook.common.logging.FLog;
 import com.facebook.infer.annotation.Assertions;
 import com.facebook.react.R;
-import com.facebook.react.ReactAndroidHWInputDeviceHelper;
+import com.facebook.react.modules.core.ReactAndroidHWInputDeviceHelper;
 import com.facebook.react.bridge.GuardedRunnable;
 import com.facebook.react.bridge.LifecycleEventListener;
 import com.facebook.react.bridge.ReactContext;


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

On Android TV, the `Modal` component is rendered in its own view class, not inside `ReactRootView`, so focus events are not handled and sent to the event listener as they are in the root view.

This change fixes that issue (#115), so that buttons inside a modal change appearance as expected when navigated to by the D-pad on Android TV.

## Test Plan

Tested with `ModalExample` in the RNTester app.
