### PR TITLE
fix: make sure UIFocusGuide is only applied when necessary

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -71,8 +71,6 @@ using namespace facebook::react;
     _tvParallaxProperties.pressMagnification = 1.0f;
     _tvParallaxProperties.pressDuration = 0.3f;
     _tvParallaxProperties.pressDelay = 0.0f;
-    self.focusGuide = [UIFocusGuide new];
-    [self addLayoutGuide:self.focusGuide];
 #else
     self.multipleTouchEnabled = YES;
 #endif
@@ -134,7 +132,16 @@ using namespace facebook::react;
 }
 
 - (void)addFocusDestinations:(NSArray*)destinations {
-  
+  if (self.focusGuide == nil) {
+    self.focusGuide = [UIFocusGuide new];
+    [self addLayoutGuide:self.focusGuide];
+
+    [self.focusGuide.topAnchor constraintEqualToAnchor:self.topAnchor].active = YES;
+    [self.focusGuide.bottomAnchor constraintEqualToAnchor:self.bottomAnchor].active = YES;
+    [self.focusGuide.widthAnchor constraintEqualToAnchor:self.widthAnchor].active = YES;
+    [self.focusGuide.heightAnchor constraintEqualToAnchor:self.heightAnchor].active = YES;
+  }
+
   self.focusGuide.preferredFocusEnvironments = destinations;
 }
 
@@ -856,11 +863,6 @@ using namespace facebook::react;
   }
   
 #if TARGET_OS_TV
-  [self.focusGuide.topAnchor constraintEqualToAnchor:self.topAnchor].active = YES;
-  [self.focusGuide.bottomAnchor constraintEqualToAnchor:self.bottomAnchor].active = YES;
-  [self.focusGuide.widthAnchor constraintEqualToAnchor:self.widthAnchor].active = YES;
-  [self.focusGuide.heightAnchor constraintEqualToAnchor:self.heightAnchor].active = YES;
-  
   if (_hasTVPreferredFocus) {
     RCTRootComponentView *rootview = [self containingRootView];
     if (rootview != nil && rootview.reactPreferredFocusedView != self) {


### PR DESCRIPTION
This PR fixes #421 and fixes #422.
## Summary

As it is described in #421, every element was getting `UIFocusGuide` attached to it unnecessarily. It was due to the `UIFocusGuide` creation in `initWithFrame` method without any checks. I moved the `UIFocusGuide` creation to `addFocusDestinations` to fix the issue.

The second issue was constant `UIFocusGuide` constraints growth as it is described in #422. The reason was setting constraints in `updateLayoutMetrics` which gets called very often. It was leading to unnecessary constraint definitions. Moved that section to `addFocusDestinations` method as well to fix it.

Here's before (doesn't show the constraints in this SS but you can check #422):

![Screenshot 2022-12-29 at 13 40 35](https://user-images.githubusercontent.com/22980987/209963201-786f929f-19d4-4ed8-aa6d-7845ff4e714b.png)

Here's after the fix (even after a couple fast refreshes):

![Screenshot 2022-12-29 at 14 14 17](https://user-images.githubusercontent.com/22980987/209963227-71e6f438-66eb-4f4c-9691-1bc1cc8686ae.png)

## Test Plan

- Build the `RNTester` app (Fabric enabled)
- Navigate to `TVFocusGuideExample`
- Check if only the element that uses `TVFocusGuide` on the JS side has `TVFocusGuide` attached to them on the native side.
- Pick an element with `TVFocusGuide` attached to it as a reference point
- Check the `TVFocusGuide` constraints
- Trigger fast refresh a couple of times
- See if constraints grow