### PR TITLE
Fix: android crash connectAnimatedNodes

### DIFF
--- a/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
+++ b/Libraries/NativeAnimation/RCTNativeAnimatedTurboModule.mm
@@ -26,9 +26,6 @@ typedef void (^AnimatedOperation)(RCTNativeAnimatedNodesManager *nodesManager);
   NSMutableArray<AnimatedOperation> *_operations;
   // Operations called before views have been updated.
   NSMutableArray<AnimatedOperation> *_preOperations;
-  NSMutableDictionary<NSNumber *, NSNumber *> *_animIdIsManagedByFabric;
-  // A set of nodeIDs managed by Fabric.
-  NSMutableSet<NSNumber *> *_nodeIDsManagedByFabric;
 }
 
 RCT_EXPORT_MODULE();
@@ -43,8 +40,6 @@ RCT_EXPORT_MODULE();
   if (self = [super init]) {
     _operations = [NSMutableArray new];
     _preOperations = [NSMutableArray new];
-    _animIdIsManagedByFabric = [NSMutableDictionary new];
-    _nodeIDsManagedByFabric = [NSMutableSet new];
   }
   return self;
 }
@@ -113,9 +108,6 @@ RCT_EXPORT_METHOD(updateAnimatedNodeConfig:(double)tag
 RCT_EXPORT_METHOD(connectAnimatedNodes:(double)parentTag
                   childTag:(double)childTag)
 {
-  if ([_nodeIDsManagedByFabric containsObject:@(childTag)]) {
-    [_nodeIDsManagedByFabric addObject:@(parentTag)];
-  }
   [self addOperationBlock:^(RCTNativeAnimatedNodesManager *nodesManager) {
     [nodesManager connectAnimatedNodes:[NSNumber numberWithDouble:parentTag] childTag:[NSNumber numberWithDouble:childTag]];
   }];
@@ -138,11 +130,7 @@ RCT_EXPORT_METHOD(startAnimatingNode:(double)animationId
     [nodesManager startAnimatingNode:[NSNumber numberWithDouble:animationId] nodeTag:[NSNumber numberWithDouble:nodeTag] config:config endCallback:callBack];
   }];
 
-  BOOL isNodeManagedByFabric = [_nodeIDsManagedByFabric containsObject:@(nodeTag)];
-  if (isNodeManagedByFabric) {
-    self->_animIdIsManagedByFabric[[NSNumber numberWithDouble:animationId]] = @YES;
-    [self flushOperationQueues];
-  }
+  [self flushOperationQueues];
 }
 
 RCT_EXPORT_METHOD(stopAnimation:(double)animationId)
@@ -150,9 +138,7 @@ RCT_EXPORT_METHOD(stopAnimation:(double)animationId)
   [self addOperationBlock:^(RCTNativeAnimatedNodesManager *nodesManager) {
     [nodesManager stopAnimation:[NSNumber numberWithDouble:animationId]];
   }];
