### PR TITLE
fix: method requestTVFocus is missing after remote-tracking v0.71.6 merge

### DIFF
--- a/Libraries/Components/View/View.js
+++ b/Libraries/Components/View/View.js
@@ -161,7 +161,7 @@ const View: React.AbstractComponent<
           nativeID={id ?? nativeID}
           style={style}
           pointerEvents={newPointerEvents}
-          ref={forwardedRef}
+          ref={_setNativeRef}
         />
       </TextAncestor.Provider>
     );


### PR DESCRIPTION
## Summary

After merging the remote-tracking [commit](https://github.com/react-native-tvos/react-native-tvos/commit/76baca940cb92e08c8983ebd2825c3bf00599cdf), the `requestTVFocus()` method is missing from the referenced object. This issue occurred because the pure `forwardRef` object was passed to the View's `ref` prop instead of using `_setNativeRef`, as defined in commit [#471](https://github.com/react-native-tvos/react-native-tvos/pull/471).

## Changelog

[General] [Fixed] - Reattached `requestTVFocus()` method to View reference object.

## Test Plan

Test the **Focus To Side Menu** button in [TVFocusGuideAutoFocusExample](https://github.com/react-native-tvos/react-native-tvos/blob/tvos-v0.71.11/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js) to ensure it works without any exceptions.
