### PR TITLE
Add FB_SONARKIT_ENABLED setting for React-Core-iOS

### DIFF
--- a/scripts/cocoapods/flipper.rb
+++ b/scripts/cocoapods/flipper.rb
@@ -80,8 +80,8 @@ def flipper_post_install(installer)
             end
         end
 
-        # Enable flipper for React-Core Debug configuration
-        if target.name == 'React-Core'
+        # Enable flipper for React-Core Debug configuration for iOS
+        if target.name == 'React-Core-iOS'
             target.build_configurations.each do |config|
                 if config.debug?
                     config.build_settings['GCC_PREPROCESSOR_DEFINITIONS'] = ['$(inherited)', 'FB_SONARKIT_ENABLED=1']

--- a/template/ios/Podfile
+++ b/template/ios/Podfile
@@ -16,6 +16,17 @@ target 'HelloWorld' do
   # Flags change depending on the env values.
   flags = get_default_flags()
 
+  # If you are using a `react-native-flipper` your iOS build will fail when `NO_FLIPPER=1` is set.
+  # because `react-native-flipper` depends on (FlipperKit,...) that will be excluded
+  #
+  # To fix this you can also exclude `react-native-flipper` using a `react-native.config.js`
+  # ```js
+  # module.exports = {
+  #   dependencies: {
+  #     ...(process.env.NO_FLIPPER ? { 'react-native-flipper': { platforms: { ios: null } } } : {}),
+  # ```
+  flipper_config = ENV['NO_FLIPPER'] == "1" ? FlipperConfiguration.disabled : FlipperConfiguration.enabled
+
   use_react_native!(
     :path => config[:reactNativePath],
     # Hermes is now enabled by default. Disable by setting this flag to false.
@@ -27,7 +38,7 @@ target 'HelloWorld' do
     #
     # Note that if you have use_frameworks! enabled, Flipper will not work and
     # you should disable the next line.
-    # :flipper_configuration => flipper_config,
+    :flipper_configuration => flipper_config,
     # An absolute path to your application root.
     :app_path => "#{Pod::Config.instance.installation_root}/.."
   )


### PR DESCRIPTION
## Summary

Fix #521 for enable Flipper for iOS.

react-native-tvos split `React-Core` to `React-Core-iOS` and `React-Core-tvOS`:

<img width="250" alt="Screenshot 2023-06-14 at 09 23 35" src="https://github.com/react-native-tvos/react-native-tvos/assets/3001525/786eeeae-7397-40c8-a20e-c0930a3c4baa">

I haven't tested with `React-Core-tvOS`, it probably not work.

## Test Plan

Confirmed it works with an initial project on iOS:
<img width="228" alt="Screenshot 2023-06-14 at 09 23 28" src="https://github.com/react-native-tvos/react-native-tvos/assets/3001525/3b0cc54f-5671-4340-9533-56e1256d13df">