-  if ([_animIdIsManagedByFabric[[NSNumber numberWithDouble:animationId]] boolValue]) {
-    [self flushOperationQueues];
-  }
+  [self flushOperationQueues];
 }
 
 RCT_EXPORT_METHOD(setAnimatedNodeValue:(double)nodeTag
@@ -192,9 +178,6 @@ RCT_EXPORT_METHOD(extractAnimatedNodeOffset:(double)nodeTag)
 RCT_EXPORT_METHOD(connectAnimatedNodeToView:(double)nodeTag
                   viewTag:(double)viewTag)
 {
-  if (RCTUIManagerTypeForTagIsFabric(@(viewTag))) {
-    [_nodeIDsManagedByFabric addObject:@(nodeTag)];
-  }
   [self addOperationBlock:^(RCTNativeAnimatedNodesManager *nodesManager) {
     // viewName is not used when node is managed by Fabric, and nodes are always managed by Fabric in Bridgeless.
     [nodesManager connectAnimatedNodeToView:[NSNumber numberWithDouble:nodeTag] viewTag:[NSNumber numberWithDouble:viewTag] viewName:nil];
@@ -290,7 +273,6 @@ RCT_EXPORT_METHOD(getValue:(double)nodeTag saveValueCallback:(RCTResponseSenderB
   NSArray<AnimatedOperation> *operations = _operations;
   _preOperations = [NSMutableArray new];
   _operations = [NSMutableArray new];
-
 
   RCTExecuteOnMainQueue(^{
     for (AnimatedOperation operation in preOperations) {

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/EventAnimationDriver.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/EventAnimationDriver.java
@@ -21,8 +21,13 @@ import java.util.List;
 /* package */ class EventAnimationDriver implements RCTEventEmitter {
   private List<String> mEventPath;
   /* package */ ValueAnimatedNode mValueNode;
+  /* package */ String mEventName;
+  /* package */ int mViewTag;
 
-  public EventAnimationDriver(List<String> eventPath, ValueAnimatedNode valueNode) {
+  public EventAnimationDriver(
+      String eventName, int viewTag, List<String> eventPath, ValueAnimatedNode valueNode) {
+    mEventName = eventName;
+    mViewTag = viewTag;
     mEventPath = eventPath;
     mValueNode = valueNode;
   }

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -113,7 +113,7 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
 
     @AnyThread
     boolean isEmpty() {
-      return mQueue.isEmpty();
+      return mQueue.isEmpty() && mPeekedOperation != null;
     }
 
     void setSynchronizedAccess(boolean isSynchronizedAccess) {

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedModule.java
@@ -393,8 +393,8 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
 
   /**
    * Given a viewTag, detect if we're running in Fabric or non-Fabric and attach an event listener
-   * to the correct UIManager, if necessary. This is expected to only be called from the JS thread,
-   * and not concurrently.
+   * to the correct UIManager, if necessary. This is expected to only be called from the native
+   * module thread, and not concurrently.
    *
    * @param viewTag
    */
@@ -417,8 +417,7 @@ public class NativeAnimatedModule extends NativeAnimatedModuleSpec
     }
 
     // Subscribe to UIManager (Fabric or non-Fabric) lifecycle events if we haven't yet
-    if ((mInitializedForFabric && mUIManagerType == UIManagerType.FABRIC)
-        || (mInitializedForNonFabric && mUIManagerType == UIManagerType.DEFAULT)) {
+    if (mUIManagerType == UIManagerType.FABRIC ? mInitializedForFabric : mInitializedForNonFabric) {
       return;
     }
 

--- a/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/animated/NativeAnimatedNodesManager.java
@@ -30,11 +30,9 @@ import com.facebook.react.uimanager.events.EventDispatcher;
 import com.facebook.react.uimanager.events.EventDispatcherListener;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Map;
 import java.util.Queue;
 
 /**
@@ -57,9 +55,9 @@ import java.util.Queue;
   private final SparseArray<AnimatedNode> mAnimatedNodes = new SparseArray<>();
   private final SparseArray<AnimationDriver> mActiveAnimations = new SparseArray<>();
   private final SparseArray<AnimatedNode> mUpdatedNodes = new SparseArray<>();
-  // Mapping of a view tag and an event name to a list of event animation drivers. 99% of the time
-  // there will be only one driver per mapping so all code code should be optimized around that.
-  private final Map<String, List<EventAnimationDriver>> mEventDrivers = new HashMap<>();
+  // List of event animation drivers for an event on view.
+  // There may be multiple drivers for the same event and view.
+  private final List<EventAnimationDriver> mEventDrivers = new ArrayList<>();
   private final ReactApplicationContext mReactApplicationContext;
   private int mAnimatedGraphBFSColor = 0;
   // Used to avoid allocating a new array on every frame in `runUpdates` and `onEventDispatch`.
@@ -462,7 +460,8 @@ import java.util.Queue;
   }
 
   @UiThread
-  public void addAnimatedEventToView(int viewTag, String eventName, ReadableMap eventMapping) {
+  public void addAnimatedEventToView(
+      int viewTag, String eventHandlerName, ReadableMap eventMapping) {
     int nodeTag = eventMapping.getInt("animatedValueTag");
     AnimatedNode node = mAnimatedNodes.get(nodeTag);
     if (node == null) {
@@ -473,8 +472,8 @@ import java.util.Queue;
       throw new JSApplicationIllegalArgumentException(
           "addAnimatedEventToView: Animated node on view ["
               + viewTag
-              + "] connected to event ("
-              + eventName
+              + "] connected to event handler ("
+              + eventHandlerName
               + ") should be of type "
               + ValueAnimatedNode.class.getName());
     }
@@ -485,32 +484,27 @@ import java.util.Queue;
       pathList.add(path.getString(i));
     }
 
-    EventAnimationDriver event = new EventAnimationDriver(pathList, (ValueAnimatedNode) node);
-    String key = viewTag + eventName;
-    if (mEventDrivers.containsKey(key)) {
-      mEventDrivers.get(key).add(event);
-    } else {
-      List<EventAnimationDriver> drivers = new ArrayList<>(1);
-      drivers.add(event);
-      mEventDrivers.put(key, drivers);
-    }
+    String eventName = normalizeEventName(eventHandlerName);
+
+    EventAnimationDriver eventDriver =
+        new EventAnimationDriver(eventName, viewTag, pathList, (ValueAnimatedNode) node);
+    mEventDrivers.add(eventDriver);
   }
 
   @UiThread
-  public void removeAnimatedEventFromView(int viewTag, String eventName, int animatedValueTag) {
-    String key = viewTag + eventName;
-    if (mEventDrivers.containsKey(key)) {
-      List<EventAnimationDriver> driversForKey = mEventDrivers.get(key);
-      if (driversForKey.size() == 1) {
-        mEventDrivers.remove(viewTag + eventName);
-      } else {
-        ListIterator<EventAnimationDriver> it = driversForKey.listIterator();
-        while (it.hasNext()) {
-          if (it.next().mValueNode.mTag == animatedValueTag) {
-            it.remove();
-            break;
-          }
-        }
+  public void removeAnimatedEventFromView(
+      int viewTag, String eventHandlerName, int animatedValueTag) {
+
+    String eventName = normalizeEventName(eventHandlerName);
+
+    ListIterator<EventAnimationDriver> it = mEventDrivers.listIterator();
+    while (it.hasNext()) {
+      EventAnimationDriver driver = it.next();
+      if (eventName.equals(driver.mEventName)
+          && viewTag == driver.mViewTag
+          && animatedValueTag == driver.mValueNode.mTag) {
+        it.remove();
+        break;
       }
     }
   }
@@ -546,18 +540,19 @@ import java.util.Queue;
       if (uiManager == null) {
         return;
       }
-      String eventName = uiManager.resolveCustomDirectEventName(event.getEventName());
-      if (eventName == null) {
-        eventName = "";
-      }
 
-      List<EventAnimationDriver> driversForKey = mEventDrivers.get(event.getViewTag() + eventName);
-      if (driversForKey != null) {
-        for (EventAnimationDriver driver : driversForKey) {
+      boolean foundAtLeastOneDriver = false;
+      Event.EventAnimationDriverMatchSpec matchSpec = event.getEventAnimationDriverMatchSpec();
+      for (EventAnimationDriver driver : mEventDrivers) {
+        if (matchSpec.match(driver.mViewTag, driver.mEventName)) {
+          foundAtLeastOneDriver = true;
           stopAnimationsForNode(driver.mValueNode);
           event.dispatch(driver);
           mRunUpdateNodeList.add(driver.mValueNode);
         }
+      }
+
+      if (foundAtLeastOneDriver) {
         updateNodes(mRunUpdateNodeList);
         mRunUpdateNodeList.clear();
       }
@@ -771,5 +766,15 @@ import java.util.Queue;
     } else {
       mWarnedAboutGraphTraversal = false;
     }
+  }
+
+  private String normalizeEventName(String eventHandlerName) {
+    // Fabric UIManager also makes this assumption
+    String eventName = eventHandlerName;
+    if (eventHandlerName.startsWith("on")) {
+      eventName = "top" + eventHandlerName.substring(2);
+    }
+
+    return eventName;
   }
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/uimanager/events/Event.java
@@ -39,6 +39,7 @@ public abstract class Event<T extends Event> {
   private int mViewTag;
   private long mTimestampMs;
   private int mUniqueID = sUniqueID++;
+  private @Nullable EventAnimationDriverMatchSpec mEventAnimationDriverMatchSpec;
 
   protected Event() {}
 
@@ -156,6 +157,19 @@ public abstract class Event<T extends Event> {
   /** @return the name of this event as registered in JS */
   public abstract String getEventName();
 
+  public EventAnimationDriverMatchSpec getEventAnimationDriverMatchSpec() {
+    if (mEventAnimationDriverMatchSpec == null) {
+      mEventAnimationDriverMatchSpec =
+          new EventAnimationDriverMatchSpec() {
+            @Override
+            public boolean match(int viewTag, String eventName) {
+              return viewTag == getViewTag() && eventName.equals(getEventName());
+            };
+          };
+    }
+    return mEventAnimationDriverMatchSpec;
+  }
+
   /**
    * Dispatch this event to JS using the given event emitter. Compatible with old and new renderer.
    * Instead of using this or dispatchModern, it is recommended that you simply override
@@ -215,5 +229,9 @@ public abstract class Event<T extends Event> {
       }
     }
     dispatch(rctEventEmitter);
+  }
+
+  public interface EventAnimationDriverMatchSpec {
+    boolean match(int viewTag, String eventName);
   }
 }


### PR DESCRIPTION
This issue (https://github.com/facebook/react-native/issues/33375) has been fixed upstream in `react-native` but the commits are not yet in our repository. We're not exactly sure what causes it, but we were able to resolve the issue by cherry-picking those 4 commits related to `NativeAnimatedNodesManager.java` from upstream into `react-native-tvos`.

We did a lot of manual testing and ran automated tests every hour last night, and we can now no longer reproduce it.

Our patched fork with those 4 commits [`@wouterds/react-native-tvos`](https://www.npmjs.com/package/@wouterds/react-native-tvos)
Sentry stacktrace: https://sentry.io/share/issue/d58aa423fa9e4ddebb0a4271533d1590/