### PR TITLE
Improve reability of Error cell when focused (tvOS)

### DIFF
--- a/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
+++ b/packages/react-native/React/CoreModules/RCTDeviceInfo.mm
@@ -103,11 +103,11 @@ RCT_EXPORT_MODULE()
   [[NSNotificationCenter defaultCenter] removeObserver:self
                                                   name:RCTAccessibilityManagerDidUpdateMultiplierNotification
                                                 object:[_moduleRegistry moduleForName:"AccessibilityManager"]];
-
+#if !TARGET_OS_TV
   [[NSNotificationCenter defaultCenter] removeObserver:self
                                                   name:UIApplicationDidChangeStatusBarOrientationNotification
                                                 object:nil];
-
+#endif
   [[NSNotificationCenter defaultCenter] removeObserver:self name:UIApplicationDidBecomeActiveNotification object:nil];
 
   [[NSNotificationCenter defaultCenter] removeObserver:self name:RCTUserInterfaceStyleDidChangeNotification object:nil];

--- a/packages/react-native/React/CoreModules/RCTRedBox.mm
+++ b/packages/react-native/React/CoreModules/RCTRedBox.mm
@@ -302,6 +302,23 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
   return lineInfo;
 }
 
+- (void)tableView:(UITableView *)tableView didUpdateFocusInContext:(UITableViewFocusUpdateContext *)context withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator
+{
+    UITableViewCell *previouslyFocusedItem = (UITableViewCell *)context.previouslyFocusedItem;
+    if ([previouslyFocusedItem isKindOfClass:[UITableViewCell class]]) {
+        [coordinator addCoordinatedUnfocusingAnimations:^(id<UIFocusAnimationContext>  _Nonnull animationContext) {
+            previouslyFocusedItem.textLabel.textColor = [UIColor whiteColor];
+        } completion:nil];
+    }
+
+    UITableViewCell *nextFocusedItem = (UITableViewCell *)context.nextFocusedItem;
+    if ([nextFocusedItem isKindOfClass:[UITableViewCell class]]) {
+        [coordinator addCoordinatedFocusingAnimations:^(id<UIFocusAnimationContext>  _Nonnull animationContext) {
+            nextFocusedItem.textLabel.textColor = [UIColor blackColor];
+        } completion:nil];
+    }
+}
+
 #pragma mark - TableView
 
 - (NSInteger)numberOfSectionsInTableView:(__unused UITableView *)tableView


### PR DESCRIPTION
## Summary:

When the cell is focused on the Error screen, the white text is hard to read on a light background. Changing the text color to black when the cell is in focus can enhance the text's readability.

And, fixing an error where the RNTester app fails to compile:
> [!CAUTION]
> RCTDeviceInfo.mm:107:56 'UIApplicationDidChangeStatusBarOrientationNotification' is unavailable: not available on tvOS

| Xcode Screenshot |
| - |
|<img width="1493" alt="Screenshot 2024-02-02 at 8 26 31 PM" src="https://github.com/react-native-tvos/react-native-tvos/assets/3449816/28025c72-1497-42db-b5e1-f86958d6be72">|

## Changelog:

[IOS][FIXED] - Readability of text when Error message box is focused (tvOS)
[IOS][FIXED] - Compile error in RNTester app (tvOS)

## Test Plan:

Tested the change using the RNTester app and a newly created app. After the change, the app compiled and the text color is black when focused. I did regression testing with an iOS React Native app and saw no regression. 

| Before | After |
| --- | -- |
| ![Simulator Screenshot - Apple TV 4K (2nd generation) - 2024-02-02 at 10 42 08](https://github.com/react-native-tvos/react-native-tvos/assets/3449816/1261494f-d1cd-4bf2-993e-cab5de01d95c)|![Simulator Screenshot - Apple TV 4K (2nd generation) - 2024-02-02 at 10 50 13](https://github.com/react-native-tvos/react-native-tvos/assets/3449816/8b20a9b5-9f5d-403a-a591-8c5749a694ae)|
|![Simulator Screenshot - Apple TV 4K (2nd generation) - 2024-02-02 at 10 50 51](https://github.com/react-native-tvos/react-native-tvos/assets/3449816/ada60f07-08fb-43a3-9c65-cda1e18ac9d0)|![Simulator Screenshot - Apple TV 4K (2nd generation) - 2024-02-02 at 10 50 17](https://github.com/react-native-tvos/react-native-tvos/assets/3449816/5ca60400-9cc2-44a8-bc91-3d674a8b6b0b)|



