### PR TITLE
update tvos-types to include pan events

### DIFF
--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -31,31 +31,32 @@ declare module 'react-native' {
   nextFocusUp?: number,
   }
 
-  export const useTVEventHandler: (handleEvent: (event: HWKeyEvent) => void) => void;
+  export const useTVEventHandler: (handleEvent: (event: HWEvent) => void) => void;
 
-  export const TVMenuControl: {
+  export const TVEventControl: {
     enableTVMenuKey(): void;
     disableTVMenuKey(): void;
+    enableTVPanGesture(): void;
+    disableTVPanGesture(): void;
   };
 
-  interface HWFocusEvent {
-    eventType: 'blur' | 'focus';
-    eventKeyAction: -1;
-    tag: number;
-  }
-
-  export type HWKeyEvent =
-    | HWFocusEvent
-    | {
-        eventType: 'up' | 'down' | 'right' | 'left' | string;
-        eventKeyAction: -1 | 1 | 0 | number;
-        tag?: number;
-      };
+  export type HWEvent = {
+    eventType: 'up' | 'down' | 'right' | 'left' | 'blur' | 'focus' | 'pan' | string;
+    eventKeyAction: -1 | 1 | 0 | number;
+    tag?: number;
+    body?: {
+      state: "began" | "changed" | "ended",
+      x: number,
+      y: number,
+      velocityx: number,
+      velocityy: number
+    } 
+  };
 
   export class TVEventHandler {
     enable<T extends React.Component<unknown>>(
       component?: T,
-      callback?: (component: T, data: HWKeyEvent) => void
+      callback?: (component: T, data: HWEvent) => void
     ): void;
     disable(): void;
   }
@@ -103,11 +104,11 @@ declare module 'react-native' {
     /**
      * Called when the scroller comes into focus (e.g. for highlighting)
      */
-    onFocus?(evt: HWKeyEvent): void;
+    onFocus?(evt: HWEvent): void;
     /**
      * Called when the scroller goes out of focus
      */
-    onBlur?(evt: HWKeyEvent): void;
+    onBlur?(evt: HWEvent): void;
   }
 
   export class TVTextScrollView extends React.Component<TVTextScrollViewProps> {}

--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -42,10 +42,10 @@ declare module 'react-native' {
 
   export type HWEvent = {
     eventType: 'up' | 'down' | 'right' | 'left' | 'blur' | 'focus' | 'pan' | string;
-    eventKeyAction: -1 | 1 | 0 | number;
+    eventKeyAction?: -1 | 1 | 0 | number;
     tag?: number;
     body?: {
-      state: "began" | "changed" | "ended",
+      state: "Began" | "Changed" | "Ended",
       x: number,
       y: number,
       velocityx: number,


### PR DESCRIPTION
## Summary

The TVMenuControl was renamed to TVEventControl & 'pan' events were added

## Changelog

- Remove un-used `HWFocusEvent` since in practise the type-system could only ever reach the "common" event
- Renamed TVMenuContro to TVEventControl
- Added the missing fields for the 'pan' events
- Renamed HWKeyEvent to HWEvent since it contextuelly made more sense based on recent changes
