### PR TITLE
Pressable should honor disabled prop (#550)

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -305,7 +305,8 @@ function Pressable(props: Props, forwardedRef): React.Node {
     accessibilityLiveRegion,
     accessibilityLabel,
     accessibilityState: _accessibilityState,
-    focusable: focusable !== false,
+    focusable:
+      focusable !== false && disabled !== true && ariaDisabled !== true,
     isTVSelectable: isTVSelectable !== false && accessible !== false,
     accessibilityValue,
     hitSlop,
@@ -380,7 +381,7 @@ function Pressable(props: Props, forwardedRef): React.Node {
         if (evt?.eventType === 'focus') {
           setFocused(true);
           onFocus && onFocus(evt);
-        // $FlowFixMe[prop-missing]
+          // $FlowFixMe[prop-missing]
         } else if (evt.eventType === 'blur') {
           onBlur && onBlur(evt);
           setFocused(false);
@@ -391,12 +392,12 @@ function Pressable(props: Props, forwardedRef): React.Node {
       if (Platform.isTVOS) {
         // $FlowFixMe[prop-missing]
         if (focused && evt.eventType === 'select') {
-        // $FlowFixMe[incompatible-exact]
+          // $FlowFixMe[incompatible-exact]
           onPress && onPress(evt);
         }
         // $FlowFixMe[prop-missing]
         if (focused && evt.eventType === 'longSelect') {
-        // $FlowFixMe[incompatible-exact]
+          // $FlowFixMe[incompatible-exact]
           onLongPress && onLongPress(evt);
         }
       }
@@ -426,7 +427,12 @@ function Pressable(props: Props, forwardedRef): React.Node {
       nextFocusLeft={tagForComponentOrHandle(props.nextFocusLeft)}
       nextFocusRight={tagForComponentOrHandle(props.nextFocusRight)}
       nextFocusUp={tagForComponentOrHandle(props.nextFocusUp)}
-      isTVSelectable={isTVSelectable !== false && accessible !== false}
+      isTVSelectable={
+        isTVSelectable !== false &&
+        accessible !== false &&
+        disabled !== true &&
+        ariaDisabled !== true
+      }
       style={typeof style === 'function' ? style({pressed, focused}) : style}
       tvParallaxProperties={tvParallaxProperties}
       collapsable={false}>

--- a/packages/rn-tester/js/components/RNTesterNavbar.js
+++ b/packages/rn-tester/js/components/RNTesterNavbar.js
@@ -156,13 +156,11 @@ const RNTesterNavbar = ({
           handleNavBarPress={handleNavBarPress}
           theme={theme}
         />
-        {Platform.isTV ? <View style={{flex: 1}} />  : (
-          <BookmarkTab
-            isBookmarkActive={isBookmarkActive}
-            handleNavBarPress={handleNavBarPress}
-            theme={theme}
-          />
-        )}
+        <BookmarkTab
+          isBookmarkActive={isBookmarkActive}
+          handleNavBarPress={handleNavBarPress}
+          theme={theme}
+        />
         <APITab
           isAPIActive={isAPIActive}
           handleNavBarPress={handleNavBarPress}

--- a/packages/rn-tester/js/examples/Pressable/PressableExample.js
+++ b/packages/rn-tester/js/examples/Pressable/PressableExample.js
@@ -47,8 +47,10 @@ function ContentPress() {
           onPress={() => {
             setTimesPressed(current => current + 1);
           }}>
-          {({pressed}) => (
-            <Text style={styles.text}>{pressed ? 'Pressed!' : 'Press Me'}</Text>
+          {({pressed, focused}) => (
+            <Text style={[styles.text, {opacity: focused ? 0.5 : 1.0}]}>
+              {pressed ? 'Pressed!' : 'Press Me'}
+            </Text>
           )}
         </Pressable>
       </View>
@@ -142,7 +144,10 @@ function PressableFeedbackEvents() {
     <View testID="pressable_feedback_events">
       <View style={[styles.row, styles.centered]}>
         <Pressable
-          style={styles.wrapper}
+          style={({focused}) => [
+            styles.wrapper,
+            {opacity: focused ? 0.5 : 1.0},
+          ]}
           testID="pressable_feedback_events_button"
           accessibilityLabel="pressable feedback events"
           accessibilityRole="button"
@@ -180,7 +185,10 @@ function PressableDelayEvents() {
     <View testID="pressable_delay_events">
       <View style={[styles.row, styles.centered]}>
         <Pressable
-          style={styles.wrapper}
+          style={({focused}) => [
+            styles.wrapper,
+            {opacity: focused ? 0.5 : 1.0},
+          ]}
           testID="pressable_delay_events_button"
           onPress={() => appendEvent('press')}
           onPressIn={() => appendEvent('pressIn')}
@@ -241,7 +249,10 @@ function PressableHitSlop() {
       <View style={[styles.row, styles.centered]}>
         <Pressable
           onPress={() => setTimesPressed(num => num + 1)}
-          style={styles.hitSlopWrapper}
+          style={({focused}) => [
+            styles.hitSlopWrapper,
+            {opacity: focused ? 0.5 : 1.0},
+          ]}
           hitSlop={{top: 30, bottom: 30, left: 60, right: 60}}
           testID="pressable_hit_slop_button">
           <Text style={styles.hitSlopButton}>Press Outside This View</Text>
@@ -283,7 +294,14 @@ function PressableNativeMethods() {
 function PressableDisabled() {
   return (
     <>
-      <Pressable disabled={true} style={[styles.row, styles.block]}>
+      <Pressable
+        disabled={true}
+        onPress={() => console.warn('Disabled pressable was pressed!')}
+        style={({pressed, focused}) => [
+          {opacity: pressed || focused ? 0.5 : 1},
+          styles.row,
+          styles.block,
+        ]}>
         <Text style={styles.disabledButton}>Disabled Pressable</Text>
       </Pressable>
 
@@ -293,8 +311,8 @@ function PressableDisabled() {
           enabled: true,
           pressMagnification: 1.1,
         }}
-        style={({pressed}) => [
-          {opacity: pressed ? 0.5 : 1},
+        style={({pressed, focused}) => [
+          {opacity: pressed || focused ? 0.5 : 1},
           styles.row,
           styles.block,
         ]}>
@@ -316,7 +334,9 @@ function PressableHoverStyle() {
           styles.wrapperCustom,
         ]}
         onHoverIn={() => setHovered(true)}
-        onHoverOut={() => setHovered(false)}>
+        onHoverOut={() => setHovered(false)}
+        onFocus={() => setHovered(true)}
+        onBlur={() => setHovered(false)}>
         <Text style={styles.text}>Hover Me</Text>
       </Pressable>
     </View>


### PR DESCRIPTION
`Touchable` components are honoring the `disabled` prop and not allowing selection or focus when disabled. However, `Pressable` is ignoring this prop for TV apps.

Made changes to set `isTVSelectable` and `focusable` to false when `disabled` is true.

## Test Plan

Added a `console.warn()` to `PressableExample` in `RNTester` if the example disabled component is pressed or selected. Made other improvements to `PressableExample` to make focus changes visible in the example components.