### PR TITLE
Fixed compilation error with RCTModalHostView.m

### DIFF
--- a/React/Views/RCTModalHostView.m
+++ b/React/Views/RCTModalHostView.m
@@ -95,16 +95,20 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : coder)
 
 - (void)enableEventHandlers
 {
+#if TARGET_OS_TV
   self.tvRemoteHandler = [[RCTTVRemoteHandler alloc] initWithView:_modalViewController.view];
   [self.tvRemoteHandler disableTVMenuKey];
 
   [_modalViewController.view addGestureRecognizer:_menuButtonGestureRecognizer];
+#endif
 }
 
 - (void)disableEventHandlers
 {
+#if TARGET_OS_TV
   self.tvRemoteHandler = nil;
   [_modalViewController.view removeGestureRecognizer:_menuButtonGestureRecognizer];
+#endif
 }
 
 - (void)notifyForOrientationChange


### PR DESCRIPTION
Fixed an issue where tvRemoteHandler in RCTModalHostView.m was used even when not targeting TvOS, which is not available.