### PR TITLE
Apple TV: TVEventControl methods for controlling cancelsTouchesInView

### DIFF
--- a/Libraries/Components/TV/TVEventControl.js
+++ b/Libraries/Components/TV/TVEventControl.js
@@ -22,4 +22,10 @@ module.exports = {
   disableTVPanGesture: () => {
     TVMenuBridge && TVMenuBridge.disableTVPanGesture();
   },
+  enableGestureHandlersCancelTouches: () => {
+    TVMenuBridge && TVMenuBridge.enableGestureHandlersCancelTouches();
+  },
+  disableGestureHandlersCancelTouches: () => {
+    TVMenuBridge && TVMenuBridge.disableGestureHandlersCancelTouches();
+  },
 };

--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ class Game2048 extends React.Component {
 - _TVEventControl_: (Formerly "TVMenuControl") (Apple TV only) This module provides methods to enable and disable firing of two types of events from the Apple TV Siri remote:
   - `enableTVMenuKey`/`disableTVMenuKey`:  Method to enable and disable the menu key gesture recognizer, in order to fix an issue with Apple's guidelines for menu key navigation (see https://github.com/facebook/react-native/issues/18930).  The `RNTester` app uses these methods to implement correct menu key behavior for back navigation.
   - `enableTVPanGesture`/`disableTVPanGesture`: Methods to enable and disable detection of finger touches that pan across the touch surface of the Siri remote. See `TVEventHandlerExample` in the `RNTester` app for a demo.
+  - `enableGestureHandlersCancelTouches`/`disableGestureHandlersCancelTouches`: Methods to turn on and turn off cancellation of touches by the gesture handlers in `RCTTVRemoteHandler` (see #366). Cancellation of touches is turned on (enabled) by default in 0.69 and earlier releases.
 
 - _TVFocusGuideView_: This component provides support for Apple's `UIFocusGuide` API and is implemented in the same way for Android TV, to help ensure that focusable controls can be navigated to, even if they are not directly in line with other controls.  An example is provided in `RNTester` that shows two different ways of using this component.
 

--- a/React/Base/RCTTVRemoteHandler.h
+++ b/React/Base/RCTTVRemoteHandler.h
@@ -13,6 +13,9 @@ extern NSString * _Nonnull const RCTTVDisableMenuKeyNotification;
 extern NSString * _Nonnull const RCTTVEnablePanGestureNotification;
 extern NSString * _Nonnull const RCTTVDisablePanGestureNotification;
 
+extern NSString * _Nonnull const RCTTVEnableGestureHandlersCancelTouchesNotification;
+extern NSString * _Nonnull const RCTTVDisableGestureHandlersCancelTouchesNotification;
+
 extern NSString * _Nonnull const RCTTVRemoteEventMenu;
 extern NSString * _Nonnull const RCTTVRemoteEventPlayPause;
 extern NSString * _Nonnull const RCTTVRemoteEventSelect;
@@ -45,6 +48,9 @@ extern NSString * _Nonnull const RCTTVRemoteEventPan;
 
 + (BOOL)usePanGesture;
 + (void)setUsePanGesture:(BOOL)usePanGesture;
+
++ (BOOL)gestureHandlersCancelTouches;
++ (void)setGestureHandlersCancelTouches:(BOOL)cancelTouches;
 
 - (void)enableTVMenuKey;
 - (void)disableTVMenuKey;

--- a/React/Modules/RCTTVMenuBridge.m
+++ b/React/Modules/RCTTVMenuBridge.m
@@ -36,4 +36,14 @@ RCT_EXPORT_METHOD(disableTVPanGesture)
     [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVDisablePanGestureNotification object:nil];
 }
 
+RCT_EXPORT_METHOD(enableGestureHandlersCancelTouches) {
+  [RCTTVRemoteHandler setGestureHandlersCancelTouches:YES];
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVEnableGestureHandlersCancelTouchesNotification object:nil];
+}
+
+RCT_EXPORT_METHOD(disableGestureHandlersCancelTouches) {
+  [RCTTVRemoteHandler setGestureHandlersCancelTouches:NO];
+  [[NSNotificationCenter defaultCenter] postNotificationName:RCTTVDisableGestureHandlersCancelTouchesNotification object:nil];
+}
+
 @end

--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -84,6 +84,7 @@ const RNTesterApp = (): React.Node => {
 
   // Setup hardware back button press listener
   React.useEffect(() => {
+    TVEventControl.disableGestureHandlersCancelTouches();
     if (activeModuleKey) {
       TVEventControl.enableTVMenuKey();
     } else {

--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -38,6 +38,8 @@ declare module 'react-native' {
     disableTVMenuKey(): void;
     enableTVPanGesture(): void;
     disableTVPanGesture(): void;
+    enableGestureHandlersCancelTouches(): void;
+    disableGestureHandlersCancelTouches(): void;
   };
 
   export type HWEvent = {


### PR DESCRIPTION
Builds on top of #366 to allow app developers to control whether `RCTTVRemoteHandler`'s gesture recognizers cancel touches (and block other event handlers).