### PR TITLE
Provide API for greater control of FocusGuide `autoFocus` logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,11 +204,20 @@ class Game2048 extends React.Component {
 
 - _TVFocusGuideView_: This component provides support for Apple's `UIFocusGuide` API and is implemented in the same way for Android TV, to help ensure that focusable controls can be navigated to, even if they are not directly in line with other controls.  An example is provided in `RNTester` that shows two different ways of using this component.
 
-| Prop | Value | Description | 
-|---|---|---|
-| destinations | any[]? | Array of `Component`s to register as destinations of the FocusGuideView |
-| autoFocus | boolean? | If true, `TVFocusGuide` will automatically manage focus for you. It will redirect the focus to the first focusable child on the first visit. It also remembers the last focused child and redirects the focus to it on the subsequent visits. `destinations` prop takes precedence over this prop when used together. |
-| trapFocus* (Up, Down, Left, Right) | Prevents focus escaping from the container for the given directions. |
+| Prop                               | Value                  | Description                                                                                                                                                                                                                                                                                                            | 
+|------------------------------------|------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| destinations                       | any[]?                 | Array of `Component`s to register as destinations of the FocusGuideView                                                                                                                                                                                                                                                |
+| autoFocus                          | boolean?               | If true, `TVFocusGuide` will automatically manage focus for you. It will redirect the focus to the first focusable child on the first visit. It also remembers the last focused child and redirects the focus to it on the subsequent visits. `destinations` prop takes precedence over this prop when used together.  |
+| entryMode                          | `'first' \| 'restore'` | Strategy for handling focus when entering the FocusGuide. Defaults to `restore`, which remembers last focused element. Setting it to `first` always focuses first element on entering the FocusGuide. Works only with `autoFocus`.                                                                                     |
+| trapFocus* (Up, Down, Left, Right) |                        | Prevents focus escaping from the container for the given directions.                                                                                                                                                                                                                                                   |
+
+Additionally, some TV only imperative methods are available on `<TVFocusGuideView>` `ref`:
+
+| Method                    | Description                                                                                                                             | 
+|---------------------------|-----------------------------------------------------------------------------------------------------------------------------------------|
+| `requestTVFocus()`        | Imperatively requests focus on this FocusGuide.                                                                                         |
+| `updateLastFocus(target)` | When `entryMode` is set to `"restore"`, updates currently tracked last focused element. Accepts ref to native view or nativeID (tag)    | 
+| `resetLastFocus()`        | When `entryMode` is set to `"restore"` (default), resets last focused element to first visible element in focus guide.                  | 
 
 More information on the focus handling improvements above can be found in [this article](https://medium.com/xite-engineering/revolutionizing-focus-management-in-tv-applications-with-react-native-10ba69bd90).
 

--- a/packages/react-native/Libraries/Components/TV/TVFocusGuideView.js
+++ b/packages/react-native/Libraries/Components/TV/TVFocusGuideView.js
@@ -40,6 +40,8 @@ type TVFocusGuideViewProps = $ReadOnly<{
 
   autoFocus?: boolean,
 
+  entryMode?: 'restore' | 'first',
+
   trapFocusUp?: boolean,
   trapFocusDown?: boolean,
   trapFocusLeft?: boolean,
@@ -50,6 +52,13 @@ export type TVFocusGuideViewImperativeMethods = $ReadOnly<{
   setDestinations: (
     destinations: (?React.ElementRef<HostComponent<mixed>>)[],
   ) => void,
+  updateLastFocus: (
+    viewRef: React.ElementRef<HostComponent<mixed>>,
+    target: (?React.ElementRef<HostComponent<mixed>>) | number
+  ) => void;
+  resetLastFocus: (
+    viewRef: React.ElementRef<HostComponent<mixed>>
+  ) => void;
 }>;
 
 function TVFocusGuideView(
@@ -78,6 +87,22 @@ function TVFocusGuideView(
     [],
   );
 
+  const updateLastFocus = React.useCallback((target) => {
+    if (focusGuideRef.current) {
+      // Handle ref to component argument
+      const handle = (typeof target === "number") ? target : findNodeHandle(target)
+      if (handle) {
+        Commands.updateLastFocus(focusGuideRef.current, handle);
+      }
+    }
+  }, []);
+
+  const resetLastFocus = React.useCallback(() => {
+    if (focusGuideRef.current) {
+      Commands.updateLastFocus(focusGuideRef.current, null);
+    }
+  }, []);
+
   const _setNativeRef = setAndForwardRef({
     getForwardedRef: () => forwardedRef,
     setLocalRef: ref => {
@@ -93,6 +118,8 @@ function TVFocusGuideView(
       // imperative methods of this component like `setDestinations()`.
       if (ref) {
         ref.setDestinations = setDestinations;
+        ref.updateLastFocus = updateLastFocus;
+        ref.resetLastFocus = resetLastFocus;
       }
     },
   });

--- a/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/View/ViewNativeComponent.js
@@ -124,6 +124,10 @@ interface NativeCommands {
     destinations: Array<number>, // Node handles are basically integers
   ) => void;
   +requestTVFocus: (viewRef: React.ElementRef<HostComponent<mixed>>) => void;
+  +updateLastFocus: (
+    viewRef: React.ElementRef<HostComponent<mixed>>,
+    target: number | null
+  ) => void;
 }
 
 export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
@@ -132,6 +136,7 @@ export const Commands: NativeCommands = codegenNativeCommands<NativeCommands>({
     'setPressed',
     'setDestinations',
     'requestTVFocus',
+    'updateLastFocus',
   ],
 });
 

--- a/packages/react-native/React/Views/RCTTVView.h
+++ b/packages/react-native/React/Views/RCTTVView.h
@@ -15,6 +15,14 @@
 @interface RCTTVView : RCTView
 
 /**
+ * Enum defining allowed EntryModes for TVFocusGuideView
+ */
+typedef NS_ENUM(NSInteger, RCTTVFocusGuideEntryMode) {
+  RCTTVFocusGuideEntryModeRestore = 0,
+  RCTTVFocusGuideEntryModeFirst,
+};
+
+/**
  * TV event handlers
  */
 @property (nonatomic, assign) BOOL isTVSelectable; // True if this view is TV-focusable
@@ -46,6 +54,7 @@
  * Auto focus
  */
 @property (nonatomic, assign) BOOL autoFocus;
+@property (nonatomic, assign) RCTTVFocusGuideEntryMode entryMode;
 
 @property (nonatomic, assign) BOOL trapFocusUp;
 @property (nonatomic, assign) BOOL trapFocusDown;
@@ -83,6 +92,8 @@
 - (void)setFocusDestinations:(NSArray*)destinations;
 
 - (void)requestTVFocus;
+
+- (void)updateLastFocus:(id)target;
 
 @property (nonatomic, strong) UIFocusGuide * focusGuide;
 

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -26,7 +26,6 @@
   BOOL motionEffectsAdded;
   NSArray* focusDestinations;
   id<UIFocusItem> previouslyFocusedItem;
-  
 }
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge {
@@ -45,6 +44,7 @@
       };
     });
     self.tvParallaxProperties = defaultTVParallaxProperties;
