### PR TITLE
Detect long up/down/left/right arrow press

### DIFF
--- a/React/Base/RCTTVRemoteHandler.h
+++ b/React/Base/RCTTVRemoteHandler.h
@@ -22,6 +22,10 @@ extern NSString * _Nonnull const RCTTVRemoteEventSelect;
 
 extern NSString * _Nonnull const RCTTVRemoteEventLongPlayPause;
 extern NSString * _Nonnull const RCTTVRemoteEventLongSelect;
+extern NSString * _Nonnull const RCTTVRemoteEventLongUp;
+extern NSString * _Nonnull const RCTTVRemoteEventLongDown;
+extern NSString * _Nonnull const RCTTVRemoteEventLongLeft;
+extern NSString * _Nonnull const RCTTVRemoteEventLongRight;
 
 extern NSString * _Nonnull const RCTTVRemoteEventLeft;
 extern NSString * _Nonnull const RCTTVRemoteEventRight;

--- a/React/Base/RCTTVRemoteHandler.m
+++ b/React/Base/RCTTVRemoteHandler.m
@@ -35,6 +35,10 @@ NSString *const RCTTVRemoteEventSelect = @"select";
 
 NSString *const RCTTVRemoteEventLongPlayPause = @"longPlayPause";
 NSString *const RCTTVRemoteEventLongSelect = @"longSelect";
+NSString *const RCTTVRemoteEventLongUp = @"longUp";
+NSString *const RCTTVRemoteEventLongDown = @"longDown";
+NSString *const RCTTVRemoteEventLongLeft = @"longLeft";
+NSString *const RCTTVRemoteEventLongRight = @"longRight";
 
 NSString *const RCTTVRemoteEventLeft = @"left";
 NSString *const RCTTVRemoteEventRight = @"right";
@@ -186,6 +190,22 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
   [self addLongPressGestureRecognizerWithSelector:@selector(longSelectPressed:)
                                         pressType:UIPressTypeSelect
                                              name:RCTTVRemoteEventLongSelect];
+
+  [self addLongPressGestureRecognizerWithSelector:@selector(longUpPressed:)
+                                        pressType:UIPressTypeUpArrow
+                                             name:RCTTVRemoteEventLongUp];
+
+  [self addLongPressGestureRecognizerWithSelector:@selector(longDownPressed:)
+                                        pressType:UIPressTypeDownArrow
+                                             name:RCTTVRemoteEventLongDown];
+
+  [self addLongPressGestureRecognizerWithSelector:@selector(longLeftPressed:)
+                                        pressType:UIPressTypeLeftArrow
+                                             name:RCTTVRemoteEventLongLeft];
+
+  [self addLongPressGestureRecognizerWithSelector:@selector(longRightPressed:)
+                                        pressType:UIPressTypeRightArrow
+                                             name:RCTTVRemoteEventLongRight];
 
   // Recognizers for Apple TV remote trackpad swipes
 
@@ -376,6 +396,26 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
 - (void)longSelectPressed:(UIGestureRecognizer *)r
 {
   [self sendAppleTVEvent:RCTTVRemoteEventLongSelect];
+}
+
+- (void)longUpPressed:(UIGestureRecognizer *)r
+{
+  [self sendAppleTVEvent:RCTTVRemoteEventLongUp];
+}
+
+- (void)longDownPressed:(UIGestureRecognizer *)r
+{
+  [self sendAppleTVEvent:RCTTVRemoteEventLongDown];
+}
+
+- (void)longLeftPressed:(UIGestureRecognizer *)r
+{
+  [self sendAppleTVEvent:RCTTVRemoteEventLongLeft];
+}
+
+- (void)longRightPressed:(UIGestureRecognizer *)r
+{
+  [self sendAppleTVEvent:RCTTVRemoteEventLongRight];
 }
 
 - (void)swipedUp:(UIGestureRecognizer *)r

--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -43,7 +43,7 @@ declare module 'react-native' {
   };
 
   export type HWEvent = {
-    eventType: 'up' | 'down' | 'right' | 'left' | 'blur' | 'focus' | 'pan' | string;
+    eventType: 'up' | 'down' | 'right' | 'left' | 'longUp' | 'longDown' | 'longRight' | 'longLeft' | 'blur' | 'focus' | 'pan' | string;
     eventKeyAction?: -1 | 1 | 0 | number;
     tag?: number;
     body?: {


### PR DESCRIPTION
## Summary

The detection of a long press in any of the DPad arrows is relevant in different scenarios, for example for fast-forwarding or fast-backward the progress of a video. So, I have added these cases to the `onHWKeyEvent` and named them `longUp/longDown/longLeft/longRight`.

These events can be detected by using the `useTVEventHandler`, for example:
```ts
        const myTVEventHandler = useCallback(
            (event: HWEvent) => {
                switch (event.eventType) {
                    case 'longUp':
                        handleLongUp();
                        break;
                    case 'longDown':
                        handleLongDown();
                        break;
                    case 'longLeft':
                        handleLongLeft();
                        break;
                    case 'longRight':
                        handleLongRight();
                        break;
                }
            },
            [handleLongUp, handleLongDown, handleLongLeft, handleLongRight],
        );

        useTVEventHandler(myTVEventHandler);
```
### tvOS
I have adjusted `RCTTVRemoteHandler.m` to detect the long press in the DPad arrows by looking at how it was made for the `longSelect`.

In this video, you can see that when a DPAD arrow is long-pressed an event is dispatched, and another event is dispatched when the key is released. This way we could easily detect when the long press began and ended.

https://user-images.githubusercontent.com/45874461/211531343-9f6dc464-c562-4354-86e5-a810919d8f70.mov


### Android TV
I have adjusted the `ReactAndroidHWInputDeviceHelper.java` to do the same as with tvOS, but I couldn't manage to test it locally. I followed the [advice](https://github.com/react-native-tvos/react-native-tvos/discussions/434) from @douglowder but without success. So I kindly ask for some assistance to test if the changes are detecting long presses for the DPad arrows on Android TV.


## Changelog

[tvOS/AndroidTV] [Added] - Dispatch onHWKeyEvent when a long press occurs in any of the DPad arrows

## Test Plan
I didn't add any tests yet, but I would love to add some to cover the new changes on the `useTVEventHandler` and with some help to test the `RCTTVRemoteHandler.m` and `ReactAndroidHWInputDeviceHelper.java`
