### PR TITLE
fix: Disable phone touch handlers for Apple TV

### DIFF
--- a/packages/react-native/React-Core.podspec
+++ b/packages/react-native/React-Core.podspec
@@ -100,13 +100,15 @@ Pod::Spec.new do |s|
       exclude_files = exclude_files.append("React/CxxBridge/JSCExecutorFactory.{h,mm}")
     end
     ss.exclude_files = exclude_files
-    ss.ios.exclude_files      = "React/**/RCTTV*.*"
+    ss.ios.exclude_files      = "React/**/RCTTV*.*",
+                                "React/Base/RCTTouchHandlerTV.m"
     ss.tvos.exclude_files     = "React/Modules/RCTClipboard*",
                                 "React/Views/RCTDatePicker*",
                                 "React/Views/RCTPicker*",
                                 "React/Views/RefreshControl/*",
                                 "React/Views/RCTSlider*",
-                                "React/Views/RCTSwitch*"
+                                "React/Views/RCTSwitch*",
+                                "React/Base/RCTTouchHandler.m"
     ss.private_header_files   = "React/Cxx*/*.h"
   end
 

--- a/packages/react-native/React/Base/RCTTouchHandler.m
+++ b/packages/react-native/React/Base/RCTTouchHandler.m
@@ -42,6 +42,20 @@
   uint16_t _coalescingKey;
 }
 
+#if TARGET_OS_TV
+
+- (instancetype)initWithBridge:(RCTBridge *)bridge
+{
+  return [super initWithTarget:nil action:NULL];
+}
+
+RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)action)
+
+- (void)attachToView:(UIView *)view {}
+- (void)detachFromView:(UIView *)view {}
+
+#else // TARGET_OS_TV
+
 - (instancetype)initWithBridge:(RCTBridge *)bridge
 {
   RCTAssertParam(bridge);
@@ -373,5 +387,7 @@ static BOOL RCTAnyTouchesChanged(NSSet<UITouch *> *touches)
   // Same condition for `failure of` as for `be prevented by`.
   return [self canBePreventedByGestureRecognizer:otherGestureRecognizer];
 }
+
+#endif // TARGET_OS_TV
 
 @end

--- a/packages/react-native/React/Base/RCTTouchHandler.m
+++ b/packages/react-native/React/Base/RCTTouchHandler.m
@@ -42,20 +42,6 @@
   uint16_t _coalescingKey;
 }
 
-#if TARGET_OS_TV
-
-- (instancetype)initWithBridge:(RCTBridge *)bridge
-{
-  return [super initWithTarget:nil action:NULL];
-}
-
-RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)action)
-
-- (void)attachToView:(UIView *)view {}
-- (void)detachFromView:(UIView *)view {}
-
-#else // TARGET_OS_TV
-
 - (instancetype)initWithBridge:(RCTBridge *)bridge
 {
   RCTAssertParam(bridge);
@@ -387,7 +373,5 @@ static BOOL RCTAnyTouchesChanged(NSSet<UITouch *> *touches)
   // Same condition for `failure of` as for `be prevented by`.
   return [self canBePreventedByGestureRecognizer:otherGestureRecognizer];
 }
-
-#endif // TARGET_OS_TV
 
 @end

--- a/packages/react-native/React/Base/RCTTouchHandlerTV.m
+++ b/packages/react-native/React/Base/RCTTouchHandlerTV.m
@@ -1,0 +1,35 @@
+#import <Foundation/Foundation.h>
+
+#import "RCTTouchHandler.h"
+
+#import "RCTAssert.h"
+#import "RCTBridge.h"
+#import "RCTEventDispatcherProtocol.h"
+#import "RCTLog.h"
+#import "RCTSurfaceView.h"
+#import "RCTTouchEvent.h"
+#import "RCTUIManager.h"
+#import "RCTUtils.h"
+#import "UIView+React.h"
+
+@interface RCTTouchHandler () <UIGestureRecognizerDelegate>
+@end
+
+// The touch handler should not be active on tvOS, so tvOS uses this
+// stub implementation that does nothing.
+// Fixes https://github.com/react-native-tvos/react-native-tvos/issues/595
+//
+@implementation RCTTouchHandler
+
+- (instancetype)initWithBridge:(RCTBridge *)bridge
+{
+  return [super initWithTarget:nil action:NULL];
+}
+
+RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)action)
+
+- (void)attachToView:(UIView *)view {}
+- (void)detachFromView:(UIView *)view {}
+- (void)cancel {}
+
+@end

