### PR TITLE
Use focus guides for nextFocus on tvOS (fix #306)

### DIFF
--- a/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/Libraries/Components/Touchable/TouchableHighlight.js
@@ -19,6 +19,8 @@ import typeof TouchableWithoutFeedback from './TouchableWithoutFeedback';
 import Platform from '../../Utilities/Platform';
 import View from '../../Components/View/View';
 import type {ViewProps} from '../../Components/View/ViewPropTypes';
+import typeof TVParallaxPropertiesType from '../AppleTV/TVViewPropTypes';
+import tagForComponentOrHandle from '../AppleTV/tagForComponentOrHandle';
 import * as React from 'react';
 
 type AndroidProps = $ReadOnly<{|
@@ -29,9 +31,21 @@ type AndroidProps = $ReadOnly<{|
   nextFocusUp?: ?number,
 |}>;
 
+type TVProps = $ReadOnly<{|
+  hasTVPreferredFocus?: ?boolean,
+  isTVSelectable?: ?boolean,
+  tvParallaxProperties?: ?TVParallaxPropertiesType,
+  nextFocusDown?: ?number,
+  nextFocusForward?: ?number,
+  nextFocusLeft?: ?number,
+  nextFocusRight?: ?number,
+  nextFocusUp?: ?number,
+|}>;
+
 type Props = $ReadOnly<{|
   ...React.ElementConfig<TouchableWithoutFeedback>,
   ...AndroidProps,
+  ...TVProps,
   ...ViewProps,
 
   activeOpacity?: ?number,
@@ -313,11 +327,11 @@ class TouchableHighlight extends React.Component<Props, State> {
         hasTVPreferredFocus={this.props.hasTVPreferredFocus === true}
         isTVSelectable={this.props.isTVSelectable !== false && this.props.accessible !== false}
         tvParallaxProperties={this.props.tvParallaxProperties}
-        nextFocusDown={this.props.nextFocusDown}
-        nextFocusForward={this.props.nextFocusForward}
-        nextFocusLeft={this.props.nextFocusLeft}
-        nextFocusRight={this.props.nextFocusRight}
-        nextFocusUp={this.props.nextFocusUp}
+        nextFocusDown={tagForComponentOrHandle(this.props.nextFocusDown)}
+        nextFocusForward={tagForComponentOrHandle(this.props.nextFocusForward)}
+        nextFocusLeft={tagForComponentOrHandle(this.props.nextFocusLeft)}
+        nextFocusRight={tagForComponentOrHandle(this.props.nextFocusRight)}
+        nextFocusUp={tagForComponentOrHandle(this.props.nextFocusUp)}
         focusable={
           this.props.focusable !== false && this.props.onPress !== undefined
         }

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -71,6 +71,10 @@ NS_ASSUME_NONNULL_BEGIN
 
 #if TARGET_OS_TV
 @property(nonatomic, nullable) UIFocusGuide *focusGuide;
+@property(nonatomic, nullable) UIFocusGuide *focusGuideUp;
+@property(nonatomic, nullable) UIFocusGuide *focusGuideDown;
+@property(nonatomic, nullable) UIFocusGuide *focusGuideLeft;
+@property(nonatomic, nullable) UIFocusGuide *focusGuideRight;
 #endif
 
 /**

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -309,41 +309,92 @@ using namespace facebook::react;
   return _props->isTVSelectable;
 }
 
-- (NSArray<id<UIFocusEnvironment>> *)preferredFocusEnvironments {
-  if (_nextFocusActiveTarget == nil) return [super preferredFocusEnvironments];
-  UIView * nextFocusActiveTarget = _nextFocusActiveTarget;
-  _nextFocusActiveTarget = nil;
-  NSArray<id<UIFocusEnvironment>> * focusEnvironment = @[nextFocusActiveTarget];
-  return focusEnvironment;
-}
+// In tvOS, to support directional focus APIs, we add a UIFocusGuide for each
+// side of the view where a nextFocus has been set. Set layout constraints to
+// make the guide 1 px thick, and set the destination to the nextFocus object.
+//
+// This is only done once the view is focused.
+//
+- (void)enableDirectionalFocusGuides
+{
+  if (self->_nextFocusUp != nil) {
+    if (self.focusGuideUp == nil) {
+      self.focusGuideUp = [UIFocusGuide new];
+      [[self containingRootView] addLayoutGuide:self.focusGuideUp];
 
-- (BOOL) shouldUpdateFocusInContext:(UIFocusUpdateContext *)context {
-  if (self.isFocused) {
-    if (_nextFocusUp != nil && context.focusHeading == UIFocusHeadingUp) {
-      self->_nextFocusActiveTarget = _nextFocusUp;
-      [self setNeedsFocusUpdate];
-      return false;
+      [self.focusGuideUp.bottomAnchor constraintEqualToAnchor:self.topAnchor].active = YES;
+      [self.focusGuideUp.widthAnchor constraintEqualToAnchor:self.widthAnchor].active = YES;
+      [self.focusGuideUp.heightAnchor constraintEqualToConstant:1.0].active = YES;
+      [self.focusGuideUp.leftAnchor constraintEqualToAnchor:self.leftAnchor].active = YES;
     }
-    if (_nextFocusDown != nil && context.focusHeading == UIFocusHeadingDown) {
-      self->_nextFocusActiveTarget = _nextFocusDown;
-      [self setNeedsFocusUpdate];
-      return false;
-    }
-    if (_nextFocusLeft != nil && context.focusHeading == UIFocusHeadingLeft) {
-      self->_nextFocusActiveTarget = _nextFocusLeft;
-      [self setNeedsFocusUpdate];
-      return false;
-    }
-    if (_nextFocusRight != nil && context.focusHeading == UIFocusHeadingRight) {
-      self->_nextFocusActiveTarget = _nextFocusRight;
-      [self setNeedsFocusUpdate];
-      return false;
-    }
-    self->_nextFocusActiveTarget = nil;
-    return true;
+
+    self.focusGuideUp.preferredFocusEnvironments = @[self->_nextFocusUp];
   }
-  self->_nextFocusActiveTarget = nil;
-  return true;
+
+  if (self->_nextFocusDown != nil) {
+    if (self.focusGuideDown == nil) {
+      self.focusGuideDown = [UIFocusGuide new];
+      [[self containingRootView] addLayoutGuide:self.focusGuideDown];
+
+      [self.focusGuideDown.topAnchor constraintEqualToAnchor:self.bottomAnchor].active = YES;
+      [self.focusGuideDown.widthAnchor constraintEqualToAnchor:self.widthAnchor].active = YES;
+      [self.focusGuideDown.heightAnchor constraintEqualToConstant:1.0].active = YES;
+      [self.focusGuideDown.leftAnchor constraintEqualToAnchor:self.leftAnchor].active = YES;
+    }
+
+    self.focusGuideDown.preferredFocusEnvironments = @[self->_nextFocusDown];
+  }
+
+  if (self->_nextFocusLeft != nil) {
+    if (self.focusGuideLeft == nil) {
+      self.focusGuideLeft = [UIFocusGuide new];
+      [[self containingRootView] addLayoutGuide:self.focusGuideLeft];
+
+      [self.focusGuideLeft.topAnchor constraintEqualToAnchor:self.topAnchor].active = YES;
+      [self.focusGuideLeft.widthAnchor constraintEqualToConstant:1.0].active = YES;
+      [self.focusGuideLeft.heightAnchor constraintEqualToAnchor:self.heightAnchor].active = YES;
+      [self.focusGuideLeft.rightAnchor constraintEqualToAnchor:self.leftAnchor].active = YES;
+    }
+
+    self.focusGuideLeft.preferredFocusEnvironments = @[self->_nextFocusLeft];
+  }
+
+  if (self->_nextFocusRight != nil) {
+    if (self.focusGuideRight == nil) {
+      self.focusGuideRight = [UIFocusGuide new];
+      [[self containingRootView] addLayoutGuide:self.focusGuideRight];
+
+      [self.focusGuideRight.topAnchor constraintEqualToAnchor:self.topAnchor].active = YES;
+      [self.focusGuideRight.widthAnchor constraintEqualToConstant:1.0].active = YES;
+      [self.focusGuideRight.heightAnchor constraintEqualToAnchor:self.heightAnchor].active = YES;
+      [self.focusGuideRight.leftAnchor constraintEqualToAnchor:self.rightAnchor].active = YES;
+    }
+
+    self.focusGuideRight.preferredFocusEnvironments = @[self->_nextFocusRight];
+  }
+}
+// Called when focus leaves this view -- disable the directional focus guides
+// (if they exist) so that they don't interfere with focus navigation from
+// other views
+//
+- (void)disableDirectionalFocusGuides
+{
+  if (self.focusGuideUp != nil) {
+    [[self containingRootView] removeLayoutGuide:self.focusGuideUp];
+    self.focusGuideUp = nil;
+  }
+  if (self.focusGuideDown != nil) {
+    [[self containingRootView] removeLayoutGuide:self.focusGuideDown];
+    self.focusGuideDown = nil;
+  }
+  if (self.focusGuideLeft != nil) {
+    [[self containingRootView] removeLayoutGuide:self.focusGuideLeft];
+    self.focusGuideLeft = nil;
+  }
+  if (self.focusGuideRight != nil) {
+    [[self containingRootView] removeLayoutGuide:self.focusGuideRight];
+    self.focusGuideRight = nil;
+  }
 }
 
 - (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator
@@ -353,11 +404,13 @@ using namespace facebook::react;
     }
     if (context.nextFocusedView == self && self.isUserInteractionEnabled ) {
       [self becomeFirstResponder];
+      [self enableDirectionalFocusGuides];
       [coordinator addCoordinatedAnimations:^(void){
           [self addParallaxMotionEffects];
           [self sendFocusNotification:context];
       } completion:^(void){}];
     } else {
+      [self disableDirectionalFocusGuides];
       [coordinator addCoordinatedAnimations:^(void){
           [self removeParallaxMotionEffects];
           [self sendBlurNotification:context];

--- a/React/Views/RCTTVView.h
+++ b/React/Views/RCTTVView.h
@@ -32,11 +32,15 @@
 /**
  * Focus direction tags
  */
-@property (nonatomic, strong) RCTTVView * nextFocusUp;
-@property (nonatomic, strong) RCTTVView * nextFocusDown;
-@property (nonatomic, strong) RCTTVView * nextFocusLeft;
-@property (nonatomic, strong) RCTTVView * nextFocusRight;
-@property (nonatomic, strong) RCTTVView * nextFocusActiveTarget;
+@property (nonatomic, weak) RCTTVView * nextFocusUp;
+@property (nonatomic, weak) RCTTVView * nextFocusDown;
+@property (nonatomic, weak) RCTTVView * nextFocusLeft;
+@property (nonatomic, weak) RCTTVView * nextFocusRight;
+
+@property (nonatomic, strong) UIFocusGuide * focusGuideUp;
+@property (nonatomic, strong) UIFocusGuide * focusGuideDown;
+@property (nonatomic, strong) UIFocusGuide * focusGuideLeft;
+@property (nonatomic, strong) UIFocusGuide * focusGuideRight;
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge;
 

--- a/packages/rn-tester/js/examples/DirectionalNextFocus/DirectionalNextFocusExample.js
+++ b/packages/rn-tester/js/examples/DirectionalNextFocus/DirectionalNextFocusExample.js
@@ -15,7 +15,7 @@ const ReactNative = require('react-native');
 
 import {RNTesterThemeContext} from '../../components/RNTesterTheme';
 
-const {View, StyleSheet, TouchableOpacity, Text, findNodeHandle} = ReactNative;
+const {Platform, View, StyleSheet, TouchableOpacity, Text, findNodeHandle} = ReactNative;
 
 exports.framework = 'React';
 exports.title = 'DirectionalNextFocus example';
@@ -29,8 +29,10 @@ exports.examples = [
   },
 ];
 
-const width = 200;
-const height = 120;
+const scale = Platform.OS === 'android' ? 0.5 : 1.0;
+
+const width = 200*scale;
+const height = 120*scale;
 
 const Button = React.forwardRef((props: $FlowFixMeProps, ref) => {
   return (
@@ -114,7 +116,7 @@ const DirectionalNextFocusExample = () => {
           ref={component => setLeftDestination(component)}
           hasTVPreferredFocus={true}
           style={{width: width * 3}}
-          label="nextLeft destination does not work on tvOS because there is no actual focusable in the direction"
+          label="nextLeft destination"
         />
       </View>
     </View>
@@ -123,23 +125,19 @@ const DirectionalNextFocusExample = () => {
 
 const styles = StyleSheet.create({
   container: {
-    marginTop: -20,
     backgroundColor: 'transparent',
   },
   rowContainer: {
     flexDirection: 'row',
-    padding: 100,
+    padding: 0.5*width,
   },
   buttonText: {
-    fontSize: 30,
+    fontSize: 30*scale,
   },
   buttonStyle: {
     width,
     height,
-    marginLeft: 20,
-    marginRight: 20,
-    marginTop: 20,
-    marginBottom: 20,
+    margin: 20*scale,
   },
   focusGuide: {
     width,


### PR DESCRIPTION
- Adds 1 px thick focus guides when needed... e.g. if `nextFocusRight` is set, place a 1 px thick focus guide on the right of the view, with focus destination set to the value of `nextFocusRight`.
- nextFocus APIs work even without real views in the direction of navigation
- works for both Fabric and non-Fabric
- Corrects missing implementation details in `TouchableHighlight`
- Update DirectionalNextFocus RNTester example