### PR TITLE
Fix onLongPress bug AndroidTV

### DIFF
--- a/Libraries/Components/Touchable/TVTouchable.js
+++ b/Libraries/Components/Touchable/TVTouchable.js
@@ -46,7 +46,7 @@ export default class TVTouchable {
             config.onPress(tvData);
           }
         } else if (tvData.eventType === 'longSelect') {
-          if (!config.getDisabled()) {
+          if (Platform.OS !== 'android' && !config.getDisabled()) {
             config.onLongPress(tvData);
           }
         }


### PR DESCRIPTION
The function is not available on AndroidTV which crashes it, I added an explicit platform check similarly as was done in TouchableNativeFeedback.js (b94c21cfcc869eeb9a5aff852ea856e379d373d4). This fixes #442.

Could you also have a look @maximilize since you introduced this feature?

Thanks!