--- a/packages/react-native/React/Fabric/RCTSurfacePointerHandlerTV.mm
+++ b/packages/react-native/React/Fabric/RCTSurfacePointerHandlerTV.mm
@@ -1,0 +1,37 @@
+/*
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTSurfacePointerHandler.h"
+
+#import <React/RCTIdentifierPool.h>
+#import <React/RCTReactTaggedView.h>
+#import <React/RCTUtils.h>
+#import <React/RCTViewComponentView.h>
+
+#import "RCTConversions.h"
+#import "RCTTouchableComponentViewProtocol.h"
+
+@interface RCTSurfacePointerHandler () <UIGestureRecognizerDelegate>
+@end
+
+// The touch handler should not be active on tvOS, so tvOS uses this
+// stub implementation that does nothing.
+// Fixes https://github.com/react-native-tvos/react-native-tvos/issues/595
+//
+@implementation RCTSurfacePointerHandler
+
+- (instancetype)init
+{
+  return [super initWithTarget:nil action:nil];
+}
+
+RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)action)
+
+- (void)attachToView:(UIView *)view {}
+- (void)detachFromView:(UIView *)view {}
+
+@end

--- a/packages/react-native/React/Fabric/RCTSurfaceTouchHandlerTV.mm
+++ b/packages/react-native/React/Fabric/RCTSurfaceTouchHandlerTV.mm
@@ -1,0 +1,30 @@
+#import "RCTSurfaceTouchHandler.h"
+
+#import <React/RCTIdentifierPool.h>
+#import <React/RCTUtils.h>
+#import <React/RCTViewComponentView.h>
+
+#import "RCTConversions.h"
+#import "RCTSurfacePointerHandler.h"
+#import "RCTTouchableComponentViewProtocol.h"
+
+// The touch handler should not be active on tvOS, so tvOS uses this
+// stub implementation that does nothing.
+// Fixes https://github.com/react-native-tvos/react-native-tvos/issues/595
+//
+@interface RCTSurfaceTouchHandler () <UIGestureRecognizerDelegate>
+@end
+
+@implementation RCTSurfaceTouchHandler
+
+- (instancetype)init
+{
+  return [super initWithTarget:nil action:nil];
+}
+
+RCT_NOT_IMPLEMENTED(-(instancetype)initWithTarget : (id)target action : (SEL)action)
+
+- (void)attachToView:(UIView *)view {}
+- (void)detachFromView:(UIView *)view {}
+
+@end

--- a/packages/react-native/React/React-RCTFabric.podspec
+++ b/packages/react-native/React/React-RCTFabric.podspec
@@ -56,7 +56,11 @@ Pod::Spec.new do |s|
   s.source                 = source
   s.source_files           = "Fabric/**/*.{c,h,m,mm,S,cpp}"
   s.exclude_files          = "**/tests/*",
-                             "**/android/*",
+                             "**/android/*"
+  s.tvos.exclude_files     = "Fabric/**/RCTSurfaceTouchHandler.mm",
+                             "Fabric/**/RCTSurfacePointerHandler.mm"
+  s.ios.exclude_files      = "Fabric/**/RCTSurfaceTouchHandlerTV.mm",
+                             "Fabric/**/RCTSurfacePointerHandlerTV.mm"
   s.compiler_flags         = folly_compiler_flags + ' ' + boost_compiler_flags
   s.header_dir             = "React"
   s.module_name            = "RCTFabric"


### PR DESCRIPTION
## Summary:

- They are not needed for TV
- Fixes #595

The solution is to add TV-specific stub implementations of `RCTTouchHandler`, `RCTSurfacePointerHandler`, and `RCTSurfaceTouchHandler`, and modify podspecs to include the right implementations for phone and TV targets.

## Changelog:

[iOS] [Fix] Disable phone touch handlers

## Test Plan:

- Test release build on real tvOS 17.0 or greater device
