### PR TITLE
feat: add showsScrollIndex prop to ScrollView

### DIFF
--- a/Libraries/Lists/VirtualizedList.d.ts
+++ b/Libraries/Lists/VirtualizedList.d.ts
@@ -344,4 +344,10 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
   windowSize?: number | undefined;
 
   CellRendererComponent?: React.ComponentType<any> | undefined;
+
+  /**
+   * (TvOS only)
+   * Defines if UIScrollView index should be shown when fast scrolling.
+   */
+  showsScrollIndex?: boolean;
 }

--- a/Libraries/Lists/VirtualizedListProps.js
+++ b/Libraries/Lists/VirtualizedListProps.js
@@ -258,6 +258,11 @@ type OptionalProps = {|
    * The legacy implementation is no longer supported.
    */
   legacyImplementation?: empty,
+  /**
+   * (TvOS only)
+   * Defines if UIScrollView index should be shown when fast scrolling.
+   */
+  showsScrollIndex?: ?boolean,
 |};
 
 export type Props = {|

--- a/React/Views/ScrollView/RCTScrollView.h
+++ b/React/Views/ScrollView/RCTScrollView.h
@@ -56,6 +56,7 @@
 @property (nonatomic, assign) BOOL snapToEnd;
 @property (nonatomic, copy) NSString *snapToAlignment;
 @property (nonatomic, assign) BOOL inverted;
+@property (nonatomic, assign) BOOL showsScrollIndex;
 
 // NOTE: currently these event props are only declared so we can export the
 // event names to JS - we don't call the blocks directly because scroll events

--- a/React/Views/ScrollView/RCTScrollView.m
+++ b/React/Views/ScrollView/RCTScrollView.m
@@ -477,6 +477,18 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
   if ([changedProps containsObject:@"contentSize"]) {
     [self updateContentSizeIfNeeded];
   }
+  if ([changedProps containsObject:@"showsScrollIndex"]) {
+    [self updateScrollIndex];
+  }
+}
+
+- (void)updateScrollIndex
+{
+  if (!self.showsScrollIndex) {
+      self.scrollView.indexDisplayMode = UIScrollViewIndexDisplayModeAlwaysHidden;
+  } else {
+      self.scrollView.indexDisplayMode = UIScrollViewIndexDisplayModeAutomatic;
+  }
 }
 
 - (BOOL)centerContent

--- a/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/React/Views/ScrollView/RCTScrollViewManager.m
@@ -100,6 +100,7 @@ RCT_EXPORT_VIEW_PROPERTY(onScrollEndDrag, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollBegin, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollEnd, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(showsScrollIndex, BOOL)
 #if defined(__IPHONE_OS_VERSION_MAX_ALLOWED) && __IPHONE_OS_VERSION_MAX_ALLOWED >= 130000 /* __IPHONE_13_0 */
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustsScrollIndicatorInsets, BOOL)
 #endif

--- a/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-basic.js
@@ -239,6 +239,7 @@ class FlatListExample extends React.PureComponent<Props, State> {
             getItemLayout={
               this.state.fixedHeight ? this._getItemLayout : undefined
             }
+            showsScrollIndex={false}
             accessibilityRole="list"
             horizontal={this.state.horizontal}
             inverted={this.state.inverted}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

Add new prop to ScrollView that allows to hide the fast scrolling indicator for tvOS. Reference: https://developer.apple.com/documentation/uikit/uiscrollviewindexdisplaymode?language=objc

Before (default behaviour): 

https://github.com/react-native-tvos/react-native-tvos/assets/52801365/319898ed-b874-4822-a8bb-b4165e085130



After: 

https://github.com/react-native-tvos/react-native-tvos/assets/52801365/51e5fc82-e209-41ff-9d97-b2a4f027ad56



## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry. For an example, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[tvOS] [Added] - new prop for controlling scrollIndex behaviour

## Test Plan

Add `showsScrollIndex` prop to flat list and check if the fast scrolling indicator shows up.
