### PR TITLE
fix: make sure initialScrollIndex is bigger than 0

### DIFF
--- a/Libraries/Lists/VirtualizedList.js
+++ b/Libraries/Lists/VirtualizedList.js
@@ -1768,11 +1768,14 @@ class VirtualizedList extends React.PureComponent<Props, State> {
         // So let's wait until the scroll view metrics have been set up. And until then,
         // we will trust the initialNumToRender suggestion
         if (visibleLength > 0 && contentLength > 0) {
-          // If we have a non-zero initialScrollIndex and run this before we've scrolled,
+          // If we have a positive non-zero initialScrollIndex and run this before we've scrolled,
           // we'll wipe out the initialNumToRender rendered elements starting at initialScrollIndex.
           // So let's wait until we've scrolled the view to the right place. And until then,
           // we will trust the initialScrollIndex suggestion.
-          if (!this.props.initialScrollIndex || this._hasDoneInitialScroll) {
+          if (
+            !(this.props.initialScrollIndex > 0) ||
+            this._hasDoneInitialScroll
+          ) {
             newState = computeWindowedRenderLimits(
               this.props.data,
               this.props.getItemCount,


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When passing `initialScrollIndex` smaller than 0 for example -1 new elements won't render. `_updateCellsToRender` function was checking if `this.props.initialScrollIndex` is truthy and -1 was returning true.

## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://github.com/facebook/react-native/wiki/Changelog
-->

[General] [Fixed] - make sure initialScrollIndex is bigger than 0
