### PR TITLE
Update typescript types to support react-native 0.69

### DIFF
--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -122,4 +122,30 @@ declare module 'react-native' {
   export interface PressableStateCallbackType {
     readonly focused: boolean;
   }
+
+  export interface TouchableWithoutFeedbackPropsIOS {
+    /**
+     * *(Apple TV only)* TV preferred focus (see documentation for the View component).
+     *
+     * @platform ios
+     */
+    hasTVPreferredFocus?: boolean;
+
+    /**
+     * *(Apple TV only)* Object with properties to control Apple TV parallax effects.
+     *
+     * enabled: If true, parallax effects are enabled.  Defaults to true.
+     * shiftDistanceX: Defaults to 2.0.
+     * shiftDistanceY: Defaults to 2.0.
+     * tiltAngle: Defaults to 0.05.
+     * magnification: Defaults to 1.0.
+     * pressMagnification: Defaults to 1.0.
+     * pressDuration: Defaults to 0.3.
+     * pressDelay: Defaults to 0.0.
+     *
+     * @platform ios
+     */
+    tvParallaxProperties?: TVParallaxProperties;
+  }
+
 }


### PR DESCRIPTION
## Summary

Adding back the typescript types `hasTVPreferredFocus` `tvParallaxProperties` that now has been removed from the react-native main repo.
