### PR TITLE
Pick up fixes from RN core for 0.69 branch

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1146,7 +1146,7 @@ jobs:
       - run_yarn
       - add_ssh_keys:
           fingerprints:
-            - "1c:98:e0:3a:52:79:95:29:12:cd:b4:87:5b:41:e2:bb"
+            - "1f:c7:61:c4:e2:ff:77:e3:cc:ca:a7:34:c2:79:e3:3c"
       - run:
           name: "Set new react-native version and commit changes"
           command: |
@@ -1249,7 +1249,7 @@ jobs:
                 command: |
                   curl -X POST https://api.github.com/repos/react-native-community/rn-diff-purge/dispatches \
                     -H "Accept: application/vnd.github.v3+json" \
-                    -u "$PAT_USERNAME:$PAT_TOKEN" \
+                    -H "Authorization: Bearer $REACT_NATIVE_BOT_GITHUB_TOKEN" \
                     -d "{\"event_type\": \"publish\", \"client_payload\": { \"version\": \"${CIRCLE_TAG:1}\" }}"
       # END: Stable releases
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
-    zeitwerk (2.6.6)
+    zeitwerk (2.6.7)
 
 PLATFORMS
   ruby

--- a/Libraries/Core/ReactNativeVersion.js
+++ b/Libraries/Core/ReactNativeVersion.js
@@ -12,6 +12,6 @@
 exports.version = {
   major: 0,
   minor: 69,
-  patch: 6,
+  patch: 8,
   prerelease: null,
 };

--- a/Libraries/Core/ReactNativeVersion.js
+++ b/Libraries/Core/ReactNativeVersion.js
@@ -13,5 +13,5 @@ exports.version = {
   major: 0,
   minor: 69,
   patch: 6,
-  prerelease: '3',
+  prerelease: null,
 };

--- a/React/Base/RCTVersion.m
+++ b/React/Base/RCTVersion.m
@@ -23,7 +23,7 @@ NSDictionary* RCTGetReactNativeVersion(void)
     __rnVersion = @{
                   RCTVersionMajor: @(0),
                   RCTVersionMinor: @(69),
-                  RCTVersionPatch: @(6),
+                  RCTVersionPatch: @(8),
                   RCTVersionPrerelease: [NSNull null],
                   };
   });

--- a/React/Base/RCTVersion.m
+++ b/React/Base/RCTVersion.m
@@ -24,7 +24,7 @@ NSDictionary* RCTGetReactNativeVersion(void)
                   RCTVersionMajor: @(0),
                   RCTVersionMinor: @(69),
                   RCTVersionPatch: @(6),
-                  RCTVersionPrerelease: @"3",
+                  RCTVersionPrerelease: [NSNull null],
                   };
   });
   return __rnVersion;

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.69.6
+VERSION_NAME=0.69.8
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/gradle.properties
+++ b/ReactAndroid/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=0.69.6-3
+VERSION_NAME=0.69.6
 GROUP=com.facebook.react
 
 POM_NAME=ReactNative

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
@@ -17,6 +17,6 @@ public class ReactNativeVersion {
   public static final Map<String, Object> VERSION = MapBuilder.<String, Object>of(
       "major", 0,
       "minor", 69,
-      "patch", 6,
+      "patch", 8,
       "prerelease", null);
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/systeminfo/ReactNativeVersion.java
@@ -18,5 +18,5 @@ public class ReactNativeVersion {
       "major", 0,
       "minor", 69,
       "patch", 6,
-      "prerelease", "3");
+      "prerelease", null);
 }

--- a/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -586,6 +586,10 @@ public class ReactEditText extends AppCompatEditText
         new SpannableStringBuilder(reactTextUpdate.getText());
 
     manageSpans(spannableStringBuilder, reactTextUpdate.mContainsMultipleFragments);
+
+    // Mitigation for https://github.com/facebook/react-native/issues/35936 (S318090)
+    stripAbsoluteSizeSpans(spannableStringBuilder);
+
     mContainsImages = reactTextUpdate.containsImages();
 
     // When we update text, we trigger onChangeText code that will
@@ -656,6 +660,27 @@ public class ReactEditText extends AppCompatEditText
     // impact the whole Spannable, because that would override "local" styles per-fragment
     if (!skipAddSpansForMeasurements) {
       addSpansForMeasurement(getText());
+    }
+  }
+
+  private void stripAbsoluteSizeSpans(SpannableStringBuilder sb) {
+    // We have already set a font size on the EditText itself. We can safely remove sizing spans
+    // which are the same as the set font size, and not otherwise overlapped.
+    final int effectiveFontSize = mTextAttributes.getEffectiveFontSize();
+    ReactAbsoluteSizeSpan[] spans = sb.getSpans(0, sb.length(), ReactAbsoluteSizeSpan.class);
+
+    outerLoop:
+    for (ReactAbsoluteSizeSpan span : spans) {
+      ReactAbsoluteSizeSpan[] overlappingSpans =
+          sb.getSpans(sb.getSpanStart(span), sb.getSpanEnd(span), ReactAbsoluteSizeSpan.class);
+
+      for (ReactAbsoluteSizeSpan overlappingSpan : overlappingSpans) {
+        if (span.getSize() != effectiveFontSize) {
+          continue outerLoop;
+        }
+      }
+
+      sb.removeSpan(span);
     }
   }
 

--- a/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -18,7 +18,7 @@ constexpr struct {
   int32_t Major = 0;
   int32_t Minor = 69;
   int32_t Patch = 6;
-  std::string_view Prerelease = "3";
+  std::string_view Prerelease = "";
 } ReactNativeVersion;
 
 } // namespace facebook::react

--- a/ReactCommon/cxxreact/ReactNativeVersion.h
+++ b/ReactCommon/cxxreact/ReactNativeVersion.h
@@ -17,7 +17,7 @@ namespace facebook::react {
 constexpr struct {
   int32_t Major = 0;
   int32_t Minor = 69;
-  int32_t Patch = 6;
+  int32_t Patch = 8;
   std::string_view Prerelease = "";
 } ReactNativeVersion;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tvos",
-  "version": "0.69.6",
+  "version": "0.69.8",
   "bin": "./cli.js",
   "description": "A framework for building native apps using React",
   "license": "MIT",
@@ -177,7 +177,7 @@
     "metro-babel-register": "0.70.3",
     "mkdirp": "^0.5.1",
     "prettier": "^2.4.1",
-    "react-native-core": "npm:react-native@0.69.6",
+    "react-native-core": "npm:react-native@0.69.8",
     "shelljs": "^0.8.5",
     "signedsource": "^1.0.0",
     "ws": "^6.1.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-tvos",
-  "version": "0.69.6-3",
+  "version": "0.69.6",
   "bin": "./cli.js",
   "description": "A framework for building native apps using React",
   "license": "MIT",

--- a/template/package.json
+++ b/template/package.json
@@ -11,7 +11,7 @@
   },
   "dependencies": {
     "react": "18.0.0",
-    "react-native": "npm:react-native-tvos@0.69.6-3"
+    "react-native": "npm:react-native-tvos@0.69.6"
   },
   "devDependencies": {
     "@babel/core": "^7.12.9",


### PR DESCRIPTION
Merge from Facebook core 0.69 stable branch.

Includes mitigation fix for Samsung text input issue https://github.com/facebook/react-native/issues/35936 .
