### PR TITLE
feat: make TVFocusGuide work reliably without safePadding v2

### DIFF
--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -88,6 +88,7 @@ const FocusGuideViewAndroidTV = (props: TVFocusGuideViewProps) => {
       {...props}
       focusable={props.focusable ?? true}
       destinations={nativeDestinations}
+      collapsable={false}
     />
   );
 };

--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -97,7 +97,9 @@ const FocusGuideViewTVOS = (props: TVFocusGuideViewProps) => {
       Commands.setDestinations(hostComponentRef, nativeDestinations);
   }, [props.destinations]);
 
-  return <ReactNative.View ref={focusGuideRef} {...props} />;
+  return (
+    <ReactNative.View ref={focusGuideRef} {...props} collapsable={false} />
+  );
 };
 
 const FocusGuideViewAndroidTV = (props: TVFocusGuideViewProps) => {

--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -23,7 +23,7 @@ type TVFocusGuideViewProps = $ReadOnly<{
    * Useful for absolute focus guides without children
    * Defaults to true
    */
-  enabled: ?Boolean,
+  enabled?: boolean,
 
   /**
    * The views the focus should go to
@@ -31,7 +31,7 @@ type TVFocusGuideViewProps = $ReadOnly<{
   destinations: ?(Object[]),
 
   /**
-   * How the TVFocusGuideView content safe padding should be applied. "null" to disable it.
+   * @deprecated Don't use it, no longer necessary.
    */
   safePadding?: 'vertical' | 'horizontal' | 'both' | null,
 }>;
@@ -39,48 +39,20 @@ type TVFocusGuideViewProps = $ReadOnly<{
 const TVFocusGuideView = ({
   enabled = true,
   safePadding,
-  style,
-  ...otherProps
+  ...props
 }: TVFocusGuideViewProps): React.Node => {
-  const paddingChoice = safePadding === undefined ? 'both' : safePadding;
-  const focusGuidePadding =
-    paddingChoice === 'both'
-      ? {padding: 1}
-      : paddingChoice === 'vertical'
-      ? {paddingVertical: 1}
-      : paddingChoice === 'horizontal'
-      ? {paddingHorizontal: 1}
-      : null;
-
   const enabledStyle = {display: enabled ? 'flex' : 'none'};
+  const style = [styles.container, props.style, enabledStyle];
 
-  /**
-   * The client specified layout(using 'style' prop) should be applied the container view ReactNative.View.
-   * And the focusGuide's layout should be overridden to wrap it fully inside the container view.
-   * For example, if the client specifies 'marginLeft' property in the style prop,
-   * then the TVFocusGuideView will apply the 'marginLeft' for both the parentView and the focusGuideView.
-   * and so, the left margin is getting added twice and UI becomes incorrect.
-   * The same is applicable for other layout properties.
-   */
-  const focusGuideStyle = [focusGuidePadding, style, styles.focusGuide];
+  if (Platform.isTVOS) {
+    return <FocusGuideViewTVOS {...props} style={style} />;
+  }
 
-  return (
-    /**
-     * The container needs to have at least a width of 1 and a height of 1.
-     * Also, being the container, it shouldn't be possible to give it some padding.
-     */
-    <ReactNative.View style={[style, styles.container, enabledStyle]}>
-      {Platform.isTV ? (
-        Platform.isTVOS ? (
-          <FocusGuideViewTVOS {...otherProps} style={focusGuideStyle} />
-        ) : (
-          <FocusGuideViewAndroidTV {...otherProps} style={focusGuideStyle} />
-        )
-      ) : (
-        otherProps.children
-      )}
-    </ReactNative.View>
-  );
+  if (Platform.isTV) {
+    return <FocusGuideViewAndroidTV {...props} style={style} />;
+  }
+
+  return <ReactNative.View {...props} style={style} />;
 };
 
 const FocusGuideViewTVOS = (props: TVFocusGuideViewProps) => {
@@ -124,22 +96,6 @@ const styles = ReactNative.StyleSheet.create({
   container: {
     minWidth: 1,
     minHeight: 1,
-    paddingTop: 0,
-    paddingBottom: 0,
-    paddingLeft: 0,
-    paddingRight: 0,
-  },
-  focusGuide: {
-    position: 'relative',
-    opacity: 1,
-    left: 0,
-    top: 0,
-    right: 0,
-    bottom: 0,
-    marginLeft: 0,
-    marginTop: 0,
-    marginRight: 0,
-    marginBottom: 0,
   },
 });
 

--- a/README.md
+++ b/README.md
@@ -206,8 +206,7 @@ class Game2048 extends React.Component {
 
 | Prop | Value | Description | 
 |---|---|---|
-| destinations | any[] | Array of `Component`s to register as destinations of the FocusGuideView | 
-| safePadding | 'both' (default) \| 'vertical' \| 'horizontal' \| null | When the FocusGuide children are exactly the same size as the FocusGuide's container, the focus will almost certainly be given directly to the children without going through the FocusGuide. This prop make sure it doesn't happen by adding a padding of 1 in all directions.<br />"null" to disable it. |
+| destinations | any[] | Array of `Component`s to register as destinations of the FocusGuideView |
 
 - _Next Focus Direction_: the props `nextFocus*` on `View` should work as expected on iOS too (previously android only). One caveat is that if there is no focusable in the `nextFocusable*` direction next to the starting view, iOS doesn't check if we want to override the destination. 
 

--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -74,7 +74,7 @@ declare module 'react-native' {
      */
     destinations?: (null | number | React.Component<any, any> | React.ComponentClass<any>)[];
     /**
-     * How the TVFocusGuideView content safe padding should be applied. "null" to disable it.
+     * @deprecated Don't use it, no longer necessary.
      */
     safePadding?: 'both' | 'vertical' | 'horizontal' | null;
   }


### PR DESCRIPTION
## Summary
This PR is almost the same as https://github.com/react-native-tvos/react-native-tvos/pull/426 but that one has been reverted by @douglowder due to a regression on Android.

[This](https://github.com/react-native-tvos/react-native-tvos/commit/507aad608565cff6a5176377de3edb9f496a63fd) fixes the problem on Android by disabling the view flattening on that platform just like we did for iOS.


https://user-images.githubusercontent.com/22980987/211201524-2276d485-1e68-41f4-bc70-3211d7c9ae35.mov



