### PR TITLE
Add swift version in tvOS target in template

### DIFF
--- a/template/ios/HelloWorld.xcodeproj/project.pbxproj
+++ b/template/ios/HelloWorld.xcodeproj/project.pbxproj
@@ -795,6 +795,8 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.HelloWorld-tvOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 12.4;
 			};
@@ -825,6 +827,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "org.reactjs.native.example.HelloWorld-tvOS";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SDKROOT = appletvos;
+				SWIFT_VERSION = 5.0;
 				TARGETED_DEVICE_FAMILY = 3;
 				TVOS_DEPLOYMENT_TARGET = 12.4;
 			};


### PR DESCRIPTION
## Summary

When installing a React Native library that contains Swift code to the tvOS target, I get the following error:

```
[!] Unable to determine Swift version for the following pods:

- `MyLib-tvOS` does not specify a Swift version and none of the targets (`MyApp-tvOS`) integrating it have the `SWIFT_VERSION` attribute set. Please contact the author or set the `SWIFT_VERSION` attribute in at least one of the targets that integrate this pod.
```

This happens because the `SWIFT_VERSION` build setting is not set on a newly created tvOS target (but it is in the iOS target).

In this PR I add the same setting to the tvOS target to enable devs to use React Native libraries using Swift code straight away.

I could find a few issues on library repositories from users having this issue:
- https://github.com/dooboolab-community/react-native-iap/issues/2159
- https://github.com/react-native-video/react-native-video/issues/3037
- https://github.com/dotintent/react-native-ble-plx/issues/492

There is a similar PR for the typescript template: https://github.com/react-native-tvos/react-native-template-typescript-tv/pull/6

## Changelog

[tvOS] [Added] - Add swift version in tvOS target in template

## Test Plan

I tested the template locally as explained in the [CLI docs](https://github.com/react-native-community/cli/blob/main/docs/commands.md#--template-string), the installation of a new package does not trigger the error and the app runs.