### PR TITLE
fix: solve TVFocusGuide first render problem

### DIFF
--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -433,16 +433,14 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 }
 
 - (void)addFocusGuide:(NSArray*)destinations {
-  
-  UIView *origin = [self reactSuperview];
-  if (self.focusGuide == nil && origin != nil) {
+  if (self.focusGuide == nil) {
     self.focusGuide = [UIFocusGuide new];
     [self addLayoutGuide:self.focusGuide];
     
-    [self.focusGuide.widthAnchor constraintEqualToAnchor:origin.widthAnchor].active = YES;
-    [self.focusGuide.heightAnchor constraintEqualToAnchor:origin.heightAnchor].active = YES;
-    [self.focusGuide.topAnchor constraintEqualToAnchor:origin.topAnchor].active = YES;
-    [self.focusGuide.leftAnchor constraintEqualToAnchor:origin.leftAnchor].active = YES;
+    [self.focusGuide.widthAnchor constraintEqualToAnchor:self.widthAnchor].active = YES;
+    [self.focusGuide.heightAnchor constraintEqualToAnchor:self.heightAnchor].active = YES;
+    [self.focusGuide.topAnchor constraintEqualToAnchor:self.topAnchor].active = YES;
+    [self.focusGuide.leftAnchor constraintEqualToAnchor:self.leftAnchor].active = YES;
   }
   
   self.focusGuide.preferredFocusEnvironments = destinations;


### PR DESCRIPTION
This PR fixes #204.

## Summary
First of all, it works fine with Fabric because the implementation is different. There are several different problems with Fabric (in particular with TVFocusGuide) which I will create issues and PRs but this is not one of them 😄 

As it's described in the issue, TVFocusGuide doesn't work sometimes, especially on the first renders. If you check `TVFocusGuideExample` in the `RNTester` app, you'll see that it works. So, you might think there's no issue but that's not the reality. The reason is, there's a constant state update going on in that example which covers up the issue by rerendering the app, thus leading to multiple native `_setDestinations` calls which make the example look like it works.

By commenting out [this](https://github.com/react-native-tvos/react-native-tvos/blob/tvos-v0.69.6/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideExample.js#L101) line and adding a simple `useEffect` call to make sure no state update happens more than once, you can easily reproduce the problem.

Something like this:
```ts
React.useEffect(() => {
  setDestination(buttonBottomLeft);
}, []);
```

There's an easier way. though. `TVFocusGuideSafePaddingExample` example doesn't work at all. (Focus should move to Button 3)

https://user-images.githubusercontent.com/22980987/209949710-09b68d63-4831-4b60-bb72-574b9110108f.mov


The problem lies in the `RCTTVView.m` file `addFocusGuide` method. The method is getting called consistently, no problem with that but there's this line:

![Screenshot 2022-12-29 at 11 59 20](https://user-images.githubusercontent.com/22980987/209941866-8dae8200-752b-404d-aa4f-2c6674e63530.png)

`origin` variable is always `nil` on the first render. It can also be **always** empty depending on the case. For example, the `TVFocusGuideSafePaddingExample` example doesn't work no matter what because `origin` is always empty for that case. Since RN Codebase is not super documented, I'm still not sure what is `reactSuperView` and why did we decide to use it in here but I assume it should be the `parent` view. I couldn't think of a case that requires us to use `parent` instead of `self`. Fabric implementation directly uses `self` in this case as well. So, I went for it and changed `origin` with `self`.

## Debugging Process
I removed `_setDestinations` calls in the `TVFocusGuideExample` and added a simple `useEffect` to trigger `setDestination` call only once as I mentioned above. Added a breakpoint in `addFocusGuide` method to debug the issue afterwards. Let's see it in action:

https://user-images.githubusercontent.com/22980987/209936522-7f96dca4-b1fa-4ac2-a93d-1c07cd04c1bc.mov

 As can be seen in the video,  `origin` is `nil` and the example doesn't work because `TVFocusGuide`'s doesn't get added to the elements.
 
 To "simulate" a second render and make things interesting, I trigger a **hot reload** and it starts working:
 
https://user-images.githubusercontent.com/22980987/209949079-39701a70-bab4-4b54-9fb2-814e03c91808.mov

## Test Plan

Don't need anything special. You can tweak the `TVFocusGuideExample.js` file as I described above or can use `TVFocusGuideSafePaddingExample.js` to see if it works. Here's how both work after the fix:

https://user-images.githubusercontent.com/22980987/209949491-d2381efe-f487-4054-8e93-a38fc9bfa9ea.mov

Focus may seem lost to you but this is due to the current styling issue of the "TVFocusGuideSafePaddingExample" example 😄 When focus moves to "Button 3" there's no focus style for it.

Sorry, screen recordings can seem a bit rushed but tried to keep them below 10mb limit of Github. Had to be fast 😄 I hope they're helpful!

