### PR TITLE
fix: [Apple TV] enable long press for Touchable/Pressable

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -51,7 +51,8 @@ using namespace facebook::react;
   BOOL _removeClippedSubviews;
   NSMutableArray<UIView *> *_reactSubviews;
   BOOL _motionEffectsAdded;
-    UITapGestureRecognizer *_selectRecognizer;
+  UITapGestureRecognizer *_selectRecognizer;
+  UILongPressGestureRecognizer * _longSelectRecognizer;
   NSSet<NSString *> *_Nullable _propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN;
   ParallaxProperties _tvParallaxProperties;
   BOOL _hasTVPreferredFocus;
@@ -249,6 +250,11 @@ using namespace facebook::react;
     [self sendNotificationWithEventType:@"select"];
 }
 
+- (void)sendLongSelectNotification:(UIGestureRecognizer *)recognizer
+{
+  [self sendNotificationWithEventType:@"longSelect"];
+}
+
 - (void)sendNotificationWithEventType:(NSString * __nonnull)eventType
 {
   [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
@@ -290,6 +296,11 @@ using namespace facebook::react;
   } else {
     [self sendSelectNotification:r];
   }
+}
+
+- (void)handleLongSelect:(__unused UIGestureRecognizer *)r
+{
+  [self sendLongSelectNotification:r];
 }
 
 - (void)addParallaxMotionEffects
@@ -887,10 +898,20 @@ using namespace facebook::react;
                                                                                    action:@selector(handleSelect:)];
       recognizer.allowedPressTypes = @[ @(UIPressTypeSelect) ];
       _selectRecognizer = recognizer;
+
+      UILongPressGestureRecognizer *longRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongSelect:)];
+      recognizer.allowedPressTypes = @[ @(UIPressTypeSelect) ];
+      [self addGestureRecognizer:longRecognizer];
+      _longSelectRecognizer = longRecognizer;
+
       [self addGestureRecognizer:_selectRecognizer];
+      [self addGestureRecognizer:_longSelectRecognizer];
     } else {
       if (_selectRecognizer) {
         [self removeGestureRecognizer:_selectRecognizer];
+      }
+      if (_longSelectRecognizer) {
+        [self removeGestureRecognizer:_longSelectRecognizer];
       }
     }
   }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -298,9 +298,11 @@ using namespace facebook::react;
   }
 }
 
-- (void)handleLongSelect:(__unused UIGestureRecognizer *)r
+- (void)handleLongSelect:(UIGestureRecognizer *)r
 {
-  [self sendLongSelectNotification:r];
+  if (r.state == UIGestureRecognizerStateBegan) {
+    [self sendLongSelectNotification:r];
+  }
 }
 
 - (void)addParallaxMotionEffects

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -22,6 +22,7 @@
 @implementation RCTTVView {
   __weak RCTBridge *_bridge;
   UITapGestureRecognizer *_selectRecognizer;
+  UILongPressGestureRecognizer * _longSelectRecognizer;
   BOOL motionEffectsAdded;
   NSArray* focusDestinations;
   id<UIFocusItem> previouslyFocusedItem;
@@ -79,10 +80,20 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
                                                                                  action:@selector(handleSelect:)];
     recognizer.allowedPressTypes = @[ @(UIPressTypeSelect) ];
     _selectRecognizer = recognizer;
+
+    UILongPressGestureRecognizer *longRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongSelect:)];
+    recognizer.allowedPressTypes = @[ @(UIPressTypeSelect) ];
+    [self addGestureRecognizer:longRecognizer];
+    _longSelectRecognizer = longRecognizer;
+
     [self addGestureRecognizer:_selectRecognizer];
+    [self addGestureRecognizer:_longSelectRecognizer];
   } else {
     if (_selectRecognizer) {
       [self removeGestureRecognizer:_selectRecognizer];
+    }
+    if (_longSelectRecognizer) {
+      [self removeGestureRecognizer:_longSelectRecognizer];
     }
   }
 }
@@ -118,6 +129,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   } else {
     [self sendSelectNotification:r];
   }
+}
+
+- (void)handleLongSelect:(__unused UIGestureRecognizer *)r
+{
+  [self sendLongSelectNotification:r];
 }
 
 - (BOOL)isUserInteractionEnabled
@@ -412,6 +428,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 - (void)sendSelectNotification:(UIGestureRecognizer *)recognizer
 {
     [self sendNotificationWithEventType:@"select"];
+}
+
+- (void)sendLongSelectNotification:(UIGestureRecognizer *)recognizer
+{
+    [self sendNotificationWithEventType:@"longSelect"];
 }
 
 - (void)sendNotificationWithEventType:(NSString * __nonnull)eventType

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -131,9 +131,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   }
 }
 
-- (void)handleLongSelect:(__unused UIGestureRecognizer *)r
+- (void)handleLongSelect:(UIGestureRecognizer *)r
 {
-  [self sendLongSelectNotification:r];
+  if (r.state == UIGestureRecognizerStateBegan) {
+    [self sendLongSelectNotification:r];
+  }
 }
 
 - (BOOL)isUserInteractionEnabled


### PR DESCRIPTION
## Summary:

Add missing gesture recognizer for long presses to Apple TV view implementations (both Fabric and non-Fabric

Fixes #637 .

## Changelog:

[iOS][Fixed] enable long press for Touchable/Pressable on Apple TV

## Test Plan:

Tested in a local Apple TV project.