+    self.entryMode = RCTTVFocusGuideEntryModeRestore;
     motionEffectsAdded = NO;
   }
   
@@ -95,6 +95,13 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     if (_longSelectRecognizer) {
       [self removeGestureRecognizer:_longSelectRecognizer];
     }
+  }
+}
+
+- (void)setEntryMode:(RCTTVFocusGuideEntryMode)entryMode
+{
+  if (_entryMode != entryMode) {
+    _entryMode = entryMode;
   }
 }
 
@@ -523,7 +530,12 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   } else if (_autoFocus && previouslyFocusedItem != nil) {
     // We also add `self` as the second option in case `previouslyFocusedItem` becomes unreachable (e.g gets detached).
     // `self` helps redirecting focus to the first focusable element in that case.
-    [self addFocusGuide:@[previouslyFocusedItem, self]];
+    if (_entryMode == RCTTVFocusGuideEntryModeFirst) {
+      previouslyFocusedItem = nil;
+      [self addFocusGuide:@[self]];
+    } else {
+      [self addFocusGuide:@[previouslyFocusedItem, self]];
+    }
   } else if (_autoFocus) {
     [self addFocusGuide:@[self]];
   } else {
@@ -575,5 +587,16 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 - (void)requestTVFocus
 {
   [self requestFocusSelf];
+}
+
+- (void)updateLastFocus:(id) target
+{
+  if ([target isKindOfClass:[UIView class]]) {
+    previouslyFocusedItem = target;
+  } else {
+    previouslyFocusedItem = nil;
+  }
+
+  [self handleFocusGuide];
 }
 @end

--- a/packages/react-native/React/Views/RCTViewManager.m
+++ b/packages/react-native/React/Views/RCTViewManager.m
@@ -135,6 +135,19 @@ RCT_MULTI_ENUM_CONVERTER(
 
 @end
 
+#if TARGET_OS_TV
+@implementation RCTConvert (RCTTVProps)
+  RCT_ENUM_CONVERTER(
+      RCTTVFocusGuideEntryMode,
+      (@{
+        @"restore" : @(RCTTVFocusGuideEntryModeRestore),
+        @"first" : @(RCTTVFocusGuideEntryModeFirst),
+      }),
+      RCTTVFocusGuideEntryModeRestore,
+      integerValue)
+@end
+#endif
+
 @implementation RCTViewManager
 
 @synthesize bridge = _bridge;
@@ -194,6 +207,7 @@ RCT_EXPORT_MODULE()
 // TODO: Delete props for Apple TV.
 RCT_EXPORT_VIEW_PROPERTY(isTVSelectable, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(hasTVPreferredFocus, BOOL)
+RCT_EXPORT_VIEW_PROPERTY(entryMode, RCTTVFocusGuideEntryMode)
 RCT_EXPORT_VIEW_PROPERTY(tvParallaxProperties, NSDictionary)
 RCT_EXPORT_VIEW_PROPERTY(nextFocusUp, NSNumber)
 RCT_EXPORT_VIEW_PROPERTY(nextFocusDown, NSNumber)
@@ -569,6 +583,14 @@ RCT_EXPORT_METHOD(requestTVFocus : (nonnull NSNumber *)viewTag)
   [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
     RCTTVView *view = (RCTTVView *)viewRegistry[viewTag];
     [view requestTVFocus];
+  }];
+}
+
+RCT_EXPORT_METHOD(updateLastFocus : (nonnull NSNumber *)viewTag : (id) target)
+{
+  [self.bridge.uiManager addUIBlock:^(RCTUIManager *uiManager, NSDictionary<NSNumber *, UIView *> *viewRegistry) {
+    RCTTVView *view = (RCTTVView *)viewRegistry[viewTag];
+    [view updateLastFocus: target];
   }];
 }
 #endif

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -103,6 +103,12 @@ BaseViewProps::BaseViewProps(
           "autoFocus",
           sourceProps.autoFocus,
           (Boolean) false)),
