### PR TITLE
fix: [Android TV] long presses should fire events promptly

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/config/ReactFeatureFlags.java
@@ -105,7 +105,13 @@ public class ReactFeatureFlags {
   public static boolean enableDelayedViewStateDeletion = false;
 
   /**
-   * Send key down events as well as key up events
+   * Android TV: Send key down events as well as key up events. 
+   * Enabling this flag will result in two 'select' TVRemoteEventHandler events
+   * (one with key action 0 and one with key action 1) for each press of the center
+   * DPad button. (Similarly for arrow keys.)
+   * Note: If you enable this flag, long presses of the select or center button will
+   * result in an initial 'select' with eventKeyAction = 0 (ACTION_DOWN), before
+   * the expected 'longSelect' events are fired. (Similarly for arrow keys.)
    */
   public static boolean enableKeyDownEvents = false;
 

--- a/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
@@ -82,7 +82,9 @@ public class ReactAndroidHWInputDeviceHelper {
   private int mLastFocusedViewId = View.NO_ID;
 
   // Presses longer than this number of milliseconds are treated as long presses
-  private long mPressedDelta = 1000;
+  // This seems to be roughly the time the emulator waits after the first key down event
+  // before sending a continuous stream of rapid key downs on a long press.
+  private long mLongPressedDelta = 300;
 
   // These are used for long press detection
   private long mLastKeyDownTime = 0;
@@ -106,9 +108,9 @@ public class ReactAndroidHWInputDeviceHelper {
   }
 
   // True if we are in the long press state and we are more than
-  // mPressedDelta milliseconds since the last long press event was fired
+  // mLongPressedDelta milliseconds since the last long press event was fired
   private boolean isLongPressEventTime(long time) {
-    return mLastKeyDownTime != 0 && time - mLastKeyDownTime > mPressedDelta;
+    return mLastKeyDownTime != 0 && time - mLastKeyDownTime > mLongPressedDelta;
   }
 
   /** Called from {@link com.facebook.react.ReactRootView}. This is the main place the key events are handled. */
@@ -158,7 +160,7 @@ public class ReactAndroidHWInputDeviceHelper {
   private boolean shouldDispatchEvent(int eventKeyCode, int eventKeyAction, long time) {
     return KEY_EVENTS_ACTIONS.containsKey(eventKeyCode) && (
       (eventKeyAction == KeyEvent.ACTION_UP) ||
-      (eventKeyAction == KeyEvent.ACTION_DOWN && ReactFeatureFlags.enableKeyDownEvents) ||
+      (eventKeyAction == KeyEvent.ACTION_DOWN && !longPressEventActive && ReactFeatureFlags.enableKeyDownEvents) ||
       (eventKeyAction == KeyEvent.ACTION_DOWN && longPressEventActive && isLongPressEventTime(time))
     );
   }

--- a/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
+++ b/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
@@ -27,7 +27,7 @@ const TVEventHandlerView: () => React.Node = () => {
     const limit = 6;
     const newEventLog = eventLog.slice(0, limit - 1);
     if (isAndroid) {
-      newEventLog.unshift(`type=${eventType}, action=${eventKeyAction || ''}`);
+      newEventLog.unshift(`type=${eventType}, action=${eventKeyAction !== undefined ? eventKeyAction : '' }`);
     } else {
       if (eventType === 'pan') {
         newEventLog.unshift(`type=${eventType}, body=${JSON.stringify(body || {})}`);


### PR DESCRIPTION
Fix #358.

Changes the long press handling to turn on a boolean state when repeated down events are detected from a DPad key, and fire TVRemoteHandler longSelect/Up/Down etc. events while the key is down, instead of waiting for the key up event.

Will do some additional testing of this change before merging.

