### PR TITLE
Move dismiss/minimize to top of LogBox screen for TV

### DIFF
--- a/Libraries/LogBox/UI/LogBoxInspector.js
+++ b/Libraries/LogBox/UI/LogBoxInspector.js
@@ -74,12 +74,13 @@ function LogBoxInspector(props: Props): React.Node {
         total={logs.length}
         level={log.level}
       />
-      <LogBoxInspectorBody log={log} onRetry={_handleRetry} />
+      {/* In the TV repo, place the footer above the body for easier navigation */}
       <LogBoxInspectorFooter
         onDismiss={props.onDismiss}
         onMinimize={props.onMinimize}
         level={log.level}
       />
+      <LogBoxInspectorBody log={log} onRetry={_handleRetry} />
     </View>
   );
 }


### PR DESCRIPTION
Per discussion, move the footer with "Dismiss" and "Minimize" to the top, so TV user does not have to navigate through all the stack frames to reach these buttons.