### PR TITLE
add focused prop to Pressable API's PressableStateCallbackType

### DIFF
--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -111,4 +111,8 @@ declare module 'react-native' {
   }
 
   export class TVTextScrollView extends React.Component<TVTextScrollViewProps> {}
+  
+  export interface PressableStateCallbackType {
+    readonly focused: boolean;
+  }
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

react-native-tvos adds a "focused" prop to Pressable's callback props (style and children). This PR adds that prop to the type definitions so it can be used in typescript code. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Added] - Pressable's focused callback prop types

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

```tsx
          <View>
              <Pressable>
                {({focused}) => (
                  <Text
                    style={tw`${focused ? 'text-red-500 ' : 'text-blue-500 '}`}>
                    Thing 1
                  </Text>
                )}
              </Pressable>
              <Pressable>
                {({focused}) => (
                  <Text
                    style={tw`${focused ? 'text-red-500 ' : 'text-blue-500 '}`}>
                    Thing 2
                  </Text>
                )}
              </Pressable>
              <Pressable>
                {({focused}) => (
                  <Text
                    style={tw`${focused ? 'text-red-500 ' : 'text-blue-500 '}`}>
                    Thing 3
                  </Text>
                )}
              </Pressable>
            </View>
```
