### PR TITLE
fix: put focus trap code back in the VirtualizedList

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -64,6 +64,7 @@ import {
   onEndReachedThresholdOrDefault,
   windowSizeOrDefault,
 } from './VirtualizedListProps';
+import TVFocusGuideView from '../../react-native/Libraries/Components/TV/TVFocusGuideView';
 
 export type {RenderItemProps, RenderItemType, Separators};
 
@@ -1109,16 +1110,30 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
           registerAsNestedChild: this._registerAsNestedChild,
           unregisterAsNestedChild: this._unregisterAsNestedChild,
         }}>
-        {React.cloneElement(
-          (
-            this.props.renderScrollComponent ||
-            this._defaultRenderScrollComponent
-          )(scrollProps),
-          {
-            ref: this._captureScrollRef,
-          },
-          cells,
-        )}
+        <TVFocusGuideView
+          trapFocusLeft={
+            horizontalOrDefault(this.props.horizontal) && this.state.first > 0
+          }
+          trapFocusRight={
+            horizontalOrDefault(this.props.horizontal) && this._hasMore
+          }
+          trapFocusUp={
+            !horizontalOrDefault(this.props.horizontal) && this.state.first > 0
+          }
+          trapFocusDown={
+            !horizontalOrDefault(this.props.horizontal) && this._hasMore
+          }>
+          {React.cloneElement(
+            (
+              this.props.renderScrollComponent ||
+              this._defaultRenderScrollComponent
+            )(scrollProps),
+            {
+              ref: this._captureScrollRef,
+            },
+            cells,
+          )}
+        </TVFocusGuideView>
       </VirtualizedListContextProvider>
     );
     let ret: React.Node = innerRet;


### PR DESCRIPTION
## Summary:
This PR puts the accidentally removed focus trapping code back to the VirtualizedList. I suspect this regression happened due to the recent big structural changes in the repository.

## Changelog:
[GENERAL] [FIXED] - Fix focus trapping regression for VirtualizedList

## Test Plan:
* Go to "TVFocusGuide autoFocus example" in the RN Tester app
* Focus on "Slow List Focus Test" list
* Spam your right arrow key to focus on the elements on the right
* Observe that focus doesn't jump to the "RIGHT" button until reaching the very last element of the list
* Try the same thing to the opposite direction

https://github.com/react-native-tvos/react-native-tvos/assets/22980987/e257f5d0-11bf-4c27-b8a6-7cd73fa58921

