### PR TITLE
TVTouchable: Skip if findNodeHandle thrown error

### DIFF
--- a/Libraries/Components/Touchable/TVTouchable.js
+++ b/Libraries/Components/Touchable/TVTouchable.js
@@ -36,7 +36,11 @@ export default class TVTouchable {
     this._tvEventHandler = new TVEventHandler();
     this._tvEventHandler.enable(component, (_, tvData) => {
       tvData.dispatchConfig = {};
-      if (ReactNative.findNodeHandle(component) === tvData.tag) {
+      let tag;
+      try {
+        tag = ReactNative.findNodeHandle(component);
+      } catch (e) {}
+      if (tag === tvData.tag) {
         if (tvData.eventType === 'focus') {
           config.onFocus(tvData);
         } else if (tvData.eventType === 'blur') {


### PR DESCRIPTION
## Summary

I got the following error with component used TVTouchable on unmount.

`ExceptionsManager.js:158 Error: Unable to find node on an unmounted component.`

## Changelog

[General] [Fixed] - Skip if findNodeHandle thrown error in TVTouchable

## Test Plan

I'm upgrading react-native-tvos to 0.71 for a project, and it's working fine with this fix (by patch).