### PR TITLE
Fix/okwasniewski/text input focus

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -368,13 +368,7 @@ public class ReactEditText extends AppCompatEditText
 
   @Override
   public boolean requestFocus(int direction, Rect previouslyFocusedRect) {
-    // This is a no-op so that when the OS calls requestFocus(), nothing will happen. ReactEditText
-    // is a controlled component, which means its focus is controlled by JS, with two exceptions:
-    // autofocus when it's attached to the window, and responding to accessibility events. In both
-    // of these cases, we call requestFocusInternal() directly.
-    // Always return true if we are already focused. This is used by android in certain places,
-    // such as text selection.
-    return isFocused();
+    return requestFocusInternal();
   }
 
   private boolean requestFocusInternal() {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -147,6 +147,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
   private static final int BLUR_TEXT_INPUT = 2;
   private static final int SET_MOST_RECENT_EVENT_COUNT = 3;
   private static final int SET_TEXT_AND_SELECTION = 4;
+  private static final int REQUEST_TV_FOCUS = 5;
 
   private static final int INPUT_TYPE_KEYBOARD_NUMBER_PAD = InputType.TYPE_CLASS_NUMBER;
   private static final int INPUT_TYPE_KEYBOARD_DECIMAL_PAD =
@@ -280,7 +281,7 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
 
   @Override
   public @Nullable Map<String, Integer> getCommandsMap() {
-    return MapBuilder.of("focusTextInput", FOCUS_TEXT_INPUT, "blurTextInput", BLUR_TEXT_INPUT);
+    return MapBuilder.of("focusTextInput", FOCUS_TEXT_INPUT, "blurTextInput", BLUR_TEXT_INPUT, "requestTVFocus", REQUEST_TV_FOCUS);
   }
 
   @Override
@@ -288,6 +289,9 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
       ReactEditText reactEditText, int commandId, @Nullable ReadableArray args) {
     switch (commandId) {
       case FOCUS_TEXT_INPUT:
+        this.receiveCommand(reactEditText, "focus", args);
+        break;
+      case REQUEST_TV_FOCUS:
         this.receiveCommand(reactEditText, "focus", args);
         break;
       case BLUR_TEXT_INPUT:

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -58,6 +58,7 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
   private static final int CMD_HOTSPOT_UPDATE = 1;
   private static final int CMD_SET_PRESSED = 2;
   private static final int CMD_SET_DESTINATIONS = 3;
+  private static final int CMD_REQUEST_TV_FOCUS = 4;
   private static final String HOTSPOT_UPDATE_KEY = "hotspotUpdate";
 
   public ReactViewManager() {
@@ -336,7 +337,7 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
 
   @Override
   public Map<String, Integer> getCommandsMap() {
-    return MapBuilder.of(HOTSPOT_UPDATE_KEY, CMD_HOTSPOT_UPDATE, "setPressed", CMD_SET_PRESSED, "setDestinations", CMD_SET_DESTINATIONS);
+    return MapBuilder.of(HOTSPOT_UPDATE_KEY, CMD_HOTSPOT_UPDATE, "setPressed", CMD_SET_PRESSED, "setDestinations", CMD_SET_DESTINATIONS, "requestTVFocus", CMD_REQUEST_TV_FOCUS);
   }
 
   @Override
@@ -357,6 +358,9 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
         handleSetDestinations(root, args);
         break;
       }
+      case CMD_REQUEST_TV_FOCUS:
+        root.requestFocus();
+        break;
     }
   }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

Hey! 

This PR fixes issues with `TextInput` focus. Previously TV platform was using the implementation that was used for mobiles. 

The main difference is that now when `requestFocus()` method is called we actually set focus to the TextEdit component instead of returning whether component is focused. 

This PR also aligns commands that those views can receive, now TextInput can also receive `requestTVFocus` (a command that's used to focus normal views). As a side note I've also added `requestTVFocus` for the old arch for ViewGroup. 

Before: 

https://github.com/react-native-tvos/react-native-tvos/assets/52801365/c7225740-f1cd-4f76-8213-90bedbaf0ad1



After: 

https://github.com/react-native-tvos/react-native-tvos/assets/52801365/4980ada7-3973-4056-b7e0-a1e283fa8d88


## Changelog

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [FIXED] - TextInput is now focusable

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - TextInput is now focusable

## Test Plan

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Launch RN tester example and check that you can navigate through TextInputs without issues. 