+      entryMode(convertRawProp(
+          context,
+          rawProps,
+          "entryMode",
+          sourceProps.entryMode,
+          TVFocusEntryMode::Restore)),
       trapFocusUp(convertRawProp(
           context,
           rawProps,
@@ -355,6 +361,12 @@ void BaseViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(collapsable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(removeClippedSubviews);
     RAW_SET_PROP_SWITCH_CASE_BASIC(experimental_layoutConformance);
+
+    // TV related props
+#if TARGET_OS_TV
+    RAW_SET_PROP_SWITCH_CASE_BASIC(entryMode);
+#endif
+      
     // events field
     VIEW_EVENT_CASE(PointerEnter);
     VIEW_EVENT_CASE(PointerEnterCapture);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -45,6 +45,7 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
   std::optional<int> nextFocusLeft;
   std::optional<int> nextFocusRight;
   bool autoFocus{false};
+  TVFocusEntryMode entryMode{TVFocusEntryMode::Restore};
   bool trapFocusUp{false};
   bool trapFocusDown{false};
   bool trapFocusLeft{false};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/primitives.h
@@ -286,6 +286,8 @@ struct BorderMetrics {
 
 #if TARGET_OS_TV
 
+enum class TVFocusEntryMode: uint8_t { Restore, First };
+
 struct TVParallaxProperties {
   std::optional<bool> enabled{};
   std::optional<float> shiftDistanceX{};

--- a/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/propsConversions.h
@@ -559,6 +559,22 @@ static inline CascadedRectangleEdges<T> convertRawProp(
 inline void fromRawValue(
     const PropsParserContext &,
     const RawValue &value,
+    TVFocusEntryMode &result) {
+  if (value.hasType<std::string>()) {
+    auto stringVal = (std::string)value;
+    if (stringVal == "first") {
+      result = TVFocusEntryMode::First;
+      return; // handled
+    }
+  }
+  
+  // default
+  result = TVFocusEntryMode::Restore;
+}
+
+inline void fromRawValue(
+    const PropsParserContext &,
+    const RawValue &value,
     TVParallaxProperties &result) {
   auto map = (std::unordered_map<std::string, RawValue>)value;
 

--- a/packages/react-native/types/public/ReactNativeTVTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTVTypes.d.ts
@@ -67,7 +67,17 @@ declare module 'react-native' {
     disable(): void;
   }
 
+  export type FocusGuideEntryMode = 'first' | 'restore';
+
   export interface FocusGuideProps extends ViewProps {
+    /**
+     * How focus should be handled when entering this focus guide.
+     * Defaults to "restore", which remembers last focused element.
+     * Setting it to "first" causes first element to always be focused when entering the view.
+     *
+     * NOTE: When using scrolled views, the first *visible* element is focused.
+     */
+    entryMode?: FocusGuideEntryMode | undefined;
      /**
      * If the view should be "visible". display "flex" if visible, otherwise "none".
      * Defaults to true
@@ -114,6 +124,16 @@ declare module 'react-native' {
     setDestinations: (
       destinations: (React.ElementRef<HostComponent<unknown>> | null | undefined)[],
     ) => void;
+    /**
+     * Overrides tracked last focused element in this FocusGuide to specified view ref or nativeId.
+     */
+    updateLastFocus: (
+      target: React.ElementRef<HostComponent<unknown>> | number
+    ) => void;
+    /**
+     * Resets tracked last focused element in this FocusGuide to first visible element.
+     */
+    resetLastFocus: () => void;
   }
 
   /**


### PR DESCRIPTION
## Summary:

This PR implements additional API that is available from JavaScript code that provides more control over native FocusGuide `autoFocus` logic.

### Motivation

Focus management is crucial part in all TV applications. It is important to make it flexible enough that it covers many needs and cases of different applications. However, we stumbled a bit with current state of `<FocusGuide>` (which is a godsend, nevertheless).

https://github.com/react-native-tvos/react-native-tvos/assets/681837/60673ec7-adaf-4440-b566-4c484cfc1a45

As you can see in the video above, changing the tag updates contents of list of tiles (e.g. movies). When user changes the tag, the tile list is updated and the first tile should be focused when user presses down.
However, when the list of tiles is updated in place (without re-mounting) the last focused element is still tracked. You have remount the list for it to work.

### Solution

To achieve that, we are proposing a new `<FocusGuide>` prop named `entryMode` which specifies a strategy that decides which element should be focused upon entering the FocusGuide.

Entry mode requires `autoFocus` property to be set.

#### Available strategies

`entryMode` accepts one of two strategies which are available at the moment:

| Entry mode | Description                                                                                                                                                                                   |
|------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| `restore`  | Behaves like current `<FocusGuide autoFocus>`. <br/> The first time focus enters the guide, the first visible element is focused, <br/> after re-entering the last focused element is focused (restored). |
| `first`    | When focus enters or re-enters the `focusGuide`, the first visible element is always focused.                                                                                                 |

New strategies can be added in the future as needed.

### New imperative methods

Additionally, for `restore` strategy, we propose two new imperative methods available on `FocusGuide` ref:

 - `resetLastFocus()` - allows to reset last focused element to first visible element imperatively
 - `updateLastFocus(target)` - imperatively sets specified `target` view as last focused element 

We believe that proposed changes allow for more flexibility when managing focus in TV applications.

### Alternative solutions

While the problem could be partially solved using `destinations`, it works in exclusion with `autoFocus`. This results in `<FocusGuide>` logic duality issue where two exclusive functionalities are provided. Our solution does not require developers to jump between them.

## Changelog:

```
- [General] [Added] - add `entryMode` prop to `FocusGuide`
- [General] [Added] - add `updateLastFocus` and `resetLastFocus` imperative methods to `FocusGuide` ref object
```

## Test Plan:

 - Updated rn-tester example

### Preview

#### Resetting last focused element imperatively

```js
const [selectedTag, setSelectedTag] = React.useState(0);
const listGuideRef = React.useRef(null);

React.useEffect(() => {
  listGuideRef.current?.resetLastFocus();
}, [selectedTag]);

return (
  // .. tags
  // list of tiles:
  <TVFocusGuide autoFocus ref={listGuideRef}>
    ...
  </TVFocusGuide>
);
```

https://github.com/react-native-tvos/react-native-tvos/assets/681837/a8c6e0e3-5503-428b-a4d5-a59037a2fd17

#### List of elements with `entryMode="first"`


https://github.com/react-native-tvos/react-native-tvos/assets/681837/d3b96883-2a28-4f5a-9180-43aa390293f7


