### PR TITLE
Fix/tvfocusguide memory leak

### DIFF
--- a/React/Views/RCTTVView.m
+++ b/React/Views/RCTTVView.m
@@ -244,6 +244,22 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   motionEffectsAdded = NO;
 }
 
+- (void)didMoveToSuperview {
+    [super didMoveToSuperview];
+
+    // There's no way for us to understand if the view is actually getting removed or getting detached.
+    // We play safe here and set the focusGuide's preferredFocusEnvs to an empty array
+    // to break a potential retain cycle (see `handleFocusGuide`).
+    if (self.superview == nil && self.focusGuide != nil) {
+        self.focusGuide.preferredFocusEnvironments = @[];
+    }
+    
+    // We should restore focusGuide's state if the item was only detached and now getting attached again.
+    if (self.superview != nil && self.focusGuide != nil) {
+        [self handleFocusGuide];
+    }
+}
+
 - (BOOL)shouldUpdateFocusInContext:(UIFocusUpdateContext *)context
 {
   // This is  the `trapFocus*` logic that prevents the focus updates if


### PR DESCRIPTION
Fixes #506.

## Summary
We've been using a tiny little unorthodox trick to make `autoFocus` feature work on tvOS platform without intervening with the focus engine. We provide `self` to UIFocusGuide's `preferredFocusEnvironments` on some cases which makes focus engine to looks for a potential next focus inside the `self` container. This way, focus gets redirected to the first focusable element inside the container automatically. You can see it below:

![Screenshot 2023-06-16 at 01 32 21](https://github.com/react-native-tvos/react-native-tvos/assets/22980987/552fbf86-4b96-4cd9-a064-b9cee135a8e7)

It's a neat little trick but it does introduce a retain cycle since `self` holds a reference to `focusGuide` and `focusGuide` holds a reference to `self`.

`preferredFocusEnvironments` has to be an `NSMutableArray` and `NSMutableArray` holds `strong` references to the objects. So it's a bit tricky situation. I tried creating a Proxy etc. but couldn't come up with a clean solution.

To solve the problem, decided to explicitly manage the `focusGuide`'s `preferredFocusEnvironment`  property by detecting UIView's superview changes. There's no easy way to detect if `UIView` is getting removed from the screen completely or just getting detached (e.g for optimization, subview clipping) but we play safe in both cases and set `preferredFocusEnvironments` to an empty array which breaks the retain cycle. This way, garbage collection can work properly and the memory leak problem goes away.

We also check if we should restore the focusGuide's state and do that, just in case.

We should maybe look for a solution without using `self` but it'd require us to rethink the whole approach.