### PR TITLE
Refactor of TV remote handler and TVMenuControl

### DIFF
--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -98,15 +98,8 @@ NSString *const RCTTVDisableMenuKeyNotification = @"RCTTVDisableMenuKeyNotificat
                                                object:self];
 
 #if TARGET_OS_TV
-      [[NSNotificationCenter defaultCenter] addObserver:self
-                                               selector:@selector(enableTVMenuKey)
-                                                   name:RCTTVEnableMenuKeyNotification
-                                                 object:nil];
 
-      [[NSNotificationCenter defaultCenter] addObserver:self
-                                               selector:@selector(disableTVMenuKey)
-                                                   name:RCTTVDisableMenuKeyNotification
-                                                 object:nil];
+      [RCTTVRemoteHandler addTVRemoteHandlerToView:self];
 
 #if RCT_DEV
       [[NSNotificationCenter defaultCenter] addObserver:self
@@ -115,11 +108,6 @@ NSString *const RCTTVDisableMenuKeyNotification = @"RCTTVDisableMenuKeyNotificat
                                                  object:nil];
 #endif
       
-    self.tvRemoteHandler = [RCTTVRemoteHandler new];
-    for (NSString *key in [self.tvRemoteHandler.tvRemoteGestureRecognizers allKeys]) {
-      [self addGestureRecognizer:self.tvRemoteHandler.tvRemoteGestureRecognizers[key]];
-    }
-    // [self addGestureRecognizer:self.tvRemoteHandler.tvMenuKeyRecognizer];
 #endif
 
     [self showLoadingView];
@@ -135,22 +123,6 @@ NSString *const RCTTVDisableMenuKeyNotification = @"RCTTVDisableMenuKeyNotificat
 }
 
 #if TARGET_OS_TV
-
-- (void)enableTVMenuKey {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (![[self gestureRecognizers] containsObject:self.tvRemoteHandler.tvMenuKeyRecognizer]) {
-            [self addGestureRecognizer:self.tvRemoteHandler.tvMenuKeyRecognizer];
-        }
-    });
-}
-
-- (void)disableTVMenuKey {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if ([[self gestureRecognizers] containsObject:self.tvRemoteHandler.tvMenuKeyRecognizer]) {
-            [self removeGestureRecognizer:self.tvRemoteHandler.tvMenuKeyRecognizer];
-        }
-    });
-}
 
 #if RCT_DEV
 - (void)showDevMenu {

--- a/React/Base/RCTRootViewInternal.h
+++ b/React/Base/RCTRootViewInternal.h
@@ -7,8 +7,6 @@
 
 #import <React/RCTRootView.h>
 
-@class RCTTVRemoteHandler;
-
 /**
  * The interface provides a set of functions that allow other internal framework
  * classes to change the RCTRootViews's internal state.
@@ -25,7 +23,6 @@
  * TV remote gesture recognizers
  */
 #if TARGET_OS_TV
-@property (nonatomic, strong) RCTTVRemoteHandler *tvRemoteHandler;
 @property (nonatomic, strong) UIView *reactPreferredFocusedView;
 #endif
 

--- a/React/Base/RCTTVRemoteHandler.h
+++ b/React/Base/RCTTVRemoteHandler.h
@@ -28,5 +28,10 @@ extern NSString *const RCTTVRemoteEventSwipeDown;
 
 @property (nonatomic, copy, readonly) NSDictionary *tvRemoteGestureRecognizers;
 @property (nonatomic, strong) UITapGestureRecognizer *tvMenuKeyRecognizer;
+@property (nonatomic, assign) BOOL useMenuKey;
+
++ (RCTTVRemoteHandler *)instance;
+
++ (void)addTVRemoteHandlerToView:( UIView * _Nonnull )view;
 
 @end

--- a/React/Base/RCTTVRemoteHandler.m
+++ b/React/Base/RCTTVRemoteHandler.m
@@ -41,6 +41,41 @@ NSString *const RCTTVRemoteEventSwipeDown = @"swipeDown";
   NSMutableDictionary<NSString *, UIGestureRecognizer *> *_tvRemoteGestureRecognizers;
 }
 
