### PR TITLE
fix: clear TVFocusGuide on view recycling process

### DIFF
--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -910,6 +910,11 @@ using namespace facebook::react;
   if ([_propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN containsObject:@"opacity"]) {
     self.layer.opacity = (float)props.opacity;
   }
+    
+  if (self.focusGuide != nil) {
+    [self removeLayoutGuide:self.focusGuide];
+    self.focusGuide = nil;
+  }
 
   _propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN = nil;
   _eventEmitter.reset();


### PR DESCRIPTION
This PR fixes #424.

## Summary

Focus behavior becomes *very* interesting on tvOS when Fabric is enabled after the first render. This is what I mean:

https://user-images.githubusercontent.com/22980987/210118993-8eef9822-d4b1-4dfa-a130-4e561cd70a47.mov

Even though it makes no sense, focus moves to `Button 4` whenever I try to move the focus up. It doesn't always have the same behavior, though. It is completely random. Sometimes you press `right` it moves up etc. To reproduce this, you just need to trigger a fast refresh once, that's it.

It was really hard to understand what's going on and turned out to be a nasty bug.

## Debugging Process

| FIRST RENDER | AFTER FAST REFRESH |
|---|---|
| ![Screenshot 2022-12-30 at 20 58 00](https://user-images.githubusercontent.com/22980987/210119145-995247e3-0f07-4e3e-ba35-3ad8e1a61577.png) | ![Screenshot 2022-12-30 at 20 59 13](https://user-images.githubusercontent.com/22980987/210119141-09e96d1c-3a1a-4c08-8632-ccd85b926dbf.png) |

As you can see, there are **3** TVFocusGuides on the tree on the first render but it becomes **4** after the first refresh. This is odd because there should always be **3** if you check the `TVFocusGuideSafePaddingExample`.

After several hours, I suspected that somehow one of the TVFocusGuides get attached to a different view or something. Decided to compare the `View` ids before and after fast refresh to see if there's any anomaly. 

Here are the results:

| FIRST RENDER | AFTER FAST REFRESH |
|---|---|
| ![Screenshot 2022-12-30 at 21 01 49](https://user-images.githubusercontent.com/22980987/210119329-077ddd11-412c-4112-9a2f-122a1d5ee676.png) | ![Screenshot 2022-12-30 at 21 03 54](https://user-images.githubusercontent.com/22980987/210119338-d5d0ab98-9be9-46d5-aa63-324bbff61c8f.png) |

You can see the `View` ids on the top right corner. The same view gets used in a completely different place! This made me thinking there most me some sort of leak or recycling going on and found that there's view recycling optimization on iOS with fabric 🤦 

So, long story short, the same view can be *recycled* and used for a different purpose on iOS with Fabric. There's `prepareForRecycle` method that notifies the view to clear its state etc. I added a piece of code in there to remove the attached TVFocusGuide when a view gets recycled to fix the issue.

