### PR TITLE
Prevent extra onPress events in TouchableNativeFeedback

### DIFF
--- a/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -319,7 +319,7 @@ class TouchableNativeFeedback extends React.Component<Props, State> {
           }
         },
         onPress: event => {
-          if (this.props.onPress != null) {
+          if (this.props.onPress != null && Platform.OS !== 'android') {
             this.props.onPress(event);
           }
         },


### PR DESCRIPTION
See #159

The same issue which happens for `TouchableHighlight` happens also to `TouchableNativeFeedback`.