### PR TITLE
feat: make TVFocusGuide work reliably without safePadding

### DIFF
--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -97,7 +97,9 @@ const FocusGuideViewTVOS = (props: TVFocusGuideViewProps) => {
       Commands.setDestinations(hostComponentRef, nativeDestinations);
   }, [props.destinations]);
 
-  return <ReactNative.View ref={focusGuideRef} {...props} />;
+  return (
+    <ReactNative.View ref={focusGuideRef} {...props} collapsable={false} />
+  );
 };
 
 const FocusGuideViewAndroidTV = (props: TVFocusGuideViewProps) => {

--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -23,7 +23,7 @@ type TVFocusGuideViewProps = $ReadOnly<{
    * Useful for absolute focus guides without children
    * Defaults to true
    */
-  enabled: ?Boolean,
+  enabled?: boolean,
 
   /**
    * The views the focus should go to
@@ -31,7 +31,7 @@ type TVFocusGuideViewProps = $ReadOnly<{
   destinations: ?(Object[]),
 
   /**
-   * How the TVFocusGuideView content safe padding should be applied. "null" to disable it.
+   * @deprecated Don't use it, no longer necessary.
    */
   safePadding?: 'vertical' | 'horizontal' | 'both' | null,
 }>;
@@ -39,48 +39,20 @@ type TVFocusGuideViewProps = $ReadOnly<{
 const TVFocusGuideView = ({
   enabled = true,
   safePadding,
-  style,
-  ...otherProps
+  ...props
 }: TVFocusGuideViewProps): React.Node => {
-  const paddingChoice = safePadding === undefined ? 'both' : safePadding;
-  const focusGuidePadding =
-    paddingChoice === 'both'
-      ? {padding: 1}
-      : paddingChoice === 'vertical'
-      ? {paddingVertical: 1}
-      : paddingChoice === 'horizontal'
-      ? {paddingHorizontal: 1}
-      : null;
-
   const enabledStyle = {display: enabled ? 'flex' : 'none'};
+  const style = [styles.container, props.style, enabledStyle];
 
-  /**
-   * The client specified layout(using 'style' prop) should be applied the container view ReactNative.View.
-   * And the focusGuide's layout should be overridden to wrap it fully inside the container view.
-   * For example, if the client specifies 'marginLeft' property in the style prop,
-   * then the TVFocusGuideView will apply the 'marginLeft' for both the parentView and the focusGuideView.
-   * and so, the left margin is getting added twice and UI becomes incorrect.
-   * The same is applicable for other layout properties.
-   */
-  const focusGuideStyle = [focusGuidePadding, style, styles.focusGuide];
+  if (Platform.isTVOS) {
+    return <FocusGuideViewTVOS {...props} style={style} />;
+  }
 
-  return (
-    /**
-     * The container needs to have at least a width of 1 and a height of 1.
-     * Also, being the container, it shouldn't be possible to give it some padding.
-     */
-    <ReactNative.View style={[style, styles.container, enabledStyle]}>
-      {Platform.isTV ? (
-        Platform.isTVOS ? (
-          <FocusGuideViewTVOS {...otherProps} style={focusGuideStyle} />
-        ) : (
-          <FocusGuideViewAndroidTV {...otherProps} style={focusGuideStyle} />
-        )
-      ) : (
-        otherProps.children
-      )}
-    </ReactNative.View>
-  );
+  if (Platform.isTV) {
+    return <FocusGuideViewAndroidTV {...props} style={style} />;
+  }
+
+  return <ReactNative.View {...props} style={style} />;
 };
 
 const FocusGuideViewTVOS = (props: TVFocusGuideViewProps) => {
@@ -124,22 +96,6 @@ const styles = ReactNative.StyleSheet.create({
   container: {
     minWidth: 1,
     minHeight: 1,
-    paddingTop: 0,
-    paddingBottom: 0,
-    paddingLeft: 0,
-    paddingRight: 0,
-  },
-  focusGuide: {
-    position: 'relative',
-    opacity: 1,
-    left: 0,
-    top: 0,
-    right: 0,
-    bottom: 0,
-    marginLeft: 0,
-    marginTop: 0,
-    marginRight: 0,
-    marginBottom: 0,
   },
 });
 

--- a/README.md
+++ b/README.md
@@ -206,8 +206,7 @@ class Game2048 extends React.Component {
 
 | Prop | Value | Description | 
 |---|---|---|
-| destinations | any[] | Array of `Component`s to register as destinations of the FocusGuideView | 
-| safePadding | 'both' (default) \| 'vertical' \| 'horizontal' \| null | When the FocusGuide children are exactly the same size as the FocusGuide's container, the focus will almost certainly be given directly to the children without going through the FocusGuide. This prop make sure it doesn't happen by adding a padding of 1 in all directions.<br />"null" to disable it. |
+| destinations | any[] | Array of `Component`s to register as destinations of the FocusGuideView |
 
 - _Next Focus Direction_: the props `nextFocus*` on `View` should work as expected on iOS too (previously android only). One caveat is that if there is no focusable in the `nextFocusable*` direction next to the starting view, iOS doesn't check if we want to override the destination. 
 

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1,23 +1,16 @@
 PODS:
   - boost (1.76.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.69.5-1)
-  - FBReactNativeSpec (0.69.5-1):
+  - FBLazyVector (0.69.6-0)
+  - FBReactNativeSpec (0.69.6-0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-Core (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-Core (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
   - fmt (7.1.3)
   - glog (0.3.5)
-  - MyNativeView (0.0.1):
-    - RCTRequired
-    - RCTTypeSafety
-    - React
-    - React-Codegen
-    - React-RCTFabric
-    - ReactCommon/turbomodule/core
   - RCT-Folly (2021.06.28.00-v2):
     - boost
     - DoubleConversion
@@ -34,599 +27,599 @@ PODS:
     - DoubleConversion
     - fmt
     - glog
-  - RCTRequired (0.69.5-1)
-  - RCTTypeSafety (0.69.5-1):
-    - FBLazyVector (= 0.69.5-1)
-    - RCTRequired (= 0.69.5-1)
-    - React-Core (= 0.69.5-1)
-  - React (0.69.5-1):
-    - React-Core (= 0.69.5-1)
-    - React-Core/DevSupport (= 0.69.5-1)
-    - React-Core/RCTWebSocket (= 0.69.5-1)
-    - React-RCTAnimation (= 0.69.5-1)
-    - React-RCTBlob (= 0.69.5-1)
-    - React-RCTImage (= 0.69.5-1)
-    - React-RCTLinking (= 0.69.5-1)
-    - React-RCTNetwork (= 0.69.5-1)
-    - React-RCTSettings (= 0.69.5-1)
-    - React-RCTText (= 0.69.5-1)
-  - React-bridging (0.69.5-1):
+  - RCTRequired (0.69.6-0)
+  - RCTTypeSafety (0.69.6-0):
+    - FBLazyVector (= 0.69.6-0)
+    - RCTRequired (= 0.69.6-0)
+    - React-Core (= 0.69.6-0)
+  - React (0.69.6-0):
+    - React-Core (= 0.69.6-0)
+    - React-Core/DevSupport (= 0.69.6-0)
+    - React-Core/RCTWebSocket (= 0.69.6-0)
+    - React-RCTAnimation (= 0.69.6-0)
+    - React-RCTBlob (= 0.69.6-0)
+    - React-RCTImage (= 0.69.6-0)
+    - React-RCTLinking (= 0.69.6-0)
+    - React-RCTNetwork (= 0.69.6-0)
+    - React-RCTSettings (= 0.69.6-0)
+    - React-RCTText (= 0.69.6-0)
+  - React-bridging (0.69.6-0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi (= 0.69.5-1)
-  - React-callinvoker (0.69.5-1)
-  - React-Codegen (0.69.5-1):
-    - FBReactNativeSpec (= 0.69.5-1)
+    - React-jsi (= 0.69.6-0)
+  - React-callinvoker (0.69.6-0)
+  - React-Codegen (0.69.6-0):
+    - FBReactNativeSpec (= 0.69.6-0)
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-Core (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-rncore (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Core (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-Core (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-rncore (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Core (0.69.6-0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.5-1)
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
+    - React-Core/Default (= 0.69.6-0)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.69.5-1):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
-    - Yoga
-  - React-Core/Default (0.69.5-1):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
-    - Yoga
-  - React-Core/DevSupport (0.69.5-1):
-    - glog
-    - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.5-1)
-    - React-Core/RCTWebSocket (= 0.69.5-1)
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-jsinspector (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
-    - Yoga
-  - React-Core/RCTAnimationHeaders (0.69.5-1):
+  - React-Core/CoreModulesHeaders (0.69.6-0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.69.5-1):
+  - React-Core/Default (0.69.6-0):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
+    - Yoga
+  - React-Core/DevSupport (0.69.6-0):
+    - glog
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - React-Core/Default (= 0.69.6-0)
+    - React-Core/RCTWebSocket (= 0.69.6-0)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-jsinspector (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
+    - Yoga
+  - React-Core/RCTAnimationHeaders (0.69.6-0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.69.5-1):
+  - React-Core/RCTBlobHeaders (0.69.6-0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.69.5-1):
+  - React-Core/RCTImageHeaders (0.69.6-0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.69.5-1):
+  - React-Core/RCTLinkingHeaders (0.69.6-0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.69.5-1):
+  - React-Core/RCTNetworkHeaders (0.69.6-0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.69.5-1):
+  - React-Core/RCTPushNotificationHeaders (0.69.6-0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.69.5-1):
+  - React-Core/RCTSettingsHeaders (0.69.6-0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core/Default
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
     - Yoga
-  - React-Core/RCTWebSocket (0.69.5-1):
+  - React-Core/RCTTextHeaders (0.69.6-0):
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.5-1)
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
+    - React-Core/Default
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
     - Yoga
-  - React-CoreModules (0.69.5-1):
+  - React-Core/RCTWebSocket (0.69.6-0):
+    - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-Codegen (= 0.69.5-1)
-    - React-Core/CoreModulesHeaders (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-RCTImage (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-cxxreact (0.69.5-1):
+    - React-Core/Default (= 0.69.6-0)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
+    - Yoga
+  - React-CoreModules (0.69.6-0):
+    - RCT-Folly (= 2021.06.28.00-v2)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-Codegen (= 0.69.6-0)
+    - React-Core/CoreModulesHeaders (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-RCTImage (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-cxxreact (0.69.6-0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-callinvoker (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsinspector (= 0.69.5-1)
-    - React-logger (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
-    - React-runtimeexecutor (= 0.69.5-1)
-  - React-Fabric (0.69.5-1):
+    - React-callinvoker (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsinspector (= 0.69.6-0)
+    - React-logger (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
+    - React-runtimeexecutor (= 0.69.6-0)
+  - React-Fabric (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-Fabric/animations (= 0.69.5-1)
-    - React-Fabric/attributedstring (= 0.69.5-1)
-    - React-Fabric/butter (= 0.69.5-1)
-    - React-Fabric/componentregistry (= 0.69.5-1)
-    - React-Fabric/componentregistrynative (= 0.69.5-1)
-    - React-Fabric/components (= 0.69.5-1)
-    - React-Fabric/config (= 0.69.5-1)
-    - React-Fabric/core (= 0.69.5-1)
-    - React-Fabric/debug_core (= 0.69.5-1)
-    - React-Fabric/debug_renderer (= 0.69.5-1)
-    - React-Fabric/imagemanager (= 0.69.5-1)
-    - React-Fabric/leakchecker (= 0.69.5-1)
-    - React-Fabric/mounting (= 0.69.5-1)
-    - React-Fabric/runtimescheduler (= 0.69.5-1)
-    - React-Fabric/scheduler (= 0.69.5-1)
-    - React-Fabric/telemetry (= 0.69.5-1)
-    - React-Fabric/templateprocessor (= 0.69.5-1)
-    - React-Fabric/textlayoutmanager (= 0.69.5-1)
-    - React-Fabric/uimanager (= 0.69.5-1)
-    - React-Fabric/utils (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/animations (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-Fabric/animations (= 0.69.6-0)
+    - React-Fabric/attributedstring (= 0.69.6-0)
+    - React-Fabric/butter (= 0.69.6-0)
+    - React-Fabric/componentregistry (= 0.69.6-0)
+    - React-Fabric/componentregistrynative (= 0.69.6-0)
+    - React-Fabric/components (= 0.69.6-0)
+    - React-Fabric/config (= 0.69.6-0)
+    - React-Fabric/core (= 0.69.6-0)
+    - React-Fabric/debug_core (= 0.69.6-0)
+    - React-Fabric/debug_renderer (= 0.69.6-0)
+    - React-Fabric/imagemanager (= 0.69.6-0)
+    - React-Fabric/leakchecker (= 0.69.6-0)
+    - React-Fabric/mounting (= 0.69.6-0)
+    - React-Fabric/runtimescheduler (= 0.69.6-0)
+    - React-Fabric/scheduler (= 0.69.6-0)
+    - React-Fabric/telemetry (= 0.69.6-0)
+    - React-Fabric/templateprocessor (= 0.69.6-0)
+    - React-Fabric/textlayoutmanager (= 0.69.6-0)
+    - React-Fabric/uimanager (= 0.69.6-0)
+    - React-Fabric/utils (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/animations (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/attributedstring (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/attributedstring (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/butter (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/butter (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/componentregistry (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/componentregistry (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/componentregistrynative (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/componentregistrynative (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-Fabric/components/activityindicator (= 0.69.5-1)
-    - React-Fabric/components/image (= 0.69.5-1)
-    - React-Fabric/components/inputaccessory (= 0.69.5-1)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.69.5-1)
-    - React-Fabric/components/modal (= 0.69.5-1)
-    - React-Fabric/components/root (= 0.69.5-1)
-    - React-Fabric/components/safeareaview (= 0.69.5-1)
-    - React-Fabric/components/scrollview (= 0.69.5-1)
-    - React-Fabric/components/slider (= 0.69.5-1)
-    - React-Fabric/components/text (= 0.69.5-1)
-    - React-Fabric/components/textinput (= 0.69.5-1)
-    - React-Fabric/components/unimplementedview (= 0.69.5-1)
-    - React-Fabric/components/view (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/activityindicator (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-Fabric/components/activityindicator (= 0.69.6-0)
+    - React-Fabric/components/image (= 0.69.6-0)
+    - React-Fabric/components/inputaccessory (= 0.69.6-0)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.69.6-0)
+    - React-Fabric/components/modal (= 0.69.6-0)
+    - React-Fabric/components/root (= 0.69.6-0)
+    - React-Fabric/components/safeareaview (= 0.69.6-0)
+    - React-Fabric/components/scrollview (= 0.69.6-0)
+    - React-Fabric/components/slider (= 0.69.6-0)
+    - React-Fabric/components/text (= 0.69.6-0)
+    - React-Fabric/components/textinput (= 0.69.6-0)
+    - React-Fabric/components/unimplementedview (= 0.69.6-0)
+    - React-Fabric/components/view (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/activityindicator (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/image (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/image (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/inputaccessory (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/inputaccessory (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/legacyviewmanagerinterop (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/legacyviewmanagerinterop (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/modal (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/modal (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/root (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/root (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/safeareaview (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/safeareaview (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/scrollview (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/scrollview (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/slider (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/slider (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/text (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/text (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/textinput (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/textinput (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/unimplementedview (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/unimplementedview (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/components/view (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/components/view (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
     - Yoga
-  - React-Fabric/config (0.69.5-1):
+  - React-Fabric/config (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/core (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/core (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/debug_core (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/debug_core (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/debug_renderer (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/debug_renderer (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/imagemanager (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/imagemanager (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - React-RCTImage (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/leakchecker (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - React-RCTImage (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/leakchecker (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/mounting (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/mounting (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/runtimescheduler (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/runtimescheduler (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/scheduler (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/scheduler (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/telemetry (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/telemetry (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/templateprocessor (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/templateprocessor (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/textlayoutmanager (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/textlayoutmanager (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
     - React-Fabric/uimanager
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/uimanager (0.69.5-1):
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/uimanager (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-Fabric/utils (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-Fabric/utils (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - RCTRequired (= 0.69.5-1)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-graphics (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-jsiexecutor (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-graphics (0.69.5-1):
+    - RCTRequired (= 0.69.6-0)
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-graphics (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-jsiexecutor (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-graphics (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - React-Core/Default (= 0.69.5-1)
-  - React-jsi (0.69.5-1):
+    - React-Core/Default (= 0.69.6-0)
+  - React-jsi (0.69.6-0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-jsi/Default (= 0.69.5-1)
-  - React-jsi/Default (0.69.5-1):
+    - React-jsi/Default (= 0.69.6-0)
+  - React-jsi/Default (0.69.6-0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsi/Fabric (0.69.5-1):
+  - React-jsi/Fabric (0.69.6-0):
     - boost (= 1.76.0)
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-  - React-jsiexecutor (0.69.5-1):
+  - React-jsiexecutor (0.69.6-0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
-  - React-jsinspector (0.69.5-1)
-  - React-logger (0.69.5-1):
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
+  - React-jsinspector (0.69.6-0)
+  - React-logger (0.69.6-0):
     - glog
-  - React-perflogger (0.69.5-1)
-  - React-RCTAnimation (0.69.5-1):
+  - React-perflogger (0.69.6-0)
+  - React-RCTAnimation (0.69.6-0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-Codegen (= 0.69.5-1)
-    - React-Core/RCTAnimationHeaders (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-RCTBlob (0.69.5-1):
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-Codegen (= 0.69.6-0)
+    - React-Core/RCTAnimationHeaders (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-RCTBlob (0.69.6-0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Codegen (= 0.69.5-1)
-    - React-Core/RCTBlobHeaders (= 0.69.5-1)
-    - React-Core/RCTWebSocket (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-RCTNetwork (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-RCTFabric (0.69.5-1):
+    - React-Codegen (= 0.69.6-0)
+    - React-Core/RCTBlobHeaders (= 0.69.6-0)
+    - React-Core/RCTWebSocket (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-RCTNetwork (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-RCTFabric (0.69.6-0):
     - RCT-Folly/Fabric (= 2021.06.28.00-v2)
-    - React-Core (= 0.69.5-1)
-    - React-Fabric (= 0.69.5-1)
-    - React-RCTImage (= 0.69.5-1)
-  - React-RCTImage (0.69.5-1):
+    - React-Core (= 0.69.6-0)
+    - React-Fabric (= 0.69.6-0)
+    - React-RCTImage (= 0.69.6-0)
+  - React-RCTImage (0.69.6-0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-Codegen (= 0.69.5-1)
-    - React-Core/RCTImageHeaders (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-RCTNetwork (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-RCTLinking (0.69.5-1):
-    - React-Codegen (= 0.69.5-1)
-    - React-Core/RCTLinkingHeaders (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-RCTNetwork (0.69.5-1):
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-Codegen (= 0.69.6-0)
+    - React-Core/RCTImageHeaders (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-RCTNetwork (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-RCTLinking (0.69.6-0):
+    - React-Codegen (= 0.69.6-0)
+    - React-Core/RCTLinkingHeaders (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-RCTNetwork (0.69.6-0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-Codegen (= 0.69.5-1)
-    - React-Core/RCTNetworkHeaders (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-RCTPushNotification (0.69.5-1):
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-Codegen (= 0.69.5-1)
-    - React-Core/RCTPushNotificationHeaders (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-RCTSettings (0.69.5-1):
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-Codegen (= 0.69.6-0)
+    - React-Core/RCTNetworkHeaders (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-RCTPushNotification (0.69.6-0):
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-Codegen (= 0.69.6-0)
+    - React-Core/RCTPushNotificationHeaders (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-RCTSettings (0.69.6-0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - RCTTypeSafety (= 0.69.5-1)
-    - React-Codegen (= 0.69.5-1)
-    - React-Core/RCTSettingsHeaders (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-RCTTest (0.69.5-1):
+    - RCTTypeSafety (= 0.69.6-0)
+    - React-Codegen (= 0.69.6-0)
+    - React-Core/RCTSettingsHeaders (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-RCTTest (0.69.6-0):
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-Core (= 0.69.5-1)
-    - React-CoreModules (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
-  - React-RCTText (0.69.5-1):
-    - React-Core/RCTTextHeaders (= 0.69.5-1)
-  - React-rncore (0.69.5-1)
-  - React-runtimeexecutor (0.69.5-1):
-    - React-jsi (= 0.69.5-1)
-  - ReactCommon/turbomodule/core (0.69.5-1):
+    - React-Core (= 0.69.6-0)
+    - React-CoreModules (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
+  - React-RCTText (0.69.6-0):
+    - React-Core/RCTTextHeaders (= 0.69.6-0)
+  - React-rncore (0.69.6-0)
+  - React-runtimeexecutor (0.69.6-0):
+    - React-jsi (= 0.69.6-0)
+  - ReactCommon/turbomodule/core (0.69.6-0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-bridging (= 0.69.5-1)
-    - React-callinvoker (= 0.69.5-1)
-    - React-Core (= 0.69.5-1)
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-logger (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
-  - ReactCommon/turbomodule/samples (0.69.5-1):
+    - React-bridging (= 0.69.6-0)
+    - React-callinvoker (= 0.69.6-0)
+    - React-Core (= 0.69.6-0)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-logger (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
+  - ReactCommon/turbomodule/samples (0.69.6-0):
     - DoubleConversion
     - glog
     - RCT-Folly (= 2021.06.28.00-v2)
-    - React-bridging (= 0.69.5-1)
-    - React-callinvoker (= 0.69.5-1)
-    - React-Core (= 0.69.5-1)
-    - React-cxxreact (= 0.69.5-1)
-    - React-jsi (= 0.69.5-1)
-    - React-logger (= 0.69.5-1)
-    - React-perflogger (= 0.69.5-1)
-    - ReactCommon/turbomodule/core (= 0.69.5-1)
+    - React-bridging (= 0.69.6-0)
+    - React-callinvoker (= 0.69.6-0)
+    - React-Core (= 0.69.6-0)
+    - React-cxxreact (= 0.69.6-0)
+    - React-jsi (= 0.69.6-0)
+    - React-logger (= 0.69.6-0)
+    - React-perflogger (= 0.69.6-0)
+    - ReactCommon/turbomodule/core (= 0.69.6-0)
   - ScreenshotManager (0.0.1):
     - RCT-Folly (= 2021.06.28.00-v2)
     - React-Core
@@ -639,7 +632,6 @@ DEPENDENCIES:
   - FBReactNativeSpec (from `../../React/FBReactNativeSpec`)
   - fmt (from `../../third-party-podspecs/fmt.podspec`)
   - glog (from `../../third-party-podspecs/glog.podspec`)
-  - MyNativeView (from `NativeComponentExample`)
   - RCT-Folly (from `../../third-party-podspecs/RCT-Folly.podspec`)
   - RCT-Folly/Fabric (from `../../third-party-podspecs/RCT-Folly.podspec`)
   - RCTRequired (from `../../Libraries/RCTRequired`)
@@ -690,8 +682,6 @@ EXTERNAL SOURCES:
     :podspec: "../../third-party-podspecs/fmt.podspec"
   glog:
     :podspec: "../../third-party-podspecs/glog.podspec"
-  MyNativeView:
-    :path: NativeComponentExample
   RCT-Folly:
     :podspec: "../../third-party-podspecs/RCT-Folly.podspec"
   RCTRequired:
@@ -760,43 +750,42 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: a7c83b31436843459a1961bfd74b96033dc77234
   DoubleConversion: 234abba95e31cc2aada0cf3b97cdb11bc5b90575
-  FBLazyVector: cf2226a59bd5f29987ed9c2fbd62ec5112543387
-  FBReactNativeSpec: 544af4c4c91487b291cf41bfb034e77abc26fa70
+  FBLazyVector: 5737ec10d2e047746161495adda7b58ddb8de320
+  FBReactNativeSpec: ef392d6c42af7942537167e5f93bd173785e7a93
   fmt: 135c0c55547979f715b56dfa54037ececa96d07a
   glog: bac6d5aa2990176cc22d0432fb3e28805d580aeb
-  MyNativeView: 412ff641161c6577d85641afa32d5f4f8014a816
   RCT-Folly: 6955e7728b76277c5df5a5aba37ee1ff1dd99976
-  RCTRequired: 76b573e31346da1e334dd0487c348e74ac40b88a
-  RCTTypeSafety: ff0f11e7d97e52643538879d067bdf2a9537e145
-  React: 8a40b14d0de2324f4a5365cd2de6a665c648891f
-  React-bridging: 2ca1fc94d59b576add06bc03561f9de03b68d674
-  React-callinvoker: a0e344ca0581f2671074faf68766cf7c1177b785
-  React-Codegen: 5317fb771b733beb9229135d11b6889d2d5d911a
-  React-Core: 143c2b03427e5a4878d8196c46c7e0d32e0739ef
-  React-CoreModules: 41295c7631e9d8a119a5473302a6f7b720b5e810
-  React-cxxreact: 83dd23aaa6640b91e0b5662d4ba7e30d6c2d741a
-  React-Fabric: bb73757ce6b1ac80b9a4558dd56768ff0b11bfab
-  React-graphics: 3b89de65ba701f53f86bfb8d6d043c65d0c6a0dc
-  React-jsi: 48ecb0a56f720841cd05e3b88caf8e1ecf770d98
-  React-jsiexecutor: cf32144953409add9db141dd22644328e5f2c85c
-  React-jsinspector: 3998ac8a185c9532c8fffe2a8d3d7da01de7687b
-  React-logger: 95d754cbf6b9dace8462da1d85a174f29befe5b4
-  React-perflogger: 9edb49fc0f012d492bb128b31f0beb06431d867c
-  React-RCTAnimation: ff6ab987eb1fe61d79e7adc402690fe5e031e8c9
-  React-RCTBlob: 89297497b5961947fba2ca1f0dfa358a6a9133b5
-  React-RCTFabric: fba9bef4abe2168d1697108405419e16551cffb0
-  React-RCTImage: 2afe2db0c74b277281fc06cb3f5b8816654be763
-  React-RCTLinking: 9333b0b5160e8cbf4078d1ab4431a4d7ddb28da7
-  React-RCTNetwork: 1e1ab69e72d30213c534950c3a4de02cd2cfb27f
-  React-RCTPushNotification: f1b8f767f98789e2ab5a6c7c2f1875f22731158d
-  React-RCTSettings: 55887e99cd8d6803d35989be48175db447e947d5
-  React-RCTTest: d8586fa5c018aab4ec64bb620d54e4bae1c6ee41
-  React-RCTText: ce385d6b39a3fa8686148c514fa7cb779bfab59d
-  React-rncore: 04b3cb20e0a36a23674a20fe7a02d00ec127901a
-  React-runtimeexecutor: 58beb7dde327da781655006911f3531df4b17c29
-  ReactCommon: 76b6f7f3035c18aa0b2b25104063a9e06bdd63fd
-  ScreenshotManager: 3ad89d9fe639c27464079c987688a4a6ed7a559c
-  Yoga: c692258673d0f081496bb4c5013a44c80b5ed237
+  RCTRequired: 82b208c729a054f3b9d294c37bbd8f1f361bf8ba
+  RCTTypeSafety: 0f7cf75cfd0a07a9cae83d3b7d084a930a18213a
+  React: cf8e13ea1cf8687a52a2852b210deb86983e36d1
+  React-bridging: 56b9397d2b33b9f978663d3c6ca151b7a93464da
+  React-callinvoker: e559fced3af63331390158dcc41e6da1a00390aa
+  React-Codegen: 5647e344500561e5e5ead30e459c3220ccc8fa14
+  React-Core: b949b03929848eef2f775ec5000e6f7d82c12b8f
+  React-CoreModules: 9f346f172266d32d0aff443636ce18d3d2671176
+  React-cxxreact: 6977285d1f632ebd9c13362c43a3d26acd5a1dc3
+  React-Fabric: 46828641af86a6ffb0f5c74a0dc5a8686d55a2d4
+  React-graphics: f37a141845c8248b84d38b48f07540f130d2de58
+  React-jsi: 390efe5b29860fd619ba16400a95585949a872cd
+  React-jsiexecutor: 2e58a8faffdd27294d98fdde643ddbc1c6ed33b4
+  React-jsinspector: 68d1645356b5b387d9e4afbe6a42a3c22965be7d
+  React-logger: 3df6481eff39de103fbc963cf9355332697264a4
+  React-perflogger: b4286f50e775f757b356ed77d993e70ab4041c6e
+  React-RCTAnimation: dbf81b8d90128de2413ba659269bcc2d104d7794
+  React-RCTBlob: 5384bf7d73e16b1c61324e58991236bd1bbd569e
+  React-RCTFabric: b479e636c9dd8bd4c8a8d4f1e8df1e2a765c7127
+  React-RCTImage: 16c1f05aa04f4d3113c29d82ecdcf56843c8c36d
+  React-RCTLinking: 82278cb035c25202fad526e8507c1f8ae72da0d2
+  React-RCTNetwork: 0e6d598d7bf9dcb77147cbb4e4d5e6f8d17e4a66
+  React-RCTPushNotification: bb1eaa0f2a89a38a02e98ff67e022cd8be1fef5e
+  React-RCTSettings: 47ac3b445c147788b2fbf33b5e3b0e9bae369fda
+  React-RCTTest: 538356388acefb8966b85548e787fb52d2977bf2
+  React-RCTText: daf7703b2dffeff0dd260dce6c6e81deae5fbf82
+  React-rncore: c41110e55c7ec61dfb495a55ad84f3592ed6c634
+  React-runtimeexecutor: c32935cd32852438f6a0c8a984586cc2f619e654
+  ReactCommon: efbc13574c4423e34eed0f2b9b23816e6f315b8e
+  ScreenshotManager: 2cece1df548810a0122fcc271d1b06f82d0cab8b
+  Yoga: 2657fb10c2eafe6baab96befd7c517d28af46500
 
 PODFILE CHECKSUM: 74642a8f3fda1d9268ac3dbeccfc5f2573ebd386
 

--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -74,7 +74,7 @@ declare module 'react-native' {
      */
     destinations?: (null | number | React.Component<any, any> | React.ComponentClass<any>)[];
     /**
-     * How the TVFocusGuideView content safe padding should be applied. "null" to disable it.
+     * @deprecated Don't use it, no longer necessary.
      */
     safePadding?: 'both' | 'vertical' | 'horizontal' | null;
   }


### PR DESCRIPTION
## Summary
Whenever I saw `safePaddings` approach, I thought "okay, this is a good workaround but the focus engine should be deterministic and shouldn't require this sort of workaround". Started digging to get rid of `safePaddings` necessity and found that it is fairly simple and the focus engine indeed works as expected if we prepare the layout in a way that it can do its job.

Here's how it works without the changes in this PR:

<table>
  <tr>
    <th>OLD ARCH</th>
    <th>FABRIC</th>
  </tr>
  <tr>
    <td>
    
https://user-images.githubusercontent.com/22980987/210111757-98a19aa3-5c33-4b8e-84ee-a85b4edcddd7.mov
</td>
        <td>
        
https://user-images.githubusercontent.com/22980987/210110060-80a31215-9fbe-4514-a85e-e0d6cc75ea1c.mov
</td>
  </tr>
</table>

This is `TVFocusGuideSafePaddingExample`. The expected behavior is simple. Button 2, 3, 4, and 5 are wrapped with `TVFocusGuide` for every row which redirects the focus to `Button 3`. If the focus moves toward that container, it should always be favored before its children (Button 2, 3, 4, 5) and redirect the focus to `Button 3`.

On my tests I couldn't find any problem with the old arch, it works perfectly fine already. But, if you check the Fabric screen recording, you'll see that it doesn't work as expected when `safePadding` is not provided.

I'd -intuitively- always expect tvOS focus engine (or any other focus engine, to be honest) to favor the container view before its children **if the focus is coming outside the container**. The problem is exactly this. With Fabric, iOS has `view flattening` built-in which flattens the UI tree as much as possible. So, *the children* are not really children in the native UI tree and in fact, because they are rendered later, the children views most likely gains priority over the "parent" container.

Here's how UI trees look like:

| OLD ARCH | FABRIC |
|---|---|
| ![Screenshot 2022-12-30 at 23 05 19](https://user-images.githubusercontent.com/22980987/210114668-44c4664f-78ec-42a2-b71f-7702dd41c018.png) | ![Screenshot 2022-12-30 at 19 47 12](https://user-images.githubusercontent.com/22980987/210114733-8b231774-c53f-4c56-9d53-27b7ef6f8a65.png) |

Everything is nested on the old arch since there's no view flattening but it's the complete opposite on Fabric and the tree is *very* "flat" 😄 tvOS can't figure out the right thing to do in this case.

## Solution
I set `collapsable` prop to false to prevent view flattening for `TVFocusGuide` view components and keep the parent-child relationship intact to fix the problem.

Here's how UI tree look like with the patch:

![Screenshot 2022-12-30 at 20 54 49](https://user-images.githubusercontent.com/22980987/210115054-cfec78f8-a300-43d8-84ac-c4d6a5ae5ce7.png)

And here's how it works with the patch:

https://user-images.githubusercontent.com/22980987/210115404-dadf38c7-62f6-4647-817b-6bec576b708b.mov

Here's how Focus Engine sees the views with and without the patch:
| W/O PATCH | WITH PATCH |
|---|---|
| ![context_8](https://user-images.githubusercontent.com/22980987/210115499-f271e1a4-a005-4bb4-8bef-4cb7df9f1f36.jpg) | ![context_10](https://user-images.githubusercontent.com/22980987/210115505-85390d26-3d73-4249-af14-a1cda0ed48f4.jpg) |



I did not remove any code and documentation related to `safePaddings` work but I think this PR makes it obsolete if I'm not missing any case. If we decide to merge this, we should almost completely revert these two PRs:

https://github.com/react-native-tvos/react-native-tvos/pull/314
https://github.com/react-native-tvos/react-native-tvos/pull/317
