### PR TITLE
chore: rename setAutoFocus public method to prevent naming collisions

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -1226,7 +1226,7 @@ public class ReactViewGroup extends ViewGroup
     this.focusDestinations = focusDestinations;
   }
 
-  public void setAutoFocus(boolean autoFocus) {
+  public void setAutoFocusTV(boolean autoFocus) {
     this.autoFocus = autoFocus;
     lastFocusedElement = new WeakReference<View>(null);
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -370,8 +370,8 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
   }
 
   @ReactProp(name = "autoFocus")
-  public void setAutoFocus(ReactViewGroup view, boolean autoFocus) {
-    view.setAutoFocus(autoFocus);
+  public void setAutoFocusTV(ReactViewGroup view, boolean autoFocus) {
+    view.setAutoFocusTV(autoFocus);
   }
 
 }


### PR DESCRIPTION
## Summary
As found out by @wouterds, a change made in the latest `autoFocus` PR made the project collide with `reac-native-screens` library. I described the problem [there](https://github.com/react-native-tvos/react-native-tvos/pull/450#issuecomment-1411934744) but echoing here for better visibility:

> They (react-native-screens) have this `SearchBarView` which extends `ReactViewGroup`. I introduced a public method in `ReactViewGroup` called `setAutoFocus` and they have [this line](https://github.com/software-mansion/react-native-screens/blob/main/android/src/main/java/com/swmansion/rnscreens/SearchBarView.kt#L22) which generates a setter called `setAutoFocus` method I believe (Kotlin magic). It's forbidden to create a method while the extended class has the same, so here we have our problem 😄

This PR changes the name of the public method introduced in the [previous PR](https://github.com/react-native-tvos/react-native-tvos/pull/450/files#diff-35d48396c88a9dcaf58aa19553bf53fb9136b3dcb630f31124992045169b36a9R1229) to solve the problem.

We should strictly follow one of the articles below to prevent a future incident like this one:

1. Don't introduce a new public method in RN Core files at all.
2. If you do, name the method with a prefix or a suffix like `TV` to reduce the risk of a potential naming conflict.
3. Don't overload existing core components with new functionality at all, create separate components extending the original ones.

I followed the second one but this is worth a discussion. Third one seems to be the way to. We've put a lot of logic into `ReactViewGroup` to support `TVFocusGuide` functionality which is obviously wrong. I know we have `RCTTVView` and lots of others on the tvOS side (at least for Paper --old-- architecture), we should probably do the same for Android. This should also ease the RN version updates since there'd be fewer potential conflicts.