### PR TITLE
Add support for Page Up / Page down (channel buttons) on iOS remote control

### DIFF
--- a/React/Base/RCTTVRemoteHandler.h
+++ b/React/Base/RCTTVRemoteHandler.h
@@ -19,6 +19,9 @@ extern NSString *const RCTTVRemoteEventRight;
 extern NSString *const RCTTVRemoteEventUp;
 extern NSString *const RCTTVRemoteEventDown;
 
+extern NSString *const RCTTVRemoteEventPageUp;
+extern NSString *const RCTTVRemoteEventPageDown;
+
 extern NSString *const RCTTVRemoteEventSwipeLeft;
 extern NSString *const RCTTVRemoteEventSwipeRight;
 extern NSString *const RCTTVRemoteEventSwipeUp;

--- a/React/Base/RCTTVRemoteHandler.m
+++ b/React/Base/RCTTVRemoteHandler.m
@@ -108,7 +108,7 @@ static __volatile BOOL __useMenuKey = NO;
     
   // Page Up/Down
   if (@available(tvOS 14.3, *)) {
-      [self addTapGestureRecognizerWithSelector:@selector(tappePagedUp:)
+      [self addTapGestureRecognizerWithSelector:@selector(tappedPageUp:)
                                       pressType:UIPressTypePageUp
                                            name:RCTTVRemoteEventPageUp];
         
@@ -294,7 +294,7 @@ static __volatile BOOL __useMenuKey = NO;
   [self sendAppleTVEvent:RCTTVRemoteEventDown toView:r.view];
 }
 
-- (void)tappePagedUp:(UIGestureRecognizer *)r
+- (void)tappedPageUp:(UIGestureRecognizer *)r
 {
   [self sendAppleTVEvent:RCTTVRemoteEventPageUp toView:r.view];
 }

--- a/React/Base/RCTTVRemoteHandler.m
+++ b/React/Base/RCTTVRemoteHandler.m
@@ -32,6 +32,9 @@ NSString *const RCTTVRemoteEventRight = @"right";
 NSString *const RCTTVRemoteEventUp = @"up";
 NSString *const RCTTVRemoteEventDown = @"down";
 
+NSString *const RCTTVRemoteEventPageUp = @"pageUp";
+NSString *const RCTTVRemoteEventPageDown = @"pageDown";
+
 NSString *const RCTTVRemoteEventSwipeLeft = @"swipeLeft";
 NSString *const RCTTVRemoteEventSwipeRight = @"swipeRight";
 NSString *const RCTTVRemoteEventSwipeUp = @"swipeUp";
@@ -102,6 +105,17 @@ static __volatile BOOL __useMenuKey = NO;
   [self addTapGestureRecognizerWithSelector:@selector(selectPressed:)
                                   pressType:UIPressTypeSelect
                                        name:RCTTVRemoteEventSelect];
+    
+  // Page Up/Down
+  if (@available(tvOS 14.3, *)) {
+      [self addTapGestureRecognizerWithSelector:@selector(tappePagedUp:)
+                                      pressType:UIPressTypePageUp
+                                           name:RCTTVRemoteEventPageUp];
+        
+      [self addTapGestureRecognizerWithSelector:@selector(tappedPageDown:)
+                                      pressType:UIPressTypePageDown
+                                           name:RCTTVRemoteEventPageDown];
+  }
 
   // Up
   [self addTapGestureRecognizerWithSelector:@selector(tappedUp:)
@@ -278,6 +292,16 @@ static __volatile BOOL __useMenuKey = NO;
 - (void)tappedDown:(UIGestureRecognizer *)r
 {
   [self sendAppleTVEvent:RCTTVRemoteEventDown toView:r.view];
+}
+
+- (void)tappePagedUp:(UIGestureRecognizer *)r
+{
+  [self sendAppleTVEvent:RCTTVRemoteEventPageUp toView:r.view];
+}
+
+- (void)tappedPageDown:(UIGestureRecognizer *)r
+{
+  [self sendAppleTVEvent:RCTTVRemoteEventPageDown toView:r.view];
 }
 
 - (void)tappedLeft:(UIGestureRecognizer *)r


### PR DESCRIPTION
## Summary

This adds support for the Channel Up/Down buttons on the iOS control center remote control.

## Changelog

[TVOS] [Added] - Add support for Channel Up/Down buttons on iOS control center remote control.

## Test Plan

Add a TV event handler that logs eventType, open the Apple TV remote on an iPhone and press channel up/down to see the new pageUp/Down events