### PR TITLE
fix: restore focus responsibly

### DIFF
--- a/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -513,7 +513,16 @@ public class ReactViewGroup extends ViewGroup
       new Runnable() {
         @Override
         public void run() {
-          moveFocusToFirstFocusable(parentFocusGuide);
+          /**
+           * Focus can move to an another element while waiting for the next frame.
+           * E.g: An element with `hasTVPreferredFocus` can appear.
+           *
+           * We check here to make sure `parentFocusGuide` still remains the focus
+           * before recovering the focus to make sure we don't accidentally override it.
+           */
+          if (parentFocusGuide.isFocused()) {
+            moveFocusToFirstFocusable(parentFocusGuide);
+          }
 
           parentFocusGuide.setFocusable(false);
           parentFocusGuide.mRecoverFocus = false;

--- a/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
+++ b/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
@@ -332,9 +332,54 @@ const RestoreFocusTestList = () => {
           styles.rowTitle,
           {marginLeft: 16 * scale, marginVertical: 16 * scale},
         ]}>
-        Restore Focus Test
+        Restore Focus When All The Items Change Test
       </Text>
       <HList itemCount={10} data={data} onItemPressed={onItemPressed} />
+    </TVFocusGuide>
+  );
+};
+
+const RestoreFocusOnSingleDeletionTestList = () => {
+  const [data, setData] = React.useState(() => generateData(10, false));
+  const itemNeedsToBeFocusedRef = React.useRef<?number>(undefined);
+
+  const onItemPressed = (id, index) => {
+    // We practially set the focus to the previous item here
+    itemNeedsToBeFocusedRef.current = index - 1;
+    setData(d => d.filter(i => i !== id));
+  };
+
+  const renderItem = ({item, index}) => {
+    return (
+      <FocusableBox
+        id={item}
+        width={300 * scale}
+        height={100 * scale}
+        style={styles.mr5}
+        text={item}
+        onPress={() => onItemPressed(item, index)}
+        hasTVPreferredFocus={index === itemNeedsToBeFocusedRef.current}
+      />
+    );
+  };
+
+  return (
+    <TVFocusGuide autoFocus style={styles.mb5}>
+      <Text
+        style={[
+          styles.rowTitle,
+          {marginLeft: 16 * scale, marginVertical: 16 * scale},
+        ]}>
+        Restore Focus To Previous Item on Deletion Test
+      </Text>
+
+      <FlatList
+        data={data}
+        renderItem={renderItem}
+        horizontal
+        contentContainerStyle={styles.hListContainer}
+        keyExtractor={item => item.toString()}
+      />
     </TVFocusGuide>
   );
 };
@@ -382,6 +427,7 @@ const ContentArea = React.forwardRef(
             Welcome to the TVFocusGuide autoFocus example!
           </Text>
           <RestoreFocusTestList />
+          <RestoreFocusOnSingleDeletionTestList />
           <RestoreFocusOnScrollToTopTestList />
           <SlowListFocusTest />
           <Row title="Category Example 1" />


### PR DESCRIPTION
## Summary
The focus recovery feature that is introduced in https://github.com/react-native-tvos/react-native-tvos/pull/450 had a bug. `hasTVPreferredFocus` or `requestTVFocus` commands were getting somewhat ignored during the focus recovery process. The implications were different on Android and tvOS. Set up a new test case to demonstrate the problem.

## Android

On Android, we detect and start a recovery effort when the focus is getting lost. Upon detection, the focus gets "parked" to the closest `TVFocusGuide` and we postpone the recovery process to the end of the main thread to give UI some time to complete rendering before we decide where the focus should go. The problem is, the focus can move to another item during that small timeframe. Like, one of the elements on the UI can request focus.  We weren't checking that case, this PR fixes that.

<table>
  <tr>
    <th>Android (Before)</th>
    <th>Android (After)</th>
  </tr>
  <tr>
    <td>
    

https://user-images.githubusercontent.com/22980987/230523857-386ffa3f-0891-4b67-a621-bd50d8074993.mov
</td>
        <td>
        

https://user-images.githubusercontent.com/22980987/230523870-98bf001c-8205-4afa-a94f-dfa93db5496f.mov
</td>
  </tr>
</table>

## tvOS

On tvOS however, the story is a bit different. The focus recovery logic works totally differently compared to Android. The main problem here wasn't the recovery itself but the way we move focus to the requested element. It was async by default which was leading `hasTVPreferred` prop or `requestTVFocus` actions (focusSelf) to be delayed to the end of the main queue. So, the focus was getting recovered to the initial element since there's no better candidate, and than getting recovered to the actual element afterward. This behavior was leading to a "stutter" as can be clearly seen in the screen recording. Introduced `requestFocusSelf` function which tries to move the focus synchronously by default but fallback to async if necessary.


<table>
  <tr>
    <th>tvOS (Before)</th>
    <th>tvOS (After)</th>
  </tr>
  <tr>
    <td>
    

https://user-images.githubusercontent.com/22980987/230523798-ab6e1303-7bbb-4a18-b985-8166d115a80b.mov
</td>
        <td>
        

https://user-images.githubusercontent.com/22980987/230523834-41feb460-c7fd-43fd-b8e3-481d6525a9f8.mov
</td>
  </tr>
</table>