+static RCTTVRemoteHandler * _instance = nil;
+
++ (RCTTVRemoteHandler *)instance
+{
+  static dispatch_once_t onceToken;
+  dispatch_once(&onceToken, ^{
+    // Set up JS thread
+      _instance = [[RCTTVRemoteHandler alloc] init];
+  });
+  return _instance;
+}
+
++ (void)addTVRemoteHandlerToView:(UIView *)view
+{
+    for (NSString *key in [[RCTTVRemoteHandler instance].tvRemoteGestureRecognizers allKeys]) {
+      [view addGestureRecognizer:[RCTTVRemoteHandler instance].tvRemoteGestureRecognizers[key]];
+    }
+    if ([RCTTVRemoteHandler instance].useMenuKey) {
+        [view enableTVMenuKey];
+    } else {
+        [view disableTVMenuKey];
+    }
+    
+    [[NSNotificationCenter defaultCenter] addObserver:view
+                                             selector:@selector(enableTVMenuKey)
+                                                 name:RCTTVEnableMenuKeyNotification
+                                               object:nil];
+
+    [[NSNotificationCenter defaultCenter] addObserver:view
+                                             selector:@selector(disableTVMenuKey)
+                                                 name:RCTTVDisableMenuKeyNotification
+                                               object:nil];
+}
+
+
 - (instancetype)init
 {
   if ((self = [super init])) {

--- a/React/Modules/RCTTVMenuBridge.m
+++ b/React/Modules/RCTTVMenuBridge.m
@@ -6,6 +6,7 @@
 
 #import "RCTTVMenuBridge.h"
 #import <React/RCTRootView.h>
+#import "RCTTVRemoteHandler.h"
 
 @implementation RCTTVMenuBridge
 
@@ -13,11 +14,13 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(enableTVMenuKey)
 {
+    [RCTTVRemoteHandler instance].useMenuKey = YES;
     [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVEnableMenuKeyNotification object:nil];
 }
 
 RCT_EXPORT_METHOD(disableTVMenuKey)
 {
+    [RCTTVRemoteHandler instance].useMenuKey = NO;
     [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVDisableMenuKeyNotification object:nil];
 }
 

--- a/React/Views/UIView+React.h
+++ b/React/Views/UIView+React.h
@@ -127,4 +127,11 @@
  */
 - (NSString *)react_recursiveDescription;
 
+#if TARGET_OS_TV
+
+- (void)enableTVMenuKey;
+- (void)disableTVMenuKey;
+
+#endif
+
 @end

--- a/React/Views/UIView+React.m
+++ b/React/Views/UIView+React.m
@@ -13,6 +13,10 @@
 #import "RCTLog.h"
 #import "RCTShadowView.h"
 
+#if TARGET_OS_TV
+#import "RCTTVRemoteHandler.h"
+#endif
+
 @implementation UIView (React)
 
 - (NSNumber *)reactTag
@@ -375,5 +379,25 @@
   [self react_addRecursiveDescriptionToString:description atLevel:0];
   return description;
 }
+
+#if TARGET_OS_TV
+
+- (void)enableTVMenuKey {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if (![[self gestureRecognizers] containsObject:[RCTTVRemoteHandler instance].tvMenuKeyRecognizer]) {
+            [self addGestureRecognizer:[RCTTVRemoteHandler instance].tvMenuKeyRecognizer];
+        }
+    });
+}
+
+- (void)disableTVMenuKey {
+    dispatch_async(dispatch_get_main_queue(), ^{
+        if ([[self gestureRecognizers] containsObject:[RCTTVRemoteHandler instance].tvMenuKeyRecognizer]) {
+            [self removeGestureRecognizer:[RCTTVRemoteHandler instance].tvMenuKeyRecognizer];
+        }
+    });
+}
+
+#endif
 
 @end

--- a/packages/rn-tester/RNTesterUnitTests/RCTAllocationTests.m
+++ b/packages/rn-tester/RNTesterUnitTests/RCTAllocationTests.m
@@ -93,6 +93,7 @@ RCT_EXPORT_METHOD(test:(__unused NSString *)a
     XCTAssertNotNil(weakBridge, @"RCTBridge should have been created");
     (void)view;
   }
+  [[NSRunLoop mainRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:2.0]];
 
   XCTAssertNil(weakBridge, @"RCTBridge should have been deallocated");
 }


### PR DESCRIPTION
Needed for React Native Navigation to work with TVMenuControl (#69)

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Refactor `RCTTVRemoteHandler` to make it a singleton (which matches its expected behavior), and create a simple wrapper to add its gesture handlers to a view.  This is needed to fix some issues with `react-native-navigation` interoperability with the Apple TV remote handler.

## Test Plan

Will test this extensively on both an RNN test project and other React Native TV projects, and also check that all the usual integration tests pass.
