### PR TITLE
Android TV: feature flag for key up events (#233) (#251)

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -89,4 +89,9 @@ public class ReactFeatureFlags {
   public static boolean enableLockFreeEventDispatcher = false;
 
   public static boolean enableAggressiveEventEmitterCleanup = false;
+
+  /**
+   * Send key down events as well as key up events
+   */
+  public static boolean enableKeyDownEvents = false;
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
@@ -15,6 +15,7 @@ import com.facebook.react.bridge.WritableMap;
 import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.common.SystemClock;
+import com.facebook.react.config.ReactFeatureFlags;
 
 import java.util.Map;
 
@@ -79,10 +80,7 @@ public class ReactAndroidHWInputDeviceHelper {
       && isSelectEvent(eventKeyCode) && mLastKeyDownTime == 0) {
       mLastKeyDownTime = time;
     }
-    // We only need the up event for Android TV
-    // if ((eventKeyAction == KeyEvent.ACTION_UP || eventKeyAction == KeyEvent.ACTION_DOWN)
-    if ((eventKeyAction == KeyEvent.ACTION_UP)
-        && KEY_EVENTS_ACTIONS.containsKey(eventKeyCode)) {
+    if (shouldDispatchEvent(eventKeyCode, eventKeyAction)) {
       long delta = time - mLastKeyDownTime;
       if (isSelectEvent(eventKeyCode) && (delta > mPressedDelta)) {
         dispatchEvent("longSelect", mLastFocusedViewId, eventKeyAction, context);
@@ -91,6 +89,14 @@ public class ReactAndroidHWInputDeviceHelper {
       }
       mLastKeyDownTime = 0;
     }
+  }
+
+  // Android TV: Only send key up actions, unless key down events are enabled
+  private boolean shouldDispatchEvent(int eventKeyCode, int eventKeyAction) {
+    return KEY_EVENTS_ACTIONS.containsKey(eventKeyCode) && (
+      (eventKeyAction == KeyEvent.ACTION_UP) ||
+      (eventKeyAction == KeyEvent.ACTION_DOWN && ReactFeatureFlags.enableKeyDownEvents)
+    );
   }
 
   /** Called from {@link com.facebook.react.ReactRootView} when focused view changes. */

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterApplication.java
@@ -187,6 +187,9 @@ public class RNTesterApplication extends Application implements ReactApplication
   @Override
   public void onCreate() {
     ReactFeatureFlags.useTurboModules = BuildConfig.ENABLE_TURBOMODULE;
+    // Normally we only send key up events in ReactAndroidHWInputDeviceHelper
+    // Change enableKeyDownEvents to true to send both key down and key up events
+    ReactFeatureFlags.enableKeyDownEvents = false;
     ReactFontManager.getInstance().addCustomFont(this, "Rubik", R.font.rubik);
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);

--- a/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
+++ b/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
@@ -17,17 +17,24 @@ const {Platform, View, Text, TouchableOpacity, useTVEventHandler} = ReactNative;
 
 const TVEventHandlerView: () => React.Node = () => {
   const [lastEventType, setLastEventType] = React.useState('');
+  const [lastEventAction, setLastEventAction] = React.useState('');
   const [eventLog, setEventLog] = React.useState([]);
 
-  function appendEvent(eventName) {
+  const isAndroid = Platform.OS === 'android';
+
+  function appendEvent(eventType, eventAction) {
     const limit = 6;
     const newEventLog = eventLog.slice(0, limit - 1);
-    newEventLog.unshift(eventName);
+    if (isAndroid) {
+      newEventLog.unshift(`type=${eventType}, action=${eventAction}`);
+    } else {
+      newEventLog.unshift(`type=${eventType}`);
+    }
     setEventLog(newEventLog);
   }
 
   const myTVEventHandler = evt => {
-    appendEvent(evt.eventType);
+    appendEvent(evt.eventType, evt.eventKeyAction);
   };
 
   if (Platform.isTV) {

--- a/template/android/app/src/main/java/com/helloworld/MainApplication.java
+++ b/template/android/app/src/main/java/com/helloworld/MainApplication.java
@@ -7,6 +7,7 @@ import com.facebook.react.ReactApplication;
 import com.facebook.react.ReactInstanceManager;
 import com.facebook.react.ReactNativeHost;
 import com.facebook.react.ReactPackage;
+import com.facebook.react.config.ReactFeatureFlags;
 import com.facebook.soloader.SoLoader;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
@@ -44,6 +45,10 @@ public class MainApplication extends Application implements ReactApplication {
   public void onCreate() {
     super.onCreate();
     SoLoader.init(this, /* native exopackage */ false);
+    // Normally we only send key up events in ReactAndroidHWInputDeviceHelper
+    // Change enableKeyDownEvents to true to send both key down and key up events
+    ReactFeatureFlags.enableKeyDownEvents = false;
+
     initializeFlipper(this, getReactNativeHost().getReactInstanceManager());
   }
 


### PR DESCRIPTION
Adding `enableKeyDownEvents` in `ReactFeatureFlags` class.  If this is set in your application startup code, both key down and key up events will be sent to TVEventHandler.  See discussion in related issue #233 . Fixes #251.

Example from template application:

```java
  @Override
  public void onCreate() {
    super.onCreate();
    SoLoader.init(this, /* native exopackage */ false);
    // Normally we only send key up events in ReactAndroidHWInputDeviceHelper
    // Change enableKeyDownEvents to true to send both key down and key up events
    ReactFeatureFlags.enableKeyDownEvents = false;
```