### PR TITLE
Fix issues found with modal TV gesture recognizer and menu key behavior (fix #341)

### DIFF
--- a/React/Base/RCTTVRemoteHandler.h
+++ b/React/Base/RCTTVRemoteHandler.h
@@ -46,4 +46,7 @@ extern NSString * _Nonnull const RCTTVRemoteEventPan;
 + (BOOL)usePanGesture;
 + (void)setUsePanGesture:(BOOL)usePanGesture;
 
+- (void)enableTVMenuKey;
+- (void)disableTVMenuKey;
+
 @end

--- a/React/Views/RCTModalHostView.h
+++ b/React/Views/RCTModalHostView.h
@@ -47,6 +47,9 @@
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge NS_DESIGNATED_INITIALIZER;
 
+- (void)enableEventHandlers;
+- (void)disableEventHandlers;
+
 @end
 
 @protocol RCTModalHostViewInteractor <NSObject>

--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -95,14 +95,16 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
 
 - (void)enableEventHandlers
 {
-  self.tvRemoteHandler = [[RCTTVRemoteHandler alloc] initWithView:_reactSubview];
-  [self addGestureRecognizer:_menuButtonGestureRecognizer];
+  self.tvRemoteHandler = [[RCTTVRemoteHandler alloc] initWithView:_modalViewController.view];
+  [self.tvRemoteHandler disableTVMenuKey];
+
+  [_modalViewController.view addGestureRecognizer:_menuButtonGestureRecognizer];
 }
 
 - (void)disableEventHandlers
 {
   self.tvRemoteHandler = nil;
-  [self removeGestureRecognizer:_menuButtonGestureRecognizer];
+  [_modalViewController.view removeGestureRecognizer:_menuButtonGestureRecognizer];
 }
 
 - (void)notifyForOrientationChange

--- a/React/Views/RCTModalHostViewController.h
+++ b/React/Views/RCTModalHostViewController.h
@@ -6,10 +6,13 @@
  */
 
 #import <UIKit/UIKit.h>
+#import "RCTModalHostView.h"
 
 @interface RCTModalHostViewController : UIViewController
 
 @property (nonatomic, copy) void (^boundsDidChangeBlock)(CGRect newBounds);
+
+@property (nonatomic, weak) RCTModalHostView *modalHostView;
 
 #if !TARGET_OS_TV
 @property (nonatomic, assign) UIInterfaceOrientationMask supportedInterfaceOrientations;

--- a/React/Views/RCTModalHostViewController.m
+++ b/React/Views/RCTModalHostViewController.m
@@ -39,6 +39,32 @@
   return self;
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+#if TARGET_OS_TV
+  [self.modalHostView enableEventHandlers];
+#endif
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+#if TARGET_OS_TV
+  [self.modalHostView disableEventHandlers];
+  if (self.modalHostView.onRequestClose) {
+    self.modalHostView.onRequestClose(nil);
+  }
+#endif
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+#if TARGET_OS_TV
+  if (self.modalHostView.onDismiss) {
+    self.modalHostView.onDismiss(nil);
+  }
+#endif
+}
+
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];

--- a/packages/rn-tester/js/components/RNTOption.js
+++ b/packages/rn-tester/js/components/RNTOption.js
@@ -43,6 +43,8 @@ export default function RNTOption(props: Props): React.Node {
       }
       hitSlop={4}
       onPress={props.onPress}
+      onFocus={() => setPressed(true)}
+      onBlur={() => setPressed(false)}
       onPressIn={() => setPressed(true)}
       onPressOut={() => setPressed(false)}
       testID={props.testID}>

--- a/packages/rn-tester/js/examples/Modal/ModalOnShow.js
+++ b/packages/rn-tester/js/examples/Modal/ModalOnShow.js
@@ -9,7 +9,7 @@
  */
 
 import * as React from 'react';
-import {Modal, Pressable, StyleSheet, Text, View} from 'react-native';
+import {Modal, Pressable, StyleSheet, Text, useTVEventHandler, View} from 'react-native';
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 function ModalOnShowOnDismiss(): React.Node {
@@ -17,6 +17,14 @@ function ModalOnShowOnDismiss(): React.Node {
   const [modalVisible, setModalVisible] = React.useState(false);
   const [onShowCount, setOnShowCount] = React.useState(0);
   const [onDismissCount, setOnDismissCount] = React.useState(0);
+
+  const [lastEvent, setLastEvent] = React.useState('');
+
+  const buttonOpacity = (pressed, focused) => (pressed || focused ? 0.7 : 1.0);
+
+  useTVEventHandler(evt => {
+    setLastEvent(evt.eventType);
+  });
 
   return (
     <View style={styles.container}>
@@ -43,14 +51,22 @@ function ModalOnShowOnDismiss(): React.Node {
                 onDismiss is called {onDismissCount} times
               </Text>
               <Pressable
-                style={[styles.button, styles.buttonClose]}
+                style={({pressed, focused}) => [
+                  styles.button,
+                  styles.buttonClose,
+                  {opacity: buttonOpacity(pressed, focused)},
+                ]}
                 onPress={() => setModalVisible(false)}>
                 <Text testID="dismiss-modal" style={styles.textStyle}>
                   Hide modal by setting visible to false
                 </Text>
               </Pressable>
               <Pressable
-                style={[styles.button, styles.buttonClose]}
+                style={({pressed, focused}) => [
+                  styles.button,
+                  styles.buttonClose,
+                  {opacity: buttonOpacity(pressed, focused)},
+                ]}
                 onPress={() => setModalShowComponent(false)}>
                 <Text
                   testID="dismiss-modal-by-removing-component"
@@ -66,8 +82,13 @@ function ModalOnShowOnDismiss(): React.Node {
       <Text testID="on-dismiss-count">
         onDismiss is called {onDismissCount} times
       </Text>
+      <Text> Last event = {lastEvent}</Text>
       <Pressable
-        style={[styles.button, styles.buttonOpen]}
+        style={({pressed, focused}) => [
+          styles.button,
+          styles.buttonOpen,
+          {opacity: buttonOpacity(pressed, focused)},
+        ]}
         onPress={() => {
           setModalShowComponent(true);
           setModalVisible(true);
@@ -83,7 +104,7 @@ function ModalOnShowOnDismiss(): React.Node {
 const styles = StyleSheet.create({
   container: {
     display: 'flex',
-    alignItems: 'center',
+    alignItems: 'flex-start',
     paddingVertical: 30,
   },
   centeredView: {


### PR DESCRIPTION
- Use the view controller's `viewDidAppear`, `viewDidDisappear`, etc., to control adding and removing menu key gesture recognizer and RCTTVRemoteHandler
- Clean up unneeded code
- Fix up RNTester ModalExample for TV