### PR TITLE
TV patch 25: template and README fixups

### DIFF
--- a/packages/react-native/template/package.json
+++ b/packages/react-native/template/package.json
@@ -3,10 +3,11 @@
   "version": "0.0.1",
   "private": true,
   "scripts": {
-    "android": "react-native run-android",
-    "ios": "react-native run-ios",
+    "android": "expo run:android",
+    "ios": "expo run:ios",
+    "tvos": "expo run:ios --scheme HelloWorld-tvOS --device \"Apple TV\"",
     "lint": "eslint .",
-    "start": "react-native start",
+    "start": "expo start",
     "test": "jest"
   },
   "dependencies": {


### PR DESCRIPTION
- Align the template scripts with `react-native-template-typescript-tv` and fully use Expo CLI
- README improvements
  - Discuss both TV platforms (less Apple TV centric)
  - Reorganization
  - Remove outdated wording 
