### PR TITLE
Fix remote tv handler preventing subviews to recognize gestures

### DIFF
--- a/React/Base/RCTTVRemoteHandler.m
+++ b/React/Base/RCTTVRemoteHandler.m
@@ -405,6 +405,7 @@ static __volatile BOOL __usePanGesture = NO;
 {
   UILongPressGestureRecognizer *recognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:selector];
   recognizer.allowedPressTypes = @[ @(pressType) ];
+  recognizer.cancelsTouchesInView = NO;
 
   _tvRemoteGestureRecognizers[name] = recognizer;
 }
@@ -413,6 +414,7 @@ static __volatile BOOL __usePanGesture = NO;
 {
   UITapGestureRecognizer *recognizer = [[UITapGestureRecognizer alloc] initWithTarget:self action:selector];
   recognizer.allowedPressTypes = @[ @(pressType) ];
+  recognizer.cancelsTouchesInView = NO;
 
   _tvRemoteGestureRecognizers[name] = recognizer;
 }
@@ -423,6 +425,7 @@ static __volatile BOOL __usePanGesture = NO;
 {
   UISwipeGestureRecognizer *recognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:selector];
   recognizer.direction = direction;
+  recognizer.cancelsTouchesInView = NO;
 
   _tvRemoteGestureRecognizers[name] = recognizer;
 }


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

`RCTTVRemoteHandler` setups a lot of gesture handlers over the root view, but those are preventing root's children from recognizing gestures as well.

This happens because remote handler's recognizers have their `cancelsTouchesInView` set to `true` by default, as stated in [Apple's doc](https://developer.apple.com/documentation/uikit/uigesturerecognizer/1624218-cancelstouchesinview):

> When this property is true (the default) and the gesture recognizer recognizes its gesture, the touches of that gesture that are pending aren’t delivered to the view and previously delivered touches are canceled through a [touchesCancelled(_:with:)](https://developer.apple.com/documentation/uikit/uiresponder/1621116-touchescancelled) message sent to the view. If a gesture recognizer doesn’t recognize its gesture or if the value of this property is false, the view receives all touches in the multi-touch sequence.

This means no gesture recognizers under root's hierarchy will get executed because of this, including the ones coming from other native APIs like av player, for example. In fact, I'm pretty sure [this issue](https://github.com/react-native-video/react-native-video/issues/2507) from `react-native-video` is also related.

I've setup a [super simple project](https://github.com/pogist/rn-tvos-gesture-issue) using it to reproduce the problem.

Just try firing any control buttons on the transport bar (like volume or subtitles) and you'll see that nothing happens. 

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[AppleTV] [Fixed] - Fix `RCTTVRemoteHandler` preventing gesture recognizers from being fired

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

I used the repro project I mentioned earlier to test this fix.