### PR TITLE
feat: README and example for TV-specific file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,19 @@ Besides most of the core Expo modules, these also work on TV:
 TV does NOT support dev client (dev menu, dev launcher) at this time.
 TV does NOT support Expo Router at this time.
 
+## _(New)_ How to support TV specific file extensions
+
+The template contains an [example Metro configuration](./packages/react-native/template/metro.config.js) that allows Metro to resolve application source files with TV-specific code, indicated by specific file extensions (e.g. `*.ios.tv.tsx`, `*.android.tv.tsx`, `*.tv.tsx`).
+
+When this is enabled, Metro will resolve files in the following order of preference:
+
+- `file.ios.tv.tsx` or `file.android.tv.tsx`
+- `file.tv.tsx`
+- `file.ios.tsx` or `file.android.tsx`
+- `file.tsx`
+
+This config is not enabled by default, since it will impact bundling performance, but is available for developers who need this capability.
+
 ## Code changes
 
 - _JavaScript layer_: Support for TV has been added to the `Platform` React Native API.

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Besides most of the core Expo modules, these also work on TV:
 TV does NOT support dev client (dev menu, dev launcher) at this time.
 TV does NOT support Expo Router at this time.
 
+See also the [Building Expo apps for TV](https://docs.expo.dev/guides/building-for-tv/) guide from Expo.
+
 ## _(New)_ How to support TV specific file extensions
 
 The template contains an [example Metro configuration](./packages/react-native/template/metro.config.js) that allows Metro to resolve application source files with TV-specific code, indicated by specific file extensions (e.g. `*.ios.tv.tsx`, `*.android.tv.tsx`, `*.tv.tsx`).

--- a/README.md
+++ b/README.md
@@ -94,9 +94,9 @@ See also the [Building Expo apps for TV](https://docs.expo.dev/guides/building-f
 
 ## _(New)_ How to support TV specific file extensions
 
-The template contains an [example Metro configuration](./packages/react-native/template/metro.config.js) that allows Metro to resolve application source files with TV-specific code, indicated by specific file extensions (e.g. `*.ios.tv.tsx`, `*.android.tv.tsx`, `*.tv.tsx`).
+The template contains an [example Metro configuration](./packages/react-native/template/metro.config.js) that allows Metro to resolve application source files with TV-specific code, indicated by specific file extensions (e.g. `*.ios.tv.tsx`, `*.android.tv.tsx`, `*.tv.tsx`). The config will work the same way with the other standard source file extensions (`.js`, etc.), as documented in [Metro docs](https://metrobundler.dev/docs/configuration/#sourceexts)
 
-When this is enabled, Metro will resolve files in the following order of preference:
+When this is enabled, Metro will resolve files in the following order of preference (and similarly for the other supported file extensions):
 
 - `file.ios.tv.tsx` or `file.android.tv.tsx`
 - `file.tv.tsx`

--- a/README.md
+++ b/README.md
@@ -74,23 +74,9 @@ See [this document](https://docs.expo.dev/bare/using-expo-cli/) for more details
 
 ## _(New)_ Using the Expo SDK with TV apps
 
-Starting with the Expo SDK 50 preview, and react-native-tvos 0.73.x, it will be possible to create Expo apps, and build them for TV via a new config plugin.
+See the [Building Expo apps for TV](https://docs.expo.dev/guides/building-for-tv/) guide from Expo for details, including supported Expo modules and limitations.
 
-This functionality will be new in Expo SDK 50, and will be considered an experimental feature for now.
-
-The fastest way to generate a new project is described in the [TV Example](https://github.com/expo/examples/tree/master/with-tv) in the Expo examples repo.
-
-Besides most of the core Expo modules, these also work on TV:
-
-- expo-av
-- expo-image
-- expo-localization
-- expo-updates
-
-TV does NOT support dev client (dev menu, dev launcher) at this time.
-TV does NOT support Expo Router at this time.
-
-See also the [Building Expo apps for TV](https://docs.expo.dev/guides/building-for-tv/) guide from Expo.
+Expo SDK 50 or greater, and react-native-tvos 0.73.x or later, are required.
 
 ## _(New)_ How to support TV specific file extensions
 

--- a/packages/react-native/template/metro.config.js
+++ b/packages/react-native/template/metro.config.js
@@ -1,4 +1,4 @@
-const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
+const {getDefaultConfig} = require('@react-native/metro-config');
 
 /**
  * Metro configuration
@@ -6,6 +6,25 @@ const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
  *
  * @type {import('metro-config').MetroConfig}
  */
-const config = {};
+const config = getDefaultConfig(__dirname);
 
-module.exports = mergeConfig(getDefaultConfig(__dirname), config);
+// When enabled, the optional code below will allow Metro to resolve
+// and bundle source files with TV-specific extensions
+// (e.g., *.ios.tv.tsx, *.android.tv.tsx, *.tv.tsx)
+//
+// Metro will still resolve source files with standard extensions
+// as usual if TV-specific files are not found for a module.
+//
+// This code is not enabled by default, since it will impact bundling performance,
+// but is available for developers who need this capability.
+//
+/*
+const originalSourceExts = config.resolver.sourceExts;
+const tvSourceExts = [
+  ...originalSourceExts.map((e) => `tv.${e}`),
+  ...originalSourceExts,
+];
+config.resolver.sourceExts = tvSourceExts;
+ */
+
+module.exports = config;

--- a/packages/react-native/template/metro.config.js
+++ b/packages/react-native/template/metro.config.js
@@ -19,12 +19,14 @@ const config = getDefaultConfig(__dirname);
 // but is available for developers who need this capability.
 //
 /*
-const originalSourceExts = config.resolver.sourceExts;
-const tvSourceExts = [
-  ...originalSourceExts.map((e) => `tv.${e}`),
-  ...originalSourceExts,
-];
-config.resolver.sourceExts = tvSourceExts;
+if (process.env.BUILDING_FOR_TV) {
+  const originalSourceExts = config.resolver.sourceExts;
+  const tvSourceExts = [
+    ...originalSourceExts.map((e) => `tv.${e}`),
+    ...originalSourceExts,
+  ];
+  config.resolver.sourceExts = tvSourceExts;
+}
  */
 
 module.exports = config;

--- a/packages/react-native/template/metro.config.js
+++ b/packages/react-native/template/metro.config.js
@@ -1,4 +1,4 @@
-const {getDefaultConfig} = require('@react-native/metro-config');
+const {getDefaultConfig, mergeConfig} = require('@react-native/metro-config');
 
 /**
  * Metro configuration
@@ -6,27 +6,27 @@ const {getDefaultConfig} = require('@react-native/metro-config');
  *
  * @type {import('metro-config').MetroConfig}
  */
-const config = getDefaultConfig(__dirname);
+const defaultConfig = getDefaultConfig(__dirname);
 
-// When enabled, the optional code below will allow Metro to resolve
-// and bundle source files with TV-specific extensions
-// (e.g., *.ios.tv.tsx, *.android.tv.tsx, *.tv.tsx)
-//
-// Metro will still resolve source files with standard extensions
-// as usual if TV-specific files are not found for a module.
-//
-// This code is not enabled by default, since it will impact bundling performance,
-// but is available for developers who need this capability.
-//
-/*
-if (process.env.BUILDING_FOR_TV) {
-  const originalSourceExts = config.resolver.sourceExts;
-  const tvSourceExts = [
-    ...originalSourceExts.map((e) => `tv.${e}`),
-    ...originalSourceExts,
-  ];
-  config.resolver.sourceExts = tvSourceExts;
-}
- */
+const config = {
+  // When enabled, the optional code below will allow Metro to resolve
+  // and bundle source files with TV-specific extensions
+  // (e.g., *.ios.tv.tsx, *.android.tv.tsx, *.tv.tsx)
+  //
+  // Metro will still resolve source files with standard extensions
+  // as usual if TV-specific files are not found for a module.
+  //
+  // This code is not enabled by default, since it will impact bundling performance,
+  // but is available for developers who need this capability.
+  //
+  // resolver: process.env.BUILDING_FOR_TV
+  //   ? {
+  //       sourceExts: [].concat(
+  //         defaultConfig.resolver.sourceExts.map(e => `tv.${e}`),
+  //         defaultConfig.resolver.sourceExts,
+  //       ),
+  //     }
+  //   : undefined,
+};
 
-module.exports = config;
+module.exports = mergeConfig(defaultConfig, config);


### PR DESCRIPTION
## Summary:

Provide instructions and an example Metro config (in the template) for developers who need to support TV-specific file extensions (file.tv.tsx, etc.)

Closes #630 .

## Changelog:

[General][Added] Instructions for TV-specific file extensions

## Test Plan:

Tested in multiple local projects.