### PR TITLE
Use react-native version to find the hermes packages in podspec

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "react-native-tvos",
   "version": "0.69.5-0",
+  "rn-version": "0.69.5",
   "bin": "./cli.js",
   "description": "A framework for building native apps using React",
   "license": "MIT",

--- a/sdks/hermes-engine/hermes-engine.podspec
+++ b/sdks/hermes-engine/hermes-engine.podspec
@@ -12,7 +12,7 @@ import_hermesc_file=File.join(__dir__, "..", "hermesc", "osx-bin", "ImportHermes
 # package.json
 package_file = File.join(__dir__, "..", "..", "package.json")
 package = JSON.parse(File.read(package_file))
-version = package['version']
+version = package['rn-version']
 
 # We need to check the current git branch/remote to verify if
 # we're on a React Native release branch to actually build Hermes.


### PR DESCRIPTION
Fixed an issue where podspec was looking for the wrong hermes version (if enabled). Insted of the actual react-native-tvos (x.x.x-X) version, it should using the react-native (x.x.x) one.