### PR TITLE
fix: make moveFocusToFirstFocusable work as intended

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -461,8 +461,11 @@ public class ReactViewGroup extends ViewGroup
      * Here we use it for the exact purpose. It mutates/populates the `focusables` array list.
      * Focus direction (FOCUS_DOWN) doesn't matter at all because
      * it's not being used by the underlying implementation.
+     *
+     * Here we intentionally call `super` method to bypass `ReactViewGroup`'s
+     * overriden `addFocusables` logic.
      */
-    viewGroup.addFocusables(focusables, FOCUS_DOWN, FOCUSABLES_ALL);
+    super.addFocusables(focusables, FOCUS_DOWN, FOCUSABLES_ALL);
     /**
      * Depending on ViewGroup's `descendantFocusability` property,
      * the first element can be the ViewGroup itself.


### PR DESCRIPTION
## Summary
The `autoFocus`'s feature one of the primary functionalities is moving focus to the first focusable element on the first visit. I discovered that it was "accidentally" working on most of the cases which made us fail to catch this bug 😄. So, a bug was preventing the `moveFocusToFirstFocusable` function to work properly.

This PR fixes the bug and makes the function move the focus to the first focusable every time.