### PR TITLE
feat: add focusTrap functionality to TVFocusGuide

### DIFF
--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -15,14 +15,6 @@ const Platform = require('../../Utilities/Platform');
 import {Commands} from '../View/ViewNativeComponent';
 import type {ViewProps} from '../View/ViewPropTypes';
 
-type TrapDirection =
-  | 'up'
-  | 'down'
-  | 'left'
-  | 'right'
-  | 'vertical'
-  | 'horizontal';
-
 type TVFocusGuideViewProps = $ReadOnly<{
   ...ViewProps,
 

--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -116,7 +116,13 @@ const FocusGuideViewAndroidTV = (props: TVFocusGuideViewProps) => {
     // $FlowFixMe[prop-missing]
     <ReactNative.View
       {...props}
-      focusable={props.focusable ?? true}
+      /**
+       * TVFocusGuide should be focusable only if it has `destinations`.
+       * Without giving too much implementation details, I can say both
+       * `autoFocus` and `trapFocus*` functionalities manage their focusable state
+       * on the native layer when/if necessarry.
+       */
+      focusable={props.focusable || props.destinations?.length > 0}
       destinations={nativeDestinations}
       collapsable={false}
     />

--- a/Libraries/Components/TV/TVFocusGuideView.js
+++ b/Libraries/Components/TV/TVFocusGuideView.js
@@ -15,6 +15,14 @@ const Platform = require('../../Utilities/Platform');
 import {Commands} from '../View/ViewNativeComponent';
 import type {ViewProps} from '../View/ViewPropTypes';
 
+type TrapDirection =
+  | 'up'
+  | 'down'
+  | 'left'
+  | 'right'
+  | 'vertical'
+  | 'horizontal';
+
 type TVFocusGuideViewProps = $ReadOnly<{
   ...ViewProps,
 
@@ -36,6 +44,11 @@ type TVFocusGuideViewProps = $ReadOnly<{
   safePadding?: 'vertical' | 'horizontal' | 'both' | null,
 
   autoFocus?: boolean,
+
+  trapFocusUp?: boolean,
+  trapFocusDown?: boolean,
+  trapFocusLeft?: boolean,
+  trapFocusRight?: boolean,
 }>;
 
 const TVFocusGuideView = ({

--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -42,6 +42,7 @@ import {
   type ChildListState,
   type ListDebugInfo,
 } from './VirtualizedListContext.js';
+import TVFocusGuideView from '../Components/TV/TVFocusGuideView';
 
 type Item = any;
 
@@ -1116,16 +1117,30 @@ class VirtualizedList extends React.PureComponent<Props, State> {
           unregisterAsNestedChild: this._unregisterAsNestedChild,
           debugInfo: this._getDebugInfo(),
         }}>
-        {React.cloneElement(
-          (
-            this.props.renderScrollComponent ||
-            this._defaultRenderScrollComponent
-          )(scrollProps),
-          {
-            ref: this._captureScrollRef,
-          },
-          cells,
-        )}
+        <TVFocusGuideView
+          trapFocusLeft={
+            horizontalOrDefault(this.props.horizontal) && this.state.first > 0
+          }
+          trapFocusRight={
+            horizontalOrDefault(this.props.horizontal) && this._hasMore
+          }
+          trapFocusUp={
+            !horizontalOrDefault(this.props.horizontal) && this.state.first > 0
+          }
+          trapFocusDown={
+            !horizontalOrDefault(this.props.horizontal) && this._hasMore
+          }>
+          {React.cloneElement(
+            (
+              this.props.renderScrollComponent ||
+              this._defaultRenderScrollComponent
+            )(scrollProps),
+            {
+              ref: this._captureScrollRef,
+            },
+            cells,
+          )}
+        </TVFocusGuideView>
       </VirtualizedListContextProvider>
     );
     let ret: React.Node = innerRet;

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ class Game2048 extends React.Component {
 |---|---|---|
 | destinations | any[]? | Array of `Component`s to register as destinations of the FocusGuideView |
 | autoFocus | boolean? | If true, `TVFocusGuide` will automatically manage focus for you. It will redirect the focus to the first focusable child on the first visit. It also remembers the last focused child and redirects the focus to it on the subsequent visits. |
+| trapFocus* (Up, Down, Left, Right) | Prevents focus escaping from the container for the given directions. |
 
 - _Next Focus Direction_: the props `nextFocus*` on `View` should work as expected on iOS too (previously android only). One caveat is that if there is no focusable in the `nextFocusable*` direction next to the starting view, iOS doesn't check if we want to override the destination. 
 

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -53,6 +53,10 @@ using namespace facebook::react;
   UIView *_nextFocusRight;
   UIView *_nextFocusActiveTarget;
   BOOL _autoFocus;
+  BOOL _trapFocusUp;
+  BOOL _trapFocusDown;
+  BOOL _trapFocusLeft;
+  BOOL _trapFocusRight;
 }
 
 @synthesize removeClippedSubviews = _removeClippedSubviews;
@@ -420,6 +424,24 @@ using namespace facebook::react;
     [[self containingRootView] removeLayoutGuide:self.focusGuideRight];
     self.focusGuideRight = nil;
   }
+}
+
+- (BOOL)shouldUpdateFocusInContext:(UIFocusUpdateContext *)context
+{
+  if (_trapFocusUp || _trapFocusDown || _trapFocusLeft || _trapFocusRight) {
+    bool isDescendant = [context.nextFocusedView isDescendantOfView:self];
+
+    if (!isDescendant) {
+      if ((_trapFocusUp && context.focusHeading == UIFocusHeadingUp)
+         || (_trapFocusDown && context.focusHeading == UIFocusHeadingDown)
+         || (_trapFocusLeft && context.focusHeading == UIFocusHeadingLeft)
+         || (_trapFocusRight && context.focusHeading == UIFocusHeadingRight)) {
+        return false;
+      }
+    }
+  }
+
+  return [super shouldUpdateFocusInContext:context];
 }
 
 - (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator
@@ -857,6 +879,11 @@ using namespace facebook::react;
       [self removeFocusGuide];
     }
   }
