### PR TITLE
TVFocusGuide fixes and improvements

### DIFF
--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -104,8 +104,7 @@ const FocusGuideViewAndroidTV = (props: TVFocusGuideViewProps) => {
     <ReactNative.View
       style={props.style}
       focusable={props.focusable ?? true}
-      destinations={nativeDestinations}
-    >
+      destinations={nativeDestinations}>
       {props.children}
     </ReactNative.View>
   );
@@ -121,6 +120,9 @@ const styles = ReactNative.StyleSheet.create({
     paddingRight: 0,
   },
   focusGuide: {
+    position: 'relative',
+    width: '100%',
+    height: '100%',
     left: 0,
     top: 0,
     right: 0,

--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -19,6 +19,13 @@ type TVFocusGuideViewProps = $ReadOnly<{
   ...ViewProps,
 
   /**
+   * If the view should be "visible". display "flex" if visible, otherwise "none".
+   * Useful for absolute focus guides without children
+   * Defaults to true
+   */
+  enabled: ?Boolean,
+
+  /**
    * The views the focus should go to
    */
   destinations: ?(Object[]),
@@ -29,17 +36,23 @@ type TVFocusGuideViewProps = $ReadOnly<{
   safePadding?: 'vertical' | 'horizontal' | 'both' | null,
 }>;
 
-const TVFocusGuideView = (props: TVFocusGuideViewProps): React.Node => {
-  const safePadding =
-    props.safePadding === undefined ? 'both' : props.safePadding;
+const TVFocusGuideView = ({
+  enabled = true,
+  safePadding,
+  style,
+  ...otherProps
+}: TVFocusGuideViewProps): React.Node => {
+  const paddingChoice = safePadding === undefined ? 'both' : safePadding;
   const focusGuidePadding =
-    safePadding === 'both'
+    paddingChoice === 'both'
       ? {padding: 1}
-      : safePadding === 'vertical'
+      : paddingChoice === 'vertical'
       ? {paddingVertical: 1}
-      : safePadding === 'horizontal'
+      : paddingChoice === 'horizontal'
       ? {paddingHorizontal: 1}
       : null;
+
+  const enabledStyle = {display: enabled ? 'flex' : 'none'};
 
   /**
    * The client specified layout(using 'style' prop) should be applied the container view ReactNative.View.
@@ -49,22 +62,22 @@ const TVFocusGuideView = (props: TVFocusGuideViewProps): React.Node => {
    * and so, the left margin is getting added twice and UI becomes incorrect.
    * The same is applicable for other layout properties.
    */
-  const focusGuideStyle = [focusGuidePadding, props.style, styles.focusGuide];
+  const focusGuideStyle = [focusGuidePadding, style, styles.focusGuide];
 
   return (
     /**
      * The container needs to have at least a width of 1 and a height of 1.
      * Also, being the container, it shouldn't be possible to give it some padding.
      */
-    <ReactNative.View style={[props.style, styles.container]}>
+    <ReactNative.View style={[style, styles.container, enabledStyle]}>
       {Platform.isTV ? (
         Platform.isTVOS ? (
-          <FocusGuideViewTVOS {...props} style={focusGuideStyle} />
+          <FocusGuideViewTVOS {...otherProps} style={focusGuideStyle} />
         ) : (
-          <FocusGuideViewAndroidTV {...props} style={focusGuideStyle} />
+          <FocusGuideViewAndroidTV {...otherProps} style={focusGuideStyle} />
         )
       ) : (
-        props.children
+        otherProps.children
       )}
     </ReactNative.View>
   );

--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -121,8 +121,6 @@ const styles = ReactNative.StyleSheet.create({
   },
   focusGuide: {
     position: 'relative',
-    width: '100%',
-    height: '100%',
     left: 0,
     top: 0,
     right: 0,

--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -84,11 +84,7 @@ const FocusGuideViewTVOS = (props: TVFocusGuideViewProps) => {
       Commands.setDestinations(hostComponentRef, nativeDestinations);
   }, [props.destinations]);
 
-  return (
-    <ReactNative.View style={props.style} ref={focusGuideRef}>
-      {props.children}
-    </ReactNative.View>
-  );
+  return <ReactNative.View ref={focusGuideRef} {...props} />;
 };
 
 const FocusGuideViewAndroidTV = (props: TVFocusGuideViewProps) => {
@@ -102,11 +98,10 @@ const FocusGuideViewAndroidTV = (props: TVFocusGuideViewProps) => {
 
   return (
     <ReactNative.View
-      style={props.style}
+      {...props}
       focusable={props.focusable ?? true}
-      destinations={nativeDestinations}>
-      {props.children}
-    </ReactNative.View>
+      destinations={nativeDestinations}
+    />
   );
 };
 

--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -121,6 +121,7 @@ const styles = ReactNative.StyleSheet.create({
   },
   focusGuide: {
     position: 'relative',
+    opacity: 1,
     left: 0,
     top: 0,
     right: 0,

--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -62,6 +62,11 @@ declare module 'react-native' {
   }
 
   export interface FocusGuideProps extends ViewProps {
+     /**
+     * If the view should be "visible". display "flex" if visible, otherwise "none".
+     * Defaults to true
+     */
+    enabled?: boolean;
     /**
      * Array of `Component`s to register as destinations with `UIFocusGuide`
      */


### PR DESCRIPTION
## Summary

- Props not used by container should be forwarded to inner view
- Some styling attributes should be forwarded to innervew. Such as `position` and `opacity`
- New `enabled` prop, it allows to toggle the displayability of the container. Useful for focus guides that don't have children and only redirects to focus to somewhere else.

IMO, this PR should be merged in **0.68.2** as well as the latest version of react-native-tvos since 0.69.x brings changes that might not allow everyone to upgrade.