### PR TITLE
fix: TVFocusGuideView focusable prop set to false prevent focusing for all subviews

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ class Game2048 extends React.Component {
   |---|---|---|
   | destinations | any[]? | Array of `Component`s to register as destinations of the FocusGuideView |
   | autoFocus | boolean? | If true, `TVFocusGuide` will automatically manage focus for you. It will redirect the focus to the first focusable child on the first visit. It also remembers the last focused child and redirects the focus to it on the subsequent visits. `destinations` prop takes precedence over this prop when used together. |
+  | focusable | boolean? | When set to false, this view and all its subviews will be NOT focusable. |
   | trapFocus* (Up, Down, Left, Right) | Prevents focus escaping from the container for the given directions. |
   
   More information on the focus handling improvements above can be found in [this article](https://medium.com/xite-engineering/revolutionizing-focus-management-in-tv-applications-with-react-native-10ba69bd90).

--- a/packages/react-native/Libraries/Components/TV/TVFocusGuideView.js
+++ b/packages/react-native/Libraries/Components/TV/TVFocusGuideView.js
@@ -8,13 +8,14 @@
  * @format
  */
 
+import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
+import type {ViewProps} from '../View/ViewPropTypes';
+
+import setAndForwardRef from '../../Utilities/setAndForwardRef';
+import {Commands} from '../View/ViewNativeComponent';
+
 const React = require('react');
 const ReactNative = require('react-native');
-
-import {Commands} from '../View/ViewNativeComponent';
-import type {ViewProps} from '../View/ViewPropTypes';
-import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
-import setAndForwardRef from '../../Utilities/setAndForwardRef';
 
 const {View} = ReactNative;
 
@@ -44,6 +45,11 @@ type TVFocusGuideViewProps = $ReadOnly<{
   trapFocusDown?: boolean,
   trapFocusLeft?: boolean,
   trapFocusRight?: boolean,
+
+  /**
+   * When set to false, this view and all its subviews will be NOT focusable.
+   */
+  focusable?: boolean | undefined,
 }>;
 
 export type TVFocusGuideViewImperativeMethods = $ReadOnly<{
@@ -57,6 +63,8 @@ function TVFocusGuideView(
     enabled = true,
     safePadding,
     destinations: destinationsProp,
+    autoFocus,
+    focusable,
     ...props
   }: TVFocusGuideViewProps,
   forwardedRef,
@@ -106,6 +114,11 @@ function TVFocusGuideView(
   const enabledStyle = {display: enabled ? 'flex' : 'none'};
   const style = [styles.container, props.style, enabledStyle];
 
+  // If there are no destinations and the autoFocus is false the the default value of focusable should be false
+  // It is then properly handled by the native code
+  const tvOSSelectable =
+    destinationsProp || autoFocus ? focusable !== false : false;
+
   return (
     // $FlowFixMe[prop-missing]
     <ReactNative.View
@@ -113,6 +126,11 @@ function TVFocusGuideView(
       style={style}
       ref={_setNativeRef}
       collapsable={false}
+      autoFocus={autoFocus}
+      // tvOS only prop
+      isTVSelectable={tvOSSelectable}
+      // Android TV only prop
+      tvFocusable={focusable}
     />
   );
 }

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -415,13 +415,29 @@ using namespace facebook::react;
 }
 
 
+- (BOOL)isTVFocusGuide
+{
+  #if TARGET_OS_TV
+    return self.focusGuide != nil;
+  #endif
+  
+  return NO;
+}
+
+
 - (BOOL)isUserInteractionEnabled
 {
-    return YES;
+  if ([self isTVFocusGuide]) {
+    return _props->isTVSelectable;
+  }
+  return YES;
 }
 
 - (BOOL)canBecomeFocused
 {
+  if ([self isTVFocusGuide]) {
+    return NO;
+  }
   return _props->isTVSelectable;
 }
 
@@ -548,7 +564,7 @@ using namespace facebook::react;
       [self handleFocusGuide];
     }
 
-    if (context.nextFocusedView == self && self.isUserInteractionEnabled ) {
+    if (context.nextFocusedView == self && self.isUserInteractionEnabled && ![self isTVFocusGuide]) {
       [self becomeFirstResponder];
       [self enableDirectionalFocusGuides];
       [coordinator addCoordinatedAnimations:^(void){
@@ -898,7 +914,7 @@ using namespace facebook::react;
 #if TARGET_OS_TV
   // `isTVSelectable`
   if (oldViewProps.isTVSelectable != newViewProps.isTVSelectable) {
-    if (newViewProps.isTVSelectable) {
+    if (newViewProps.isTVSelectable && ![self isTVFocusGuide]) {
       UITapGestureRecognizer *recognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                                    action:@selector(handleSelect:)];
       recognizer.allowedPressTypes = @[ @(UIPressTypeSelect) ];

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -75,7 +75,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 - (void)setIsTVSelectable:(BOOL)isTVSelectable
 {
   self->_isTVSelectable = isTVSelectable;
-  if (isTVSelectable) {
+  if (isTVSelectable && ![self isTVFocusGuide]) {
     UITapGestureRecognizer *recognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
                                                                                  action:@selector(handleSelect:)];
     recognizer.allowedPressTypes = @[ @(UIPressTypeSelect) ];
@@ -138,13 +138,25 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   }
 }
 
+- (BOOL)isTVFocusGuide
+{
+  return self.focusGuide != nil;
+}
+
 - (BOOL)isUserInteractionEnabled
 {
+  if ([self isTVFocusGuide]) {
+    return (self.isTVSelectable);
+  }
   return YES;
 }
 
 - (BOOL)canBecomeFocused
 {
+  if ([self isTVFocusGuide]) {
+    return NO;
+  }
+
   return (self.isTVSelectable);
 }
 
@@ -311,7 +323,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     [self handleFocusGuide];
   }
     
-  if (context.nextFocusedView == self && self.isTVSelectable ) {
+  if (context.nextFocusedView == self && ![self isTVFocusGuide] && self.isTVSelectable ) {
     [self becomeFirstResponder];
     [self enableDirectionalFocusGuides];
     [coordinator addCoordinatedAnimations:^(void){

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -1216,7 +1216,7 @@ public class ReactViewGroup extends ViewGroup
      * `mRecoverFocus` flag indicates a temporary focus recovery mode it's in which
      * requires full access to children focusable elements.
      */
-    if (isTVFocusGuide() && !mRecoverFocus) {
+    if (isTVFocusGuide() && !mRecoverFocus && this.getDescendantFocusability() != ViewGroup.FOCUS_BLOCK_DESCENDANTS) {
       View focusedChild = getFocusedChildOfFocusGuide();
 
       /*

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -12,6 +12,7 @@ import android.graphics.Rect;
 import android.os.Build;
 import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.facebook.common.logging.FLog;
@@ -306,6 +307,9 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
     setFocusable(view, focusable);
     if (!focusable) {
       view.setFocusable(false);
+      view.setDescendantFocusability(ViewGroup.FOCUS_BLOCK_DESCENDANTS);
+    } else {
+      view.setDescendantFocusability(ViewGroup.FOCUS_BEFORE_DESCENDANTS);
     }
   }
 

--- a/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
+++ b/packages/rn-tester/js/examples/TVFocusGuide/TVFocusGuideAutoFocusExample.js
@@ -188,7 +188,7 @@ const getSelectedItemPrefix = (selectedCategory: string) => {
   return `Category ${selectedCategory} - Item`;
 };
 
-const Row = ({title}) => {
+const Row = ({title, focusable}) => {
   const [selectedCategory, setSelectedCategory] = React.useState('1');
 
   const onCategoryFocused = (event, id: number) => {
@@ -197,7 +197,7 @@ const Row = ({title}) => {
 
   return (
     <View style={styles.mb5}>
-      <TVFocusGuide autoFocus style={styles.rowTop}>
+      <TVFocusGuide autoFocus style={styles.rowTop} focusable={focusable}>
         <Text style={styles.rowTitle}>{title}</Text>
         <HList
           prefix="Category"
@@ -208,7 +208,7 @@ const Row = ({title}) => {
           onItemFocused={onCategoryFocused}
         />
       </TVFocusGuide>
-      <TVFocusGuide autoFocus style={styles.mb5}>
+      <TVFocusGuide autoFocus style={styles.mb5} focusable={focusable}>
         <HList
           prefix={getSelectedItemPrefix(selectedCategory)}
           itemCount={10}
@@ -432,6 +432,7 @@ const ContentArea = React.forwardRef(
           <SlowListFocusTest />
           <Row title="Category Example 1" />
           <Row title="Category Example 2" />
+          <Row title="Disabled Focus Subviews Example" focusable={false} />
 
           <FocusableBox
             style={styles.focusToSideMenuBtn}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Currently, disabling focus for view and its children is impossible. It is possible only by setting disabled for all touchable/pressable/buttons inside the view.

From the developer's perspective, I would love to have a prop that could be set for the parent view and will make all children not focusable.

In this PR I fixed the `focusable` prop in TVFocusGuideView that should block focus also for subviews of `TVFocusGuideView`

## Changelog:

```
- [General][Fixed] - focusable prop in TVFocusGuideView blocks focus also for its subviews
```

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

It should be tested on both Android TV and tvOS platforms and both architectures.

I added a Row in `TVFocusGuide autoFocus example` with this prop. The focus engine should omit this whole row as in the videos below

https://github.com/react-native-tvos/react-native-tvos/assets/16336501/07623266-94da-4f79-a8ad-2c9ed2a73bbc



