### PR TITLE
fix: Remove TVTouchable interference between onPress and unrender

### DIFF
--- a/Libraries/Components/Touchable/TVTouchable.js
+++ b/Libraries/Components/Touchable/TVTouchable.js
@@ -43,11 +43,17 @@ export default class TVTouchable {
           config.onBlur(tvData);
         } else if (tvData.eventType === 'select') {
           if (!config.getDisabled()) {
-            config.onPress(tvData);
+            // The timeout is needed to ensure that destructor is called in the correct order
+            // if the onPress results in an unrender of this component
+            // See https://github.com/react-native-tvos/react-native-tvos/issues/500
+            setTimeout(() => config.onPress(tvData), 0);
           }
         } else if (tvData.eventType === 'longSelect') {
           if (Platform.OS !== 'android' && !config.getDisabled()) {
-            config.onLongPress(tvData);
+            // The timeout is needed to ensure that destructor is called in the correct order
+            // if the onLongPress results in an unrender of this component
+            // See https://github.com/react-native-tvos/react-native-tvos/issues/500
+            setTimeout(() => config.onLongPress(tvData), 0);
           }
         }
       }


### PR DESCRIPTION
Fix issue #500 by adding a flag to the `TVTouchable` class to ensure that its tvEventHandler code is not called after destroy() is called.

## Test Plan

- Test code in #500 should work with no errors.