### PR TITLE
Enhancement to the nextFocus APIs for TV

### DIFF
--- a/Libraries/Components/AppleTV/tagForComponentOrHandle.js
+++ b/Libraries/Components/AppleTV/tagForComponentOrHandle.js
@@ -1,0 +1,34 @@
+// Replacement for findNodeHandle, since we need this for converting
+// components to tags when rendering nextFocus props
+// @flow
+
+// TODO: make this work for Fabric
+
+// import {findNodeHandle} from '../../Renderer/shims/ReactNative';
+
+type TagForComponentOrHandleType = (
+    component: ?(
+      | {_nativeTag: ?number, canonical: ?{_nativeTag: ?number}}
+      | number
+    ),
+  ) => ?number;
+
+const tagForComponentOrHandle: TagForComponentOrHandleType = (
+  component: ?(
+    | {_nativeTag: ?number, canonical: ?{_nativeTag: ?number}}
+    | number
+  ),
+): ?number => {
+  if (typeof component === 'number') {
+    return component;
+  }
+  if (typeof component?._nativeTag === 'number') {
+    return component?._nativeTag;
+  }
+  if (typeof component?.canonical?._nativeTag === 'number') {
+    return component?.canonical?._nativeTag;
+  }
+  return undefined;
+};
+
+export default tagForComponentOrHandle;

--- a/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/Libraries/Components/Touchable/TouchableOpacity.js
@@ -20,6 +20,7 @@ import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
 import flattenStyle from '../../StyleSheet/flattenStyle';
 import Platform from '../../Utilities/Platform';
 import typeof TVParallaxPropertiesType from '../AppleTV/TVViewPropTypes';
+import tagForComponentOrHandle from '../AppleTV/tagForComponentOrHandle';
 
 import * as React from 'react';
 
@@ -245,13 +246,15 @@ class TouchableOpacity extends React.Component<Props, State> {
         nativeID={this.props.nativeID}
         testID={this.props.testID}
         onLayout={this.props.onLayout}
-        nextFocusDown={this.props.nextFocusDown}
-        nextFocusForward={this.props.nextFocusForward}
-        nextFocusLeft={this.props.nextFocusLeft}
-        nextFocusRight={this.props.nextFocusRight}
-        nextFocusUp={this.props.nextFocusUp}
+        nextFocusDown={tagForComponentOrHandle(this.props.nextFocusDown)}
+        nextFocusForward={tagForComponentOrHandle(this.props.nextFocusForward)}
+        nextFocusLeft={tagForComponentOrHandle(this.props.nextFocusLeft)}
+        nextFocusRight={tagForComponentOrHandle(this.props.nextFocusRight)}
+        nextFocusUp={tagForComponentOrHandle(this.props.nextFocusUp)}
         hasTVPreferredFocus={this.props.hasTVPreferredFocus === true}
-        isTVSelectable={this.props.isTVSelectable !== false && this.props.accessible !== false}
+        isTVSelectable={
+          this.props.isTVSelectable !== false && this.props.accessible !== false
+        }
         tvParallaxProperties={this.props.tvParallaxProperties}
         hitSlop={this.props.hitSlop}
         focusable={
@@ -284,7 +287,7 @@ class TouchableOpacity extends React.Component<Props, State> {
           }
         },
         onPress: event => {
-          if (this.props.onPress != null && Platform.OS !== "android") {
+          if (this.props.onPress != null && Platform.OS !== 'android') {
             this.props.onPress(event);
           }
         },

--- a/packages/rn-tester/js/examples/DirectionalNextFocus/DirectionalNextFocusExample.js
+++ b/packages/rn-tester/js/examples/DirectionalNextFocus/DirectionalNextFocusExample.js
@@ -86,9 +86,9 @@ const DirectionalNextFocusExample = () => {
       <View style={styles.rowContainer}>
         <Button
           nextFocusUp={tagForDestination(upDestination)}
-          nextFocusDown={tagForDestination(downDestination)}
+          nextFocusDown={downDestination}
           nextFocusLeft={tagForDestination(leftDestination)}
-          nextFocusRight={tagForDestination(rightDestination)}
+          nextFocusRight={rightDestination}
           label="Starting point"
         />
         <Button
@@ -114,8 +114,7 @@ const DirectionalNextFocusExample = () => {
           ref={component => setLeftDestination(component)}
           hasTVPreferredFocus={true}
           style={{width: width * 3}}
-          label="nextLeft destination does not work because there is no actual focusable in the
-            direction"
+          label="nextLeft destination does not work on tvOS because there is no actual focusable in the direction"
         />
       </View>
     </View>

--- a/packages/rn-tester/js/examples/DirectionalNextFocus/DirectionalNextFocusExample.js
+++ b/packages/rn-tester/js/examples/DirectionalNextFocus/DirectionalNextFocusExample.js
@@ -29,194 +29,98 @@ exports.examples = [
   },
 ];
 
-const padding = 100;
 const width = 200;
 const height = 120;
 
-class Button extends React.Component<$FlowFixMeProps> {
-  render() {
-    return (
-      <RNTesterThemeContext.Consumer>
-        {theme => {
-          return (
-            <TouchableOpacity
-              hasTVPreferredFocus={this.props.hasTVPreferredFocus || false}
-              nextFocusUp={this.props.nextFocusUp}
-              nextFocusDown={this.props.nextFocusDown}
-              nextFocusLeft={this.props.nextFocusLeft}
-              nextFocusRight={this.props.nextFocusRight}
-              activeOpacity={0.7}
-              onPress={this.props.onPress}
-              onFocus={this.props.onFocus}
-              style={this.props.style}
-              ref={this.props.buttonRef}>
-              <Text style={[{color: theme.LinkColor}, styles.buttonText]}>
-                {this.props.label}
-              </Text>
-            </TouchableOpacity>
-          );
-        }}
-      </RNTesterThemeContext.Consumer>
-    );
-  }
-}
+const Button = React.forwardRef((props: $FlowFixMeProps, ref) => {
+  return (
+    <RNTesterThemeContext.Consumer>
+      {theme => {
+        return (
+          <TouchableOpacity
+            hasTVPreferredFocus={props.hasTVPreferredFocus || false}
+            nextFocusUp={props.nextFocusUp}
+            nextFocusDown={props.nextFocusDown}
+            nextFocusLeft={props.nextFocusLeft}
+            nextFocusRight={props.nextFocusRight}
+            activeOpacity={0.7}
+            onPress={props.onPress}
+            onFocus={props.onFocus}
+            style={[styles.buttonStyle, props.style]}
+            ref={ref}>
+            <Text style={[{color: theme.LinkColor}, styles.buttonText]}>
+              {props.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      }}
+    </RNTesterThemeContext.Consumer>
+  );
+});
 
-class ThemedView extends React.Component<$FlowFixMeProps> {
-  render() {
-    return (
-      <RNTesterThemeContext.Consumer>
-        {theme => {
-          return (
-            <View style={this.props.style}>
-              <Text style={[{color: theme.LabelColor}, styles.buttonText]}>
-                {this.props.label}
-              </Text>
-            </View>
-          );
-        }}
-      </RNTesterThemeContext.Consumer>
-    );
-  }
-}
-
-class DirectionalNextFocusExample extends React.Component<
-  $FlowFixMeProps,
-  {
-    destinations: {
-      up: ?Object,
-      down: ?Object,
-      left: ?Object,
-      right: ?Object,
-    },
-  },
-> {
-  constructor(props: Object) {
-    super(props);
-    this.state = {
-      destinations: {
-        up: undefined,
-        down: undefined,
-        left: undefined,
-        right: undefined,
-      },
-    };
-  }
-
-  render() {
-    const {destinations} = this.state;
-    return (
-      <View style={styles.container}>
-        <View style={styles.rowContainer}>
-          <Button
-            nextFocusUp={destinations.up}
-            nextFocusDown={destinations.down}
-            nextFocusLeft={destinations.left}
-            nextFocusRight={destinations.right}
-            style={{
-              width,
-              height,
-            }}
-            label="Starting point"
-          />
-          <Button
-            buttonRef={component => {
-              if (!this.state.destinations.up) {
-                this.setState(prevState => ({
-                  destinations: {
-                    ...prevState.destinations,
-                    up: findNodeHandle(component),
-                  },
-                }));
-              }
-            }}
-            style={{
-              width,
-              height,
-            }}
-            label="nextUp destination"
-          />
-          <View style={styles.containerFocusGuide}>
-            <Button
-              style={{
-                width,
-                height,
-              }}
-              label="Wrapped button 1"
-            />
-            <Button
-              buttonRef={component => {
-                if (!this.state.destinations.down) {
-                  this.setState(prevState => ({
-                    destinations: {
-                      ...prevState.destinations,
-                      down: findNodeHandle(component),
-                    },
-                  }));
-                }
-              }}
-              style={{
-                width,
-                height,
-              }}
-              label="nextDown destination"
-            />
-            <Button
-              style={{
-                width,
-                height,
-              }}
-              label="Wrapped button 3"
-            />
-          </View>
+const ThemedView = (props: $FlowFixMeProps) => (
+  <RNTesterThemeContext.Consumer>
+    {theme => {
+      return (
+        <View style={[styles.buttonStyle, props.style]}>
+          <Text style={[{color: theme.LabelColor}, styles.buttonText]}>
+            {props.label}
+          </Text>
         </View>
-        <View style={styles.rowContainer}>
+      );
+    }}
+  </RNTesterThemeContext.Consumer>
+);
+
+const DirectionalNextFocusExample = () => {
+  const [upDestination, setUpDestination] = React.useState(null);
+  const [downDestination, setDownDestination] = React.useState(null);
+  const [leftDestination, setLeftDestination] = React.useState(null);
+  const [rightDestination, setRightDestination] = React.useState(null);
+
+  const tagForDestination = (destination: ?React.Node) =>
+    destination ? findNodeHandle(destination) : undefined;
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.rowContainer}>
+        <Button
+          nextFocusUp={tagForDestination(upDestination)}
+          nextFocusDown={tagForDestination(downDestination)}
+          nextFocusLeft={tagForDestination(leftDestination)}
+          nextFocusRight={tagForDestination(rightDestination)}
+          label="Starting point"
+        />
+        <Button
+          ref={component => setUpDestination(component)}
+          label="nextUp destination"
+        />
+        <View style={styles.containerFocusGuide}>
+          <Button label="Wrapped button 1" />
           <Button
-            buttonRef={component => {
-              if (!this.state.destinations.right) {
-                this.setState(prevState => ({
-                  destinations: {
-                    ...prevState.destinations,
-                    right: findNodeHandle(component),
-                  },
-                }));
-              }
-            }}
-            style={{
-              width,
-              height,
-            }}
-            label="nextRight destination"
+            ref={component => setDownDestination(component)}
+            label="nextDown destination"
           />
-          <View
-            style={{
-              width,
-              height,
-            }}
-          />
-          <Button
-            hasTVPreferredFocus={true}
-            buttonRef={component => {
-              if (!this.state.destinations.left) {
-                this.setState(prevState => ({
-                  destinations: {
-                    ...prevState.destinations,
-                    left: findNodeHandle(component),
-                  },
-                }));
-              }
-            }}
-            style={{
-              width: width * 3,
-              height,
-            }}
-            label="nextLeft destination does not work because there is no actual focusable in the
-              direction"
-          />
+          <Button label="Wrapped button 3" />
         </View>
       </View>
-    );
-  }
-}
+      <View style={styles.rowContainer}>
+        <Button
+          ref={component => setRightDestination(component)}
+          label="nextRight destination"
+        />
+        <ThemedView label="" />
+        <Button
+          ref={component => setLeftDestination(component)}
+          hasTVPreferredFocus={true}
+          style={{width: width * 3}}
+          label="nextLeft destination does not work because there is no actual focusable in the
+            direction"
+        />
+      </View>
+    </View>
+  );
+};
 
 const styles = StyleSheet.create({
   container: {
@@ -225,10 +129,18 @@ const styles = StyleSheet.create({
   },
   rowContainer: {
     flexDirection: 'row',
-    padding,
+    padding: 100,
   },
   buttonText: {
     fontSize: 30,
+  },
+  buttonStyle: {
+    width,
+    height,
+    marginLeft: 20,
+    marginRight: 20,
+    marginTop: 20,
+    marginBottom: 20,
   },
   focusGuide: {
     width,

--- a/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideExample.js
+++ b/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideExample.js
@@ -31,236 +31,135 @@ exports.examples = [
   },
 ];
 
-const padding = 100;
 const width = 200;
 const height = 120;
 
-class Button extends React.Component<$FlowFixMeProps> {
-  render() {
-    return (
-      <RNTesterThemeContext.Consumer>
-        {theme => {
-          return (
-            <TouchableOpacity
-              activeOpacity={0.7}
-              onPress={this.props.onPress}
-              onFocus={this.props.onFocus}
-              style={this.props.style}
-              ref={this.props.focusableRef}>
-              <Text style={[{color: theme.LinkColor}, styles.buttonText]}>
-                {this.props.label}
-              </Text>
-            </TouchableOpacity>
-          );
-        }}
-      </RNTesterThemeContext.Consumer>
-    );
-  }
-}
+const Button = React.forwardRef((props: $FlowFixMeProps, ref) => {
+  return (
+    <RNTesterThemeContext.Consumer>
+      {theme => {
+        return (
+          <TouchableOpacity
+            activeOpacity={0.7}
+            onPress={props.onPress}
+            onFocus={props.onFocus}
+            style={styles.buttonStyle}
+            ref={ref}>
+            <Text style={[{color: theme.LinkColor}, styles.buttonText]}>
+              {props.label}
+            </Text>
+          </TouchableOpacity>
+        );
+      }}
+    </RNTesterThemeContext.Consumer>
+  );
+});
 
-class ThemedView extends React.Component<$FlowFixMeProps> {
-  render() {
-    return (
-      <RNTesterThemeContext.Consumer>
-        {theme => {
-          return (
-            <View style={this.props.style}>
-              <Text style={[{color: theme.LabelColor}, styles.buttonText]}>
-                {this.props.label}
-              </Text>
-            </View>
-          );
-        }}
-      </RNTesterThemeContext.Consumer>
-    );
-  }
-}
-
-class TVFocusGuideExample extends React.Component<
-  $FlowFixMeProps,
-  {
-    destination: ?Object,
-    destinationText: string,
-  },
-> {
-  constructor(props: Object) {
-    super(props);
-    this.state = {
-      destination: undefined,
-      destinationText: 'null',
-    };
-  }
-
-  buttonTopRight: ?Object;
-
-  buttonBottomLeft: ?Object;
-
-  rightButtonInFocusViewContainer: ?Object;
-
-  _setDestination(destination: ?Object, destinationText: string) {
-    this.setState({
-      destination,
-      destinationText,
-    });
-  }
-
-  render() {
-    if (!Platform.isTVOS) {
+const ThemedView = (props: $FlowFixMeProps) => (
+  <RNTesterThemeContext.Consumer>
+    {theme => {
       return (
-        <View>
-          <Text>This example is intended to be run on Apple TV.</Text>
+        <View style={[styles.buttonStyle, props.style]}>
+          <Text style={[{color: theme.LabelColor}, styles.buttonText]}>
+            {props.label}
+          </Text>
         </View>
       );
-    }
-    const destinations = this.state.destination ? [this.state.destination] : [];
+    }}
+  </RNTesterThemeContext.Consumer>
+);
+
+const TVFocusGuideExample = () => {
+  const [destination, setDestination] = React.useState(null);
+  const [destinationText, setDestinationText] = React.useState('');
+  const destinations = destination?.current ? [destination?.current] : [];
+
+  const buttonTopRight = React.useRef(null);
+  const buttonBottomLeft = React.useRef(null);
+
+  const rightButtonInFocusViewContainer = React.useRef(null);
+  const containerDestinations = rightButtonInFocusViewContainer?.current
+    ? [rightButtonInFocusViewContainer?.current]
+    : [];
+
+  const _setDestination = (o: ?Object, text: string) => {
+    setDestination(o);
+    setDestinationText(text);
+  };
+
+  if (!Platform.isTVOS) {
     return (
-      <RNTesterThemeContext.Consumer>
-        {theme => {
-          return (
-            <View style={styles.container}>
-              <View style={styles.rowContainer}>
-                <Button
-                  onPress={() => {}}
-                  style={{
-                    width,
-                    height,
-                    marginLeft: 20,
-                    marginRight: 20,
-                    marginTop: 20,
-                    marginBottom: 20,
-                  }}
-                  label="Left Top"
-                />
-                <Button
-                  onPress={() => {}}
-                  onFocus={() =>
-                    this._setDestination(this.buttonBottomLeft, 'bottom left')
-                  }
-                  focusableRef={component => (this.buttonTopRight = component)}
-                  style={{
-                    width,
-                    height,
-                    marginLeft: 20,
-                    marginRight: 20,
-                    marginTop: 20,
-                    marginBottom: 20,
-                  }}
-                  label="Right Top"
-                />
-                <ThemedView
-                  style={{
-                    width,
-                    height,
-                    marginLeft: 20,
-                    marginRight: 20,
-                    marginTop: 20,
-                    marginBottom: 20,
-                  }}
-                  label={`Focus guide points to ${this.state.destinationText}`}
-                />
-                <TVFocusGuideView
-                  style={styles.containerFocusGuide}
-                  destinations={[this.rightButtonInFocusViewContainer]}>
-                  <Button
-                    onPress={() => {}}
-                    style={{
-                      width,
-                      height,
-                      marginLeft: 20,
-                      marginRight: 20,
-                      marginTop: 20,
-                      marginBottom: 20,
-                    }}
-                    label="Wrapped button 1"
-                  />
-                  <Button
-                    onPress={() => {}}
-                    style={{
-                      width,
-                      height,
-                      marginLeft: 20,
-                      marginRight: 20,
-                      marginTop: 20,
-                      marginBottom: 20,
-                    }}
-                    label="Wrapped button 2"
-                  />
-                  <Button
-                    ref={component =>
-                      (this.rightButtonInFocusViewContainer = component)
-                    }
-                    onPress={() => {}}
-                    style={{
-                      width,
-                      height,
-                      marginLeft: 20,
-                      marginRight: 20,
-                      marginTop: 20,
-                      marginBottom: 20,
-                    }}
-                    label="Wrapped button 3"
-                  />
-                </TVFocusGuideView>
-              </View>
-              <View style={styles.rowContainer}>
-                <Button
-                  onPress={() => {}}
-                  onFocus={() =>
-                    this._setDestination(this.buttonTopRight, 'top right')
-                  }
-                  ref={component => (this.buttonBottomLeft = component)}
-                  style={{
-                    width,
-                    height,
-                    marginLeft: 20,
-                    marginRight: 20,
-                    marginTop: 20,
-                    marginBottom: 20,
-                  }}
-                  label="Left Bottom"
-                />
-                <RNTesterThemeContext.Consumer>
-                  {theme => {
-                    return (
-                      <TVFocusGuideView
-                        style={[
-                          {backgroundColor: theme.TertiarySystemFillColor},
-                          styles.focusGuide,
-                        ]}
-                        destinations={destinations}>
-                        <Text
-                          style={[
-                            {color: theme.LabelColor},
-                            styles.buttonText,
-                          ]}>
-                          Focus guide
-                        </Text>
-                      </TVFocusGuideView>
-                    );
-                  }}
-                </RNTesterThemeContext.Consumer>
-                <View
-                  style={{
-                    width,
-                    height,
-                  }}
-                />
-                <ThemedView
-                  style={{
-                    width: width * 3,
-                    height,
-                  }}
-                  label="Blue focus guide container above always points to button 3
-                    if navigating from outside"
-                />
-              </View>
-            </View>
-          );
-        }}
-      </RNTesterThemeContext.Consumer>
+      <View>
+        <Text>This example is intended to be run on Apple TV.</Text>
+      </View>
     );
   }
-}
+
+  return (
+    <RNTesterThemeContext.Consumer>
+      {theme => {
+        return (
+          <View style={styles.container}>
+            <View style={styles.rowContainer}>
+              <Button onPress={() => {}} label="Left Top" />
+              <Button
+                onPress={() => {}}
+                onFocus={() => _setDestination(buttonBottomLeft, 'bottom left')}
+                ref={buttonTopRight}
+                label="Right Top"
+              />
+              <ThemedView label={`Focus guide points to ${destinationText}`} />
+              <TVFocusGuideView
+                style={styles.containerFocusGuide}
+                destinations={containerDestinations}>
+                <Button onPress={() => {}} label="Wrapped button 1" />
+                <Button onPress={() => {}} label="Wrapped button 2" />
+                <Button
+                  ref={rightButtonInFocusViewContainer}
+                  onPress={() => {}}
+                  label="Wrapped button 3"
+                />
+              </TVFocusGuideView>
+            </View>
+            <View style={styles.rowContainer}>
+              <Button
+                onPress={() => {}}
+                onFocus={() => _setDestination(buttonTopRight, 'top right')}
+                ref={buttonBottomLeft}
+                label="Left Bottom"
+              />
+              <RNTesterThemeContext.Consumer>
+                {theme => {
+                  return (
+                    <TVFocusGuideView
+                      style={[
+                        {backgroundColor: theme.TertiarySystemFillColor},
+                        styles.focusGuide,
+                      ]}
+                      destinations={destinations}>
+                      <Text
+                        style={[{color: theme.LabelColor}, styles.buttonText]}>
+                        Focus guide
+                      </Text>
+                    </TVFocusGuideView>
+                  );
+                }}
+              </RNTesterThemeContext.Consumer>
+              <ThemedView label="" />
+              <ThemedView
+                style={{
+                  width: width * 3,
+                }}
+                label="Blue focus guide container above always points to button 3
+                  if navigating from outside"
+              />
+            </View>
+          </View>
+        );
+      }}
+    </RNTesterThemeContext.Consumer>
+  );
+};
 
 const styles = StyleSheet.create({
   container: {
@@ -268,10 +167,18 @@ const styles = StyleSheet.create({
   },
   rowContainer: {
     flexDirection: 'row',
-    padding,
+    padding: 100,
   },
   buttonText: {
     fontSize: 30,
+  },
+  buttonStyle: {
+    width,
+    height,
+    marginLeft: 20,
+    marginRight: 20,
+    marginTop: 20,
+    marginBottom: 20,
   },
   focusGuide: {
     width,


### PR DESCRIPTION
At the moment, the nextFocusLeft/Right/Up/Down APIs need React view tags to be passed in, so the app has to use findNodeHandle() to get the tags. This change allows component refs to be passed in directly, and the tags are calculated internally before passing to native layer.  Passing in tags directly will still work, so this is not a breaking change.

This PR also includes:

- Modified `DirectionalNextFocusExample` to demonstrate passing in component refs to nextFocus APIs
- Refactor `DirectionalNextFocusExample` and `TVFocusGuideViewExample` to use modern functional components