### PR TITLE
fix: [Android TV] Text should not be accessible by default 

### DIFF
--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -15,6 +15,7 @@ import processColor from '../StyleSheet/processColor';
 import TextAncestor from './TextAncestor';
 import {NativeText, NativeVirtualText} from './TextNativeComponent';
 import {type TextProps} from './TextProps';
+import Platform from '../Utilities/Platform';
 import * as React from 'react';
 import {useContext, useMemo, useState} from 'react';
 
@@ -185,7 +186,7 @@ const Text: React.AbstractComponent<
         {...restProps}
         {...eventHandlersForText}
         disabled={_disabled}
-        accessible={accessible !== false}
+        accessible={Platform.isTV ? accessible === true : accessible !== false}
         accessibilityState={_accessibilityState}
         allowFontScaling={allowFontScaling !== false}
         ellipsizeMode={ellipsizeMode ?? 'tail'}

--- a/Libraries/Text/Text.js
+++ b/Libraries/Text/Text.js
@@ -186,7 +186,11 @@ const Text: React.AbstractComponent<
         {...restProps}
         {...eventHandlersForText}
         disabled={_disabled}
-        accessible={Platform.isTV ? accessible === true : accessible !== false}
+        accessible={
+          Platform.isTV && Platform.OS === 'android'
+            ? accessible === true
+            : accessible !== false
+        }
         accessibilityState={_accessibilityState}
         allowFontScaling={allowFontScaling !== false}
         ellipsizeMode={ellipsizeMode ?? 'tail'}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Recent changes in the `Text` component make it accessible and pressable by default. On Android TV, this has the side effect of making it focusable. Only controls (`Touchable`, `Pressable`, `TextInput`, etc.) should be focusable.

Fixed by changing `Text.js` so that a `Text` component must explicitly have `accessible={true}` in order to be pressable or focusable on TV platforms.

Fixes #389 .

## Test Plan

Tested with the `TVInputDemo` test app, and `RNTester`.
