### PR TITLE
fix: wrong import made for tabBarIOS

### DIFF
--- a/packages/react-native/Libraries/Components/TabBarIOS/RCTTabBarItemNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TabBarIOS/RCTTabBarItemNativeComponent.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent').default;
 
 import type {ViewProps} from '../View/ViewPropTypes';
 import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';

--- a/packages/react-native/Libraries/Components/TabBarIOS/RCTTabBarNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TabBarIOS/RCTTabBarNativeComponent.js
@@ -10,7 +10,7 @@
 
 'use strict';
 
-const requireNativeComponent = require('../../ReactNative/requireNativeComponent');
+const requireNativeComponent = require('../../ReactNative/requireNativeComponent').default;
 
 import type {ViewProps} from '../View/ViewPropTypes';
 import type {ColorValue} from '../../StyleSheet/StyleSheetTypes';


### PR DESCRIPTION
## Summary:

Fixed imports in couple of files - 

1. RCTTabBarItemNativeComponent.js
2. RCTTabBarNativeComponent.js

## Changelog:

Make use of default exports for requireNativeComponent

Pick one each for the category and type tags:

[INTERNAL] [FIXED] - Fixed import issues in ` RCTTabBarItemNativeComponent.js` and `RCTTabBarNativeComponent.js`



## Test Plan:

Tested it in tvOS
