### PR TITLE
Implement single event listener for Touchable components to boost performance

### DIFF
--- a/Libraries/Components/AppleTV/TVFocusEventHandler.js
+++ b/Libraries/Components/AppleTV/TVFocusEventHandler.js
@@ -1,0 +1,51 @@
+/**
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ * @flow
+ */
+
+'use strict';
+
+import NativeEventEmitter from '../../EventEmitter/NativeEventEmitter';
+import Platform from '../../Utilities/Platform';
+import {type EventSubscription} from '../../vendor/emitter/EventEmitter';
+import NativeTVNavigationEventEmitter from './NativeTVNavigationEventEmitter';
+
+class TVFocusEventHandler {
+  __nativeTVNavigationEventListener: ?EventSubscription = null;
+  __nativeTVNavigationEventEmitter: ?NativeEventEmitter = null;
+  __callbackMap: Map<any, Function> = new Map();
+
+  constructor() {
+    if (Platform.OS === 'ios' && !NativeTVNavigationEventEmitter) {
+      return;
+    }
+
+    this.__nativeTVNavigationEventEmitter = new NativeEventEmitter(
+      NativeTVNavigationEventEmitter,
+    );
+    this.__nativeTVNavigationEventListener = this.__nativeTVNavigationEventEmitter.addListener(
+      'onHWKeyEvent',
+      data => {
+        const callback = this.__callbackMap.get(data.tag);
+        if (callback) {
+          callback(data);
+        }
+      },
+    );
+  }
+
+  register(componentTag: ?any, callback: Function): void {
+    this.__callbackMap.set(componentTag, callback);
+  }
+
+  unregister(componentTag: ?any): void {
+    this.__callbackMap.delete(componentTag);
+  }
+}
+
+module.exports = TVFocusEventHandler;

--- a/Libraries/Components/AppleTV/TVFocusEventHandler.js
+++ b/Libraries/Components/AppleTV/TVFocusEventHandler.js
@@ -48,4 +48,4 @@ class TVFocusEventHandler {
   }
 }
 
-module.exports = TVFocusEventHandler;
+export const tvFocusEventHandler: TVFocusEventHandler | null = Platform.isTV ? new TVFocusEventHandler() : null;

--- a/Libraries/Components/Touchable/Touchable.js
+++ b/Libraries/Components/Touchable/Touchable.js
@@ -15,7 +15,7 @@ import Platform from '../../Utilities/Platform';
 import Position from './Position';
 import UIManager from '../../ReactNative/UIManager';
 import SoundManager from '../Sound/SoundManager';
-import TVFocusEventHandler from '../AppleTV/TVFocusEventHandler';
+import {tvFocusEventHandler} from '../AppleTV/TVFocusEventHandler';
 
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 
@@ -296,7 +296,6 @@ const LONG_PRESS_DELAY_MS = LONG_PRESS_THRESHOLD - HIGHLIGHT_DELAY_MS;
 
 const LONG_PRESS_ALLOWED_MOVEMENT = 10;
 
-const tvFocusEventHandler = Platform.isTV ? new TVFocusEventHandler() : null;
 // Default amount "active" region protrudes beyond box
 
 /**

--- a/index.js
+++ b/index.js
@@ -83,7 +83,6 @@ import typeof ToastAndroid from './Libraries/Components/ToastAndroid/ToastAndroi
 import typeof * as TurboModuleRegistry from './Libraries/TurboModule/TurboModuleRegistry';
 import typeof TabBarIOS from './Libraries/Components/TabBarIOS/TabBarIOS';
 import typeof TVEventHandler from './Libraries/Components/AppleTV/TVEventHandler';
-import typeof TVFocusEventHandler from './Libraries/Components/AppleTV/TVFocusEventHandler';
 import typeof TVFocusGuideView from './Libraries/Components/AppleTV/TVFocusGuideView';
 import typeof TVMenuControl from './Libraries/Components/AppleTV/TVMenuControl';
 import typeof TVTextScrollView from './Libraries/Components/AppleTV/TVTextScrollView';
@@ -416,9 +415,6 @@ module.exports = {
   },
   get TVEventHandler(): TVEventHandler {
     return require('./Libraries/Components/AppleTV/TVEventHandler');
-  },
-  get TVFocusEventHandler(): TVFocusEventHandler {
-    return require('./Libraries/Components/AppleTV/TVFocusEventHandler');
   },
   get TVFocusGuideView(): TVFocusGuideView {
     return require('./Libraries/Components/AppleTV/TVFocusGuideView');

--- a/index.js
+++ b/index.js
@@ -83,6 +83,7 @@ import typeof ToastAndroid from './Libraries/Components/ToastAndroid/ToastAndroi
 import typeof * as TurboModuleRegistry from './Libraries/TurboModule/TurboModuleRegistry';
 import typeof TabBarIOS from './Libraries/Components/TabBarIOS/TabBarIOS';
 import typeof TVEventHandler from './Libraries/Components/AppleTV/TVEventHandler';
+import typeof TVFocusEventHandler from './Libraries/Components/AppleTV/TVFocusEventHandler';
 import typeof TVFocusGuideView from './Libraries/Components/AppleTV/TVFocusGuideView';
 import typeof TVMenuControl from './Libraries/Components/AppleTV/TVMenuControl';
 import typeof TVTextScrollView from './Libraries/Components/AppleTV/TVTextScrollView';
@@ -415,6 +416,9 @@ module.exports = {
   },
   get TVEventHandler(): TVEventHandler {
     return require('./Libraries/Components/AppleTV/TVEventHandler');
+  },
+  get TVFocusEventHandler(): TVFocusEventHandler {
+    return require('./Libraries/Components/AppleTV/TVFocusEventHandler');
   },
   get TVFocusGuideView(): TVFocusGuideView {
     return require('./Libraries/Components/AppleTV/TVFocusGuideView');


### PR DESCRIPTION
## Summary

Each Touchable component needlessly creates own event listener, which, after focus transition, results in multiple handlers called just to check if event should be even handled by particular component. Performance of focus transition can be improved.

## Changelog

[General] [Changed] - Improved focus transition performance of Touchable components by introducing single Event Listener for all Touchables, instead of one Event Listener per Touchable.

## Test Plan

I've prepared simple TV app with improvement implemented as a patch to check and measure performance improvement. Rough measurement of focus transition between tiles on AndroidTV emulator indicates that time between onBlur -> onFocus pair reduced from ~11 ms to ~7 ms on average, and peak value form ~48 ms to ~14 ms.
https://github.com/Zahoq/TouchableFocusImprovementTestApp
