### PR TITLE
Refactor of RCTTVRemoteHandler

### DIFF
--- a/React/Base/RCTRootView.m
+++ b/React/Base/RCTRootView.m
@@ -98,15 +98,6 @@ NSString *const RCTTVDisableMenuKeyNotification = @"RCTTVDisableMenuKeyNotificat
                                                object:self];
 
 #if TARGET_OS_TV
-      [[NSNotificationCenter defaultCenter] addObserver:self
-                                               selector:@selector(enableTVMenuKey)
-                                                   name:RCTTVEnableMenuKeyNotification
-                                                 object:nil];
-
-      [[NSNotificationCenter defaultCenter] addObserver:self
-                                               selector:@selector(disableTVMenuKey)
-                                                   name:RCTTVDisableMenuKeyNotification
-                                                 object:nil];
 
 #if RCT_DEV
       [[NSNotificationCenter defaultCenter] addObserver:self
@@ -115,11 +106,7 @@ NSString *const RCTTVDisableMenuKeyNotification = @"RCTTVDisableMenuKeyNotificat
                                                  object:nil];
 #endif
       
-    self.tvRemoteHandler = [RCTTVRemoteHandler new];
-    for (NSString *key in [self.tvRemoteHandler.tvRemoteGestureRecognizers allKeys]) {
-      [self addGestureRecognizer:self.tvRemoteHandler.tvRemoteGestureRecognizers[key]];
-    }
-    // [self addGestureRecognizer:self.tvRemoteHandler.tvMenuKeyRecognizer];
+    self.tvRemoteHandler = [[RCTTVRemoteHandler alloc] initWithView:self];
 #endif
 
     [self showLoadingView];
@@ -134,32 +121,12 @@ NSString *const RCTTVDisableMenuKeyNotification = @"RCTTVDisableMenuKeyNotificat
   return self;
 }
 
-#if TARGET_OS_TV
-
-- (void)enableTVMenuKey {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if (![[self gestureRecognizers] containsObject:self.tvRemoteHandler.tvMenuKeyRecognizer]) {
-            [self addGestureRecognizer:self.tvRemoteHandler.tvMenuKeyRecognizer];
-        }
-    });
-}
-
-- (void)disableTVMenuKey {
-    dispatch_async(dispatch_get_main_queue(), ^{
-        if ([[self gestureRecognizers] containsObject:self.tvRemoteHandler.tvMenuKeyRecognizer]) {
-            [self removeGestureRecognizer:self.tvRemoteHandler.tvMenuKeyRecognizer];
-        }
-    });
-}
-
-#if RCT_DEV
+#if TARGET_OS_TV && RCT_DEV
 - (void)showDevMenu {
     dispatch_async(dispatch_get_main_queue(), ^{
         [[self->_bridge devMenu] show];
     });
 }
-#endif
-
 #endif // TARGET_OS_TV
 
 - (instancetype)initWithBundleURL:(NSURL *)bundleURL
@@ -443,6 +410,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 
 - (void)dealloc
 {
+#if TARGET_OS_TV
+  self.tvRemoteHandler = nil;
+#endif
   [_contentView invalidate];
 }
 

--- a/React/Base/RCTTVRemoteHandler.h
+++ b/React/Base/RCTTVRemoteHandler.h
@@ -26,7 +26,10 @@ extern NSString *const RCTTVRemoteEventSwipeDown;
 
 @interface RCTTVRemoteHandler : NSObject
 
-@property (nonatomic, copy, readonly) NSDictionary *tvRemoteGestureRecognizers;
-@property (nonatomic, strong) UITapGestureRecognizer *tvMenuKeyRecognizer;
+- (instancetype _Nonnull )initWithView:(UIView * _Nonnull)view;
+- (instancetype _Nonnull )init __attribute__((unavailable("init not available, use initWithView:")));
+
++ (BOOL)useMenuKey;
++ (void)setUseMenuKey:(BOOL)useMenuKey;
 
 @end

--- a/React/Modules/RCTTVMenuBridge.m
+++ b/React/Modules/RCTTVMenuBridge.m
@@ -6,6 +6,7 @@
 
 #import "RCTTVMenuBridge.h"
 #import <React/RCTRootView.h>
+#import <React/RCTTVRemoteHandler.h>
 
 @implementation RCTTVMenuBridge
 
@@ -13,11 +14,13 @@ RCT_EXPORT_MODULE();
 
 RCT_EXPORT_METHOD(enableTVMenuKey)
 {
+    [RCTTVRemoteHandler setUseMenuKey:YES];
     [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVEnableMenuKeyNotification object:nil];
 }
 
 RCT_EXPORT_METHOD(disableTVMenuKey)
 {
+    [RCTTVRemoteHandler setUseMenuKey:NO];
     [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVDisableMenuKeyNotification object:nil];
 }
 

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -49,7 +49,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
     _menuButtonGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                            action:@selector(menuButtonPressed:)];
     _menuButtonGestureRecognizer.allowedPressTypes = @[ @(UIPressTypeMenu) ];
-    self.tvRemoteHandler = [RCTTVRemoteHandler new];
+    self.tvRemoteHandler = [[RCTTVRemoteHandler alloc] initWithView:self];
 #endif
     _isPresented = NO;
 
@@ -63,6 +63,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
 }
 
 #if TARGET_OS_TV
+- (void)dealloc
+{
+    self.tvRemoteHandler = nil;
+}
+
 - (void)menuButtonPressed:(__unused UIGestureRecognizer *)gestureRecognizer
 {
   if (_onRequestClose) {
@@ -119,11 +124,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
   [super insertReactSubview:subview atIndex:atIndex];
   [_touchHandler attachToView:subview];
 #if TARGET_OS_TV
-  for (NSString *key in [self.tvRemoteHandler.tvRemoteGestureRecognizers allKeys]) {
-    if (![key isEqualToString:RCTTVRemoteEventMenu]) {
-      [subview addGestureRecognizer:self.tvRemoteHandler.tvRemoteGestureRecognizers[key]];
-    }
-  }
   if (_onRequestClose) {
     [subview addGestureRecognizer:_menuButtonGestureRecognizer];
   }
@@ -142,9 +142,6 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
 #if TARGET_OS_TV
   if (_menuButtonGestureRecognizer) {
     [subview removeGestureRecognizer:_menuButtonGestureRecognizer];
-  }
-  for (UIGestureRecognizer *gr in self.tvRemoteHandler.tvRemoteGestureRecognizers) {
-    [subview removeGestureRecognizer:gr];
   }
 #endif
   _reactSubview = nil;


### PR DESCRIPTION
Fix #69 (react-native-navigation issues)

- RCTRootView code to attach TV remote handler is now wrapped inside RCTTVRemoteHandler
- TV remote handler now has global state to track whether menu key should be enabled
- TV remote handler now also listens for TVMenuControl notifications, so views that create a TV event handler no longer have to do anything else

## Test Plan

Tested with the unit and integration tests, RNTester manual testing, new project testing, and testing against `react-native-navigation`.
