### PR TITLE
fix: Correct TS type for requestTVFocus()

### DIFF
--- a/types/public/ReactNativeTVTypes.d.ts
+++ b/types/public/ReactNativeTVTypes.d.ts
@@ -31,7 +31,7 @@ declare module 'react-native' {
   nextFocusUp?: number,
   }
 
-  interface View {
+  export interface NativeMethods {
     requestTVFocus(): void;
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

The `requestTVFocus()` method was overriding the `View` interface in `ReactNativeTVTypes.d.ts`, leading to an error when executing `yarn tsc` in an app built with React Native TV. This change aligns the method type with the other types in `ReactNativeTypes.d.ts`.

Fixes #524 .

Changelog: [General][Fixed] Correct TS type for requestTVFocus()

## Test Plan

Tested in an app to ensure that `requestTVFocus()` and other similar methods (e.g. the `focus()` method of `TextInput`) are now all recognized correctly as types by the Typescript compiler.