+
+  _trapFocusUp = newViewProps.trapFocusUp;
+  _trapFocusDown = newViewProps.trapFocusDown;
+  _trapFocusLeft = newViewProps.trapFocusLeft;
+  _trapFocusRight = newViewProps.trapFocusRight;
 #endif
 
 

--- a/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -428,17 +428,16 @@ using namespace facebook::react;
 
 - (BOOL)shouldUpdateFocusInContext:(UIFocusUpdateContext *)context
 {
-  if (_trapFocusUp || _trapFocusDown || _trapFocusLeft || _trapFocusRight) {
-    bool isDescendant = [context.nextFocusedView isDescendantOfView:self];
-
-    if (!isDescendant) {
-      if ((_trapFocusUp && context.focusHeading == UIFocusHeadingUp)
-         || (_trapFocusDown && context.focusHeading == UIFocusHeadingDown)
-         || (_trapFocusLeft && context.focusHeading == UIFocusHeadingLeft)
-         || (_trapFocusRight && context.focusHeading == UIFocusHeadingRight)) {
-        return false;
-      }
-    }
+  // This is  the `trapFocus*` logic that prevents the focus updates if
+  // focus should be trapped and `nextFocusedItem` is not a child FocusEnv.
+  if ((_trapFocusUp && context.focusHeading == UIFocusHeadingUp)
+     || (_trapFocusDown && context.focusHeading == UIFocusHeadingDown)
+     || (_trapFocusLeft && context.focusHeading == UIFocusHeadingLeft)
+     || (_trapFocusRight && context.focusHeading == UIFocusHeadingRight)) {
+    
+    // Checks if `nextFocusedItem` is a child `FocusEnvironment`.
+    // If not, it returns false thus it keeps the focus inside.
+    return [UIFocusSystem environment:self containsEnvironment:context.nextFocusedItem];
   }
 
   return [super shouldUpdateFocusInContext:context];

--- a/React/Views/RCTTVView.h
+++ b/React/Views/RCTTVView.h
@@ -47,6 +47,11 @@
  */
 @property (nonatomic, assign) BOOL autoFocus;
 
+@property (nonatomic, assign) BOOL trapFocusUp;
+@property (nonatomic, assign) BOOL trapFocusDown;
+@property (nonatomic, assign) BOOL trapFocusLeft;
+@property (nonatomic, assign) BOOL trapFocusRight;
+
 - (instancetype)initWithBridge:(RCTBridge *)bridge;
 
 /**

--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -482,20 +482,4 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   self.focusGuide.preferredFocusEnvironments = destinations;
 }
 
-- (void)setTrapFocusUp:(BOOL)enabled {
-  self->_trapFocusUp = enabled;
-}
-
-- (void)setTrapFocusDown:(BOOL)enabled {
-  self->_trapFocusDown = enabled;
-}
-
-- (void)setTrapFocusLeft:(BOOL)enabled {
-  self->_trapFocusLeft = enabled;
-}
-
-- (void)setTrapFocusRight:(BOOL)enabled {
-  self->_trapFocusRight = enabled;
-}
-
 @end

--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -255,6 +255,23 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   motionEffectsAdded = NO;
 }
 
+- (BOOL)shouldUpdateFocusInContext:(UIFocusUpdateContext *)context
+{
+  // This is  the `trapFocus*` logic that prevents the focus updates if
+  // focus should be trapped and `nextFocusedItem` is not a child FocusEnv.
+  if ((_trapFocusUp && context.focusHeading == UIFocusHeadingUp)
+     || (_trapFocusDown && context.focusHeading == UIFocusHeadingDown)
+     || (_trapFocusLeft && context.focusHeading == UIFocusHeadingLeft)
+     || (_trapFocusRight && context.focusHeading == UIFocusHeadingRight)) {
+
+    // Checks if `nextFocusedItem` is a child `FocusEnvironment`.
+    // If not, it returns false thus it keeps the focus inside.
+    return [UIFocusSystem environment:self containsEnvironment:context.nextFocusedItem];
+  }
+
+  return [super shouldUpdateFocusInContext:context];
+}
+
 - (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context
        withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator
 {
@@ -463,6 +480,22 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   }
   
   self.focusGuide.preferredFocusEnvironments = destinations;
+}
+
+- (void)setTrapFocusUp:(BOOL)enabled {
+  self->_trapFocusUp = enabled;
+}
+
+- (void)setTrapFocusDown:(BOOL)enabled {
+  self->_trapFocusDown = enabled;
+}
+
+- (void)setTrapFocusLeft:(BOOL)enabled {
+  self->_trapFocusLeft = enabled;
+}
+
+- (void)setTrapFocusRight:(BOOL)enabled {
+  self->_trapFocusRight = enabled;
 }
 
 @end

--- a/React/Views/RCTViewManager.m
+++ b/React/Views/RCTViewManager.m
@@ -138,6 +138,10 @@ RCT_EXPORT_VIEW_PROPERTY(nextFocusDown, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(nextFocusLeft, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(nextFocusRight, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(autoFocus, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(trapFocusUp, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(trapFocusDown, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(trapFocusLeft, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(trapFocusRight, BOOL)
 #endif
 
 // Accessibility related properties

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -1097,14 +1097,14 @@ public class ReactViewGroup extends ViewGroup
     return false;
   }
 
-  private boolean isFocusTrap() {
-    return trapFocusUp  || trapFocusDown || trapFocusLeft || trapFocusRight;
-  }
-
   private boolean isTVFocusGuide() {
-    return focusDestinations.length > 0
-      || autoFocus
-      || isFocusTrap();
+    /**
+     * We don't count a view as `TVFocusGuide` if it has `trapFocus*` props enabled.
+     * The reason is, it's a seperate functionality that has nothing to do with other
+     * TVFocusGuide features that involves heavy focus management. So, the feature
+     * is not directly tied to `TVFocusGuide`.
+     */
+    return focusDestinations.length > 0 || autoFocus;
   }
 
   @Nullable

--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -374,4 +374,24 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
     view.setAutoFocusTV(autoFocus);
   }
 
+  @ReactProp(name = "trapFocusUp")
+  public void trapFocusUp(ReactViewGroup view, boolean enabled) {
+    view.setTrapFocusUp(enabled);
+  }
+
+  @ReactProp(name = "trapFocusDown")
+    public void trapFocusDown(ReactViewGroup view, boolean enabled) {
+    view.setTrapFocusDown(enabled);
+  }
+
+  @ReactProp(name = "trapFocusLeft")
+    public void trapFocusLeft(ReactViewGroup view, boolean enabled) {
+    view.setTrapFocusLeft(enabled);
+  }
+
+  @ReactProp(name = "trapFocusRight")
+    public void trapFocusRight(ReactViewGroup view, boolean enabled) {
+    view.setTrapFocusRight(enabled);
+  }
+
 }

--- a/ReactCommon/react/renderer/components/view/ViewProps.cpp
+++ b/ReactCommon/react/renderer/components/view/ViewProps.cpp
@@ -257,12 +257,36 @@ ViewProps::ViewProps(
           "renderToHardwareTextureAndroid",
           sourceProps.renderToHardwareTextureAndroid,
           {})),
-    autoFocus(convertRawProp(
-            context,
-            rawProps,
-            "autoFocus",
-            sourceProps.autoFocus,
-            false))
+      autoFocus(convertRawProp(
+          context,
+          rawProps,
+          "autoFocus",
+          sourceProps.autoFocus,
+          false)),
+      trapFocusUp(convertRawProp(
+          context,
+          rawProps,
+          "trapFocusUp",
+          sourceProps.trapFocusUp,
+          false)),
+      trapFocusDown(convertRawProp(
+          context,
+          rawProps,
+          "trapFocusDown",
+          sourceProps.trapFocusDown,
+          false)),
+      trapFocusLeft(convertRawProp(
+          context,
+          rawProps,
+          "trapFocusLeft",
+          sourceProps.trapFocusLeft,
+          false)),
+      trapFocusRight(convertRawProp(
+          context,
+          rawProps,
+          "trapFocusRight",
+          sourceProps.trapFocusRight,
+          false))
 #endif
           {};
 

--- a/ReactCommon/react/renderer/components/view/ViewProps.cpp
+++ b/ReactCommon/react/renderer/components/view/ViewProps.cpp
@@ -31,33 +31,73 @@ ViewProps::ViewProps(
           rawProps,
           "isTVSelectable",
           sourceProps.isTVSelectable,
-          (Boolean)false)),
+          (Boolean) false)),
       hasTVPreferredFocus(convertRawProp(
           context,
           rawProps,
           "hasTVPreferredFocus",
           sourceProps.hasTVPreferredFocus,
-          (Boolean)false)),
+          (Boolean) false)),
       tvParallaxProperties(convertRawProp(
           context,
           rawProps,
           "tvParallaxProperties",
           sourceProps.tvParallaxProperties,
           {})),
-      nextFocusUp(
-          convertRawProp(context, rawProps, "nextFocusUp", sourceProps.nextFocusUp, {})),
-      nextFocusDown(
-          convertRawProp(context, rawProps, "nextFocusDown", sourceProps.nextFocusDown, {})),
-      nextFocusLeft(
-          convertRawProp(context, rawProps, "nextFocusLeft", sourceProps.nextFocusLeft, {})),
-      nextFocusRight(
-          convertRawProp(context, rawProps, "nextFocusRight", sourceProps.nextFocusRight, {})),
+      nextFocusUp(convertRawProp(
+          context,
+          rawProps,
+          "nextFocusUp",
+          sourceProps.nextFocusUp,
+          {})),
+      nextFocusDown(convertRawProp(
+          context,
+          rawProps,
+          "nextFocusDown",
+          sourceProps.nextFocusDown,
+          {})),
+      nextFocusLeft(convertRawProp(
+          context,
+          rawProps,
+          "nextFocusLeft",
+          sourceProps.nextFocusLeft,
+          {})),
+      nextFocusRight(convertRawProp(
+          context,
+          rawProps,
+          "nextFocusRight",
+          sourceProps.nextFocusRight,
+          {})),
       autoFocus(convertRawProp(
           context,
           rawProps,
           "autoFocus",
           sourceProps.autoFocus,
           (Boolean) false)),
+      trapFocusUp(convertRawProp(
+          context,
+          rawProps,
+          "trapFocusUp",
+          sourceProps.trapFocusUp,
+          false)),
+      trapFocusDown(convertRawProp(
+          context,
+          rawProps,
+          "trapFocusDown",
+          sourceProps.trapFocusDown,
+          false)),
+      trapFocusLeft(convertRawProp(
+          context,
+          rawProps,
+          "trapFocusLeft",
+          sourceProps.trapFocusLeft,
+          false)),
+      trapFocusRight(convertRawProp(
+          context,
+          rawProps,
+          "trapFocusRight",
+          sourceProps.trapFocusRight,
+          false)),
 #endif
       opacity(convertRawProp(
           context,

--- a/ReactCommon/react/renderer/components/view/ViewProps.h
+++ b/ReactCommon/react/renderer/components/view/ViewProps.h
@@ -97,6 +97,10 @@ class ViewProps : public YogaStylableProps, public AccessibilityProps {
   bool needsOffscreenAlphaCompositing{false};
   bool renderToHardwareTextureAndroid{false};
   bool autoFocus{false};
+  bool trapFocusUp{false};
+  bool trapFocusDown{false};
+  bool trapFocusLeft{false};
+  bool trapFocusRight{false};
 #endif
 
 #pragma mark - Convenience Methods

--- a/ReactCommon/react/renderer/components/view/ViewProps.h
+++ b/ReactCommon/react/renderer/components/view/ViewProps.h
@@ -79,6 +79,10 @@ class ViewProps : public YogaStylableProps, public AccessibilityProps {
   std::optional<int> nextFocusLeft;
   std::optional<int> nextFocusRight;
   bool autoFocus{false};
+  bool trapFocusUp{false};
+  bool trapFocusDown{false};
+  bool trapFocusLeft{false};
+  bool trapFocusRight{false};
 #endif
 
   Float elevation{}; /* Android-only */

--- a/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
+++ b/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
@@ -81,9 +81,8 @@ const FocusableBox = React.memo(({width, height, text, slow, ...props}) => {
   const theme = useRNTesterTheme();
 
   if (slow) {
-    console.log('Slow component rendering...', text);
     const now = performance.now();
-    while (performance.now() - now < 500) {}
+    while (performance.now() - now < 200) {}
   }
 
   return (
@@ -247,7 +246,13 @@ const RestoreFocusTestList = () => {
 };
 
 const SlowListFocusTest = () => {
-  const data = React.useMemo(() => generateData(8), []);
+  const data = React.useMemo(() => generateData(100), []);
+
+  /**
+   * This is a testing playground for virtualized lists with slow components.
+   * Focus should be trapped inside the list until user reaches the end
+   * or the beginning of the list.
+   */
 
   return (
     <TVFocusGuide autoFocus style={styles.mb5}>

--- a/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
+++ b/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
@@ -77,13 +77,15 @@ const Text = ({style, children}) => {
   );
 };
 
-const FocusableBox = ({
-  width,
-  height,
-  text,
-  ...props
-}) => {
+const FocusableBox = React.memo(({width, height, text, slow, ...props}) => {
   const theme = useRNTesterTheme();
+
+  if (slow) {
+    console.log('Slow component rendering...', text);
+    const now = performance.now();
+    while (performance.now() - now < 500) {}
+  }
+
   return (
     <Pressable
       {...props}
@@ -100,15 +102,18 @@ const FocusableBox = ({
         props.style,
       ]}>
       {text !== undefined ? (
-        <RNText style={{fontSize: 24 * scale, color: theme.LabelColor}}>{text}</RNText>
+        <Text style={{fontSize: 24 * scale}}>{text}</Text>
       ) : null}
     </Pressable>
   );
-};
+});
 
 const SideMenu = () => {
   const theme = useRNTesterTheme();
-  const sideMenuItemStyle = [styles.sideMenuItem, {backgroundColor: theme.TertiarySystemFillColor}];
+  const sideMenuItemStyle = [
+    styles.sideMenuItem,
+    {backgroundColor: theme.TertiarySystemFillColor},
+  ];
   return (
     <TVFocusGuide autoFocus style={styles.sideMenuContainer}>
       <Text style={{fontSize: 18 * scale, marginBottom: 10 * scale}}>
@@ -135,6 +140,7 @@ const HList = ({
   onItemFocused,
   onItemPressed,
   prefix = '',
+  slow,
   ...props
 }) => {
   const listRef = React.useRef(null);
@@ -148,8 +154,9 @@ const HList = ({
         height={itemHeight}
         style={styles.mr5}
         text={getItemText({prefix, item})}
-        onFocus={() => onItemFocused?.({item, index})}
-        onPress={() => onItemPressed?.({item, index})}
+        onFocus={onItemFocused}
+        onPress={onItemPressed}
+        slow={slow}
       />
     );
   };
@@ -239,6 +246,36 @@ const RestoreFocusTestList = () => {
   );
 };
 
+const SlowListFocusTest = () => {
+  const data = React.useMemo(() => generateData(8), []);
+
+  return (
+    <TVFocusGuide autoFocus style={styles.mb5}>
+      <Text
+        style={[
+          styles.rowTitle,
+          {marginLeft: 16 * scale, marginVertical: 16 * scale},
+        ]}>
+        Slow List Focus Test
+      </Text>
+      <View style={{flexDirection: 'row'}}>
+        <FocusableBox text="LEFT" style={styles.slowListPlaceholderItem} />
+        <View style={styles.slowList}>
+          <HList
+            data={data}
+            slow
+            initialNumToRender={4}
+            windowSize={1}
+            maxToRenderPerBatch={1}
+            itemWidth={550 * scale}
+          />
+        </View>
+        <FocusableBox text="RIGHT" style={styles.slowListPlaceholderItem} />
+      </View>
+    </TVFocusGuide>
+  );
+};
+
 const ContentArea = () => {
   return (
     <TVFocusGuide autoFocus style={{flex: 1}}>
@@ -247,6 +284,7 @@ const ContentArea = () => {
           Welcome to the TVFocusGuide autoFocus example!
         </Text>
         <RestoreFocusTestList />
+        <SlowListFocusTest />
         <Row title="Category Example 1" />
         <Row title="Category Example 2" />
 
@@ -316,4 +354,11 @@ const styles = StyleSheet.create({
     marginBottom: 5 * scale,
   },
   pageTitle: {fontSize: 48 * scale, margin: 10 * scale},
+  slowListPlaceholderItem: {
+    width: 100 * scale,
+  },
+  slowList: {
+    flex: 1,
+    marginHorizontal: 8 * scale,
+  },
 });

--- a/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
+++ b/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
@@ -77,17 +77,22 @@ const Text = ({style, children}) => {
   );
 };
 
-const FocusableBox = React.memo(({width, height, text, slow, ...props}) => {
+const FocusableBox = React.memo(({id, width, height, text, slow, ...props}) => {
   const theme = useRNTesterTheme();
 
   if (slow) {
+    // eslint-disable-next-line no-undef
     const now = performance.now();
+    // eslint-disable-next-line no-undef
     while (performance.now() - now < 200) {}
   }
+
+  const onFocus = e => props?.onFocus?.(e, id);
 
   return (
     <Pressable
       {...props}
+      onFocus={onFocus}
       style={state => [
         {
           width,
@@ -149,6 +154,7 @@ const HList = ({
   const renderItem = ({item, index}) => {
     return (
       <FocusableBox
+        id={item}
         width={itemWidth}
         height={itemHeight}
         style={styles.mr5}
@@ -181,8 +187,8 @@ const getSelectedItemPrefix = selectedCategory => {
 const Row = ({title}) => {
   const [selectedCategory, setSelectedCategory] = React.useState('1');
 
-  const onCategoryFocused = ({item}) => {
-    setSelectedCategory(item);
+  const onCategoryFocused = (event, id) => {
+    setSelectedCategory(id);
   };
 
   return (
@@ -256,13 +262,7 @@ const SlowListFocusTest = () => {
 
   return (
     <TVFocusGuide autoFocus style={styles.mb5}>
-      <Text
-        style={[
-          styles.rowTitle,
-          {marginLeft: 16 * scale, marginVertical: 16 * scale},
-        ]}>
-        Slow List Focus Test
-      </Text>
+      <Text style={styles.slowListTitle}>Slow List Focus Test</Text>
       <View style={{flexDirection: 'row'}}>
         <FocusableBox text="LEFT" style={styles.slowListPlaceholderItem} />
         <View style={styles.slowList}>
@@ -336,6 +336,7 @@ const styles = StyleSheet.create({
     alignItems: 'center',
   },
   rowTitle: {marginRight: 10 * scale, fontSize: 24 * scale},
+  slowListTitle: {fontSize: 24 * scale, margin: 16 * scale},
   container: {
     flex: 1,
     flexDirection: 'row',

--- a/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
+++ b/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
@@ -246,7 +246,7 @@ const RestoreFocusTestList = () => {
 };
 
 const SlowListFocusTest = () => {
-  const data = React.useMemo(() => generateData(100), []);
+  const data = React.useMemo(() => generateData(10), []);
 
   /**
    * This is a testing playground for virtualized lists with slow components.

--- a/tvos-types.d.ts
+++ b/tvos-types.d.ts
@@ -83,6 +83,22 @@ declare module 'react-native' {
      */
     autoFocus?: boolean;
     /**
+     * Enables focus trapping for the focus guide (see README).
+     */
+    trapFocusUp?: boolean;
+    /**
+     * Enables focus trapping for the focus guide (see README).
+     */
+    trapFocusDown?: boolean;
+    /**
+     * Enables focus trapping for the focus guide (see README).
+     */
+    trapFocusLeft?: boolean;
+    /**
+     * Enables focus trapping for the focus guide (see README).
+     */
+    trapFocusRight?: boolean;
+    /**
      * @deprecated Don't use it, no longer necessary.
      */
     safePadding?: 'both' | 'vertical' | 'horizontal' | null;


### PR DESCRIPTION
## Summary

This PR introduces a new addition to `TVFocusGuide` arsenal, `focusTrap*`. This new functionality allows us to *trap* the focus inside a container. When it's in, we can make sure it stays in until we don't want it to do so.

This concept is well-known and used on the web for a11y. The difference here is though, our implementation allows us to have fine-grained control based on the direction. We can trap the focus in only one direction while allowing it to move freely in other directions. E.g we can trap it for **left** and **right** actions but not for **up** and **down**.

This flexibility is important because the functionality is mainly implemented to fix a focus bug that exists in **VirtualizedList** family (FlatList etc.). I'm not even sure calling it a *bug* is even fair but let me explain it first.

## The "bug"

As a refresher, this piece of information is important; Focus engines find the next focusable based on the rendered UI elements. This principle conflicts with virtualization because its sole purpose is *not* to render the elements until they are about to be seen by the user. In theory, the rendering speed of the virtualized list will be faster than the user's scroll speed so the user should never notice this optimization. In reality, though, we end up seeing good ol' blank areas.

When rendering speed can't keep up with user's navigation speed, the list runs out of items, and the focus moves to the most logical next element on the next d-pad command which is possibly outside the list. This is a horrible UX and it happens much more than you think it'd happen.

![image](https://user-images.githubusercontent.com/22980987/219513669-469f4a02-bd78-468e-ab72-61f519dda88b.png)


It's easier to explain by showing:

https://user-images.githubusercontent.com/22980987/219511510-4ac10e15-ee89-4cf7-803b-8bd77b21e2cf.mov


I created a list with artificially slow components. Each component takes at least 200ms to render --which is a bit extreme but I've seen worse in actual prod apps, lol--. Also, locked `windowSize` to 1 so it doesn't render items in advance. You can see the whole config [here](https://github.com/react-native-tvos/react-native-tvos/pull/465/files#diff-74d1b0c793b4986766077b9926b5e0a12ccac8f518ea4ee4d85561a22f515671R269).

As I spam `right` on the d-pad, we reach the **end**(!) of the list and focus moves to the focusable item `RIGHT`. If you pay attention to the end of the list, you'll see that the next items get rendered late and focus escapes outside. 

## Solution
Implemented `trapFocus*` props for `TVFocusGuide` that helps us control the focus routes by direction. Used it to fix VirtualizedList's focus *bug* by simply wrapping the children of the list and enabling/disabling `trapFocus*` props based on the list's direction and `first`/`last` rendered item information. If `last` is less than provided `data` array's `length`, it means the very last item is not rendered, yet there's still a risk of the bug's occurrence. We keep trapping the focus in that case. As simple as this. You can figure out the rest by reading the code I hope.

With this in place, the focus stays inside until reaching the very beginning or the very end of the list even if the user spams d-pad actions.

### tvOS

<table>
  <tr>
    <th>tvOS (Before)</th>
    <th>tvOS (After)</th>
  </tr>
  <tr>
    <td>
    
https://user-images.githubusercontent.com/22980987/219516155-a33c797d-1d6e-424b-bbe1-0028e0fd0ea3.mov
</td>
        <td>
        
https://user-images.githubusercontent.com/22980987/219517775-5029ec7e-9b80-45a4-b72f-21645d465b06.mov
</td>
  </tr>
</table>

### Android

<table>
  <tr>
    <th>Android (Before)</th>
    <th>Android (After)</th>
  </tr>
  <tr>
    <td>
    
https://user-images.githubusercontent.com/22980987/219516010-ec5a4038-5ac1-4c1d-a391-5c1015f3e045.mov
</td>
        <td>
        

https://user-images.githubusercontent.com/22980987/219516022-d859b66d-38e5-40f2-a7b5-5ca56f8e0972.mov
</td>
  </tr>
</table>


