### PR TITLE
fix: add TV event handler to Android Modal component

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.java
@@ -89,6 +89,8 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
   private boolean mPropertyRequiresNewDialog;
   private @Nullable DialogInterface.OnShowListener mOnShowListener;
   private @Nullable OnRequestCloseListener mOnRequestCloseListener;
+  private final ReactAndroidHWInputDeviceHelper mAndroidHWInputDeviceHelper =
+    new ReactAndroidHWInputDeviceHelper();
 
   public ReactModalHostView(ThemedReactContext context) {
     super(context);
@@ -300,6 +302,9 @@ public class ReactModalHostView extends ViewGroup implements LifecycleEventListe
         new DialogInterface.OnKeyListener() {
           @Override
           public boolean onKey(DialogInterface dialog, int keyCode, KeyEvent event) {
+            // Modal needs to send the key event to its own TV event handler
+            // https://github.com/react-native-tvos/react-native-tvos/issues/609
+            mAndroidHWInputDeviceHelper.handleKeyEvent(event, mHostView.mReactContext);
             if (event.getAction() == KeyEvent.ACTION_UP) {
               // We need to stop the BACK button and ESCAPE key from closing the dialog by default
               // so we capture that event and instead inform JS so that it can make the decision as

--- a/packages/rn-tester/js/examples/Modal/ModalOnShow.js
+++ b/packages/rn-tester/js/examples/Modal/ModalOnShow.js
@@ -9,8 +9,29 @@
  */
 
 import * as React from 'react';
-import {Modal, Pressable, StyleSheet, Text, useTVEventHandler, View} from 'react-native';
+import {
+  Modal,
+  Platform,
+  Pressable,
+  StyleSheet,
+  Text,
+  useTVEventHandler,
+  View,
+} from 'react-native';
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
+function TVEventView(): React.Node {
+  const [lastEventType, setLastEventType] = React.useState('');
+  const myTVEventHandler = evt => {
+    setLastEventType(evt.eventType);
+  };
+  useTVEventHandler(myTVEventHandler);
+  if (Platform.isTV) {
+    return <Text>TVEvent: {lastEventType}</Text>;
+  } else {
+    return <View />;
+  }
+}
 
 function ModalOnShowOnDismiss(): React.Node {
   const [modalShowComponent, setModalShowComponent] = React.useState(true);
@@ -44,6 +65,7 @@ function ModalOnShowOnDismiss(): React.Node {
           }}>
           <View style={[styles.centeredView, styles.modalBackdrop]}>
             <View style={styles.modalView}>
+              <TVEventView />
               <Text testID="modal-on-show-count">
                 onShow is called {onShowCount} times
               </Text>


### PR DESCRIPTION
## Summary:

On Android, modal views were not sending hardware key events to any TV event handler.

Solution: modal views have their own TV event handler instance to handle their key events.

Fixes #609 

## Changelog:

[Android][Fixed] add TV event handler to Android Modal component

## Test Plan:

Code is added to the Modal example in RNTester to show that the fix works. Without the fix, only focus and blur events are seen in the modal example.
