### PR TITLE
[ANDROID] fix: recover focus on instant scroll state changes

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -396,6 +396,8 @@ public class ReactViewGroup extends ViewGroup
     Animation animation = child.getAnimation();
     boolean isAnimating = animation != null && !animation.hasEnded();
     if (!intersects && child.getParent() != null && !isAnimating) {
+      recoverFocus(child);
+
       // We can try saving on invalidate call here as the view that we remove is out of visible area
       // therefore invalidation is not necessary.
       super.removeViewsInLayout(idx - clippedSoFar, 1);


### PR DESCRIPTION
## Summary
This PR fixes a focus recovery issue mostly related to ScrollView family components (VirtualizedList, FlatList etc. incl.). It is practically one of the missing pieces of the "focus recovery" work that was introduced [in this PR](https://github.com/react-native-tvos/react-native-tvos/pull/450). 

Focus recovery logic wasn't implemented accounting for `removeClippedSubviews` logic but VirtualizedList family components have it `true` by default on Android. It leads to this weird behavior where the focus gets lost when view clipping logic can't keep up with the scrolling speed. It is easily reproducible by calling `.scrollToIndex({ index: 0, animated: false })` on a list. You can see a slight flicker on Android below, after the scroll-to-top action. It is an artifact of `removeClippedSubviews`.

To fix this issue, we call `recoverFocus` method which parks the focus ~roughly~ until the next frame which gives clipping logic time to decide which items need to be attached or detached. After that, the code flows as expected and moves focus to the first focusable element of the list.

This doesn't cover all cases caused by `removeClippedSubviews` but covers the biggest one in my opinion. We need a bigger effort to cover all cases but we may never run into them due to the nature of TV apps because layouts and interactions are usually quite simplistic. So, until running into a bug, this should be good enough.

<table>
  <tr>
    <th>Android (BEFORE)</th>
    <th>Android (AFTER)</th>
  </tr>
  <tr>
    <td>
    

https://user-images.githubusercontent.com/22980987/225233045-7168132e-6d2e-4ac5-a96e-a56dc8a4548d.mov
</td>
        <td>
        


https://user-images.githubusercontent.com/22980987/225233321-1c04c5b3-2f67-4bb7-af83-5ee7a5e1d254.mov
</td>
  </tr>
</table>
