### PR TITLE
Add CHANNEL_UP, CHANNEL_DOWN, and DIGIT (0-9) key event support to Android TV

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
@@ -49,6 +49,18 @@ public class ReactAndroidHWInputDeviceHelper {
           .put(KeyEvent.KEYCODE_DPAD_LEFT, "left")
           .put(KeyEvent.KEYCODE_INFO, "info")
           .put(KeyEvent.KEYCODE_MENU, "menu")
+          .put(KeyEvent.KEYCODE_0, "0")
+          .put(KeyEvent.KEYCODE_1, "1")
+          .put(KeyEvent.KEYCODE_2, "2")
+          .put(KeyEvent.KEYCODE_3, "3")
+          .put(KeyEvent.KEYCODE_4, "4")
+          .put(KeyEvent.KEYCODE_5, "5")
+          .put(KeyEvent.KEYCODE_6, "6")
+          .put(KeyEvent.KEYCODE_7, "7")
+          .put(KeyEvent.KEYCODE_8, "8")
+          .put(KeyEvent.KEYCODE_9, "9")
+          .put(KeyEvent.KEYCODE_CHANNEL_DOWN, "channelDown")
+          .put(KeyEvent.KEYCODE_CHANNEL_UP, "channelUp")
           .build();
 
   /**


### PR DESCRIPTION
## Summary

Add CHANNEL_UP, CHANNEL_DOWN, and DIGIT (0-9) key event support to Android TV

## Changelog

[Android] [Added] - Add CHANNEL_UP, CHANNEL_DOWN, and DIGIT (0-9) key event support to Android TV

## Test Plan

We develop application that utilizes aforementioned events, we've made a build against react-native fork with these changes and it was working as expected. These changes just add more button mappings, so I don't think it requires some extensive testing.
