### PR TITLE
Add support for Page Up / Page down (channel buttons) on iOS remote control

### DIFF
--- a/React/Base/RCTTVRemoteHandler.m
+++ b/React/Base/RCTTVRemoteHandler.m
@@ -32,6 +32,9 @@ NSString *const RCTTVRemoteEventRight = @"right";
 NSString *const RCTTVRemoteEventUp = @"up";
 NSString *const RCTTVRemoteEventDown = @"down";
 
+NSString *const RCTTVRemoteEventPageUp = @"pageUp";
+NSString *const RCTTVRemoteEventPageDown = @"pageDown";
+
 NSString *const RCTTVRemoteEventSwipeLeft = @"swipeLeft";
 NSString *const RCTTVRemoteEventSwipeRight = @"swipeRight";
 NSString *const RCTTVRemoteEventSwipeUp = @"swipeUp";
@@ -102,6 +105,17 @@ static __volatile BOOL __useMenuKey = NO;
   [self addTapGestureRecognizerWithSelector:@selector(selectPressed:)
                                   pressType:UIPressTypeSelect
                                        name:RCTTVRemoteEventSelect];
+    
+  // Page Up/Down
+  if (@available(tvOS 14.3, *)) {
+      [self addTapGestureRecognizerWithSelector:@selector(tappePagedUp:)
+                                      pressType:UIPressTypePageUp
+                                           name:RCTTVRemoteEventPageUp];
+        
+      [self addTapGestureRecognizerWithSelector:@selector(tappedPageDown:)
+                                      pressType:UIPressTypePageDown
+                                           name:RCTTVRemoteEventPageDown];
+  }
 
   // Up
   [self addTapGestureRecognizerWithSelector:@selector(tappedUp:)


### PR DESCRIPTION
## Summary

This adds support for the Channel Up/Down buttons on the iOS control center remote control.

## Changelog

[TVOS] [Added] - Add support for Channel Up/Down buttons on iOS control center remote control.

## Test Plan

Add a TV event handler that logs eventType, open the Apple TV remote on an iPhone and press channel up/down to see the new pageUp/Down events
