### PR TITLE
Fix parallax tilt on X axis being reversed of tvOS default

### DIFF
--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -200,12 +200,12 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   // CATransform3D value for minimumRelativeValue
   CATransform3D transMinimumTiltAboutX = CATransform3DIdentity;
   transMinimumTiltAboutX.m34 = 1.0 / 500;
-  transMinimumTiltAboutX = CATransform3DRotate(transMinimumTiltAboutX, tiltAngle * -1.0, 1, 0, 0);
+  transMinimumTiltAboutX = CATransform3DRotate(transMinimumTiltAboutX, tiltAngle, 1, 0, 0);
   
   // CATransform3D value for minimumRelativeValue
   CATransform3D transMaximumTiltAboutX = CATransform3DIdentity;
   transMaximumTiltAboutX.m34 = 1.0 / 500;
-  transMaximumTiltAboutX = CATransform3DRotate(transMaximumTiltAboutX, tiltAngle, 1, 0, 0);
+  transMaximumTiltAboutX = CATransform3DRotate(transMaximumTiltAboutX, tiltAngle * -1.0, 1, 0, 0);
   
   // Set the transform property boundaries for the interpolation
   yTilt.minimumRelativeValue = [NSValue valueWithCATransform3D:transMinimumTiltAboutX];


### PR DESCRIPTION
## Summary

When using the Apple TV remote, swiping down on an interactive button triggers the parallax. But the parallax is reversed for the vertical swipe. Horizontal is correct.

When moving down, the bottom part of the button should come forward. But in the implementation of `react-native-tvos` is reversed and the bottom part of a button is moved backwards.

Correct behavior when swiping down:

https://github.com/react-native-tvos/react-native-tvos/assets/38136/b4a0cb41-ba9e-4d8e-8100-367848d7315f

## Changelog

Inverse the X tilting for the added parallax effect

[FIXED] - Pick one each for the category and type tags (fixes #593)
