### PR TITLE
fix: [Apple TV] nextFocus props is not correct while set for the focused component

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -433,6 +433,17 @@ using namespace facebook::react;
 //
 - (void)enableDirectionalFocusGuides
 {
+  [self enableNextFocusUp];
+
+  [self enableNextFocusDown];
+
+  [self enableNextFocusLeft];
+
+  [self enableNextFocusRight];
+}
+
+- (void)enableNextFocusUp
+{
   if (self->_nextFocusUp != nil) {
     if (self.focusGuideUp == nil) {
       self.focusGuideUp = [UIFocusGuide new];
@@ -446,7 +457,10 @@ using namespace facebook::react;
 
     self.focusGuideUp.preferredFocusEnvironments = @[self->_nextFocusUp];
   }
+}
 
+- (void)enableNextFocusDown
+{
   if (self->_nextFocusDown != nil) {
     if (self.focusGuideDown == nil) {
       self.focusGuideDown = [UIFocusGuide new];
@@ -460,7 +474,10 @@ using namespace facebook::react;
 
     self.focusGuideDown.preferredFocusEnvironments = @[self->_nextFocusDown];
   }
+}
 
+- (void)enableNextFocusLeft
+{
   if (self->_nextFocusLeft != nil) {
     if (self.focusGuideLeft == nil) {
       self.focusGuideLeft = [UIFocusGuide new];
@@ -474,7 +491,10 @@ using namespace facebook::react;
 
     self.focusGuideLeft.preferredFocusEnvironments = @[self->_nextFocusLeft];
   }
+}
 
+- (void)enableNextFocusRight
+{
   if (self->_nextFocusRight != nil) {
     if (self.focusGuideRight == nil) {
       self.focusGuideRight = [UIFocusGuide new];
@@ -942,6 +962,9 @@ using namespace facebook::react;
     if (newViewProps.nextFocusUp.has_value()) {
       UIView *rootView = [self containingRootView];
       _nextFocusUp = [rootView viewWithTag:newViewProps.nextFocusUp.value()];
+      if (self.isFocused) {
+        [self enableNextFocusUp];
+      }
     } else {
       _nextFocusUp = nil;
     }
@@ -951,6 +974,9 @@ using namespace facebook::react;
     if (newViewProps.nextFocusDown.has_value()) {
       UIView *rootView = [self containingRootView];
       _nextFocusDown = [rootView viewWithTag:newViewProps.nextFocusDown.value()];
+      if (self.isFocused) {
+        [self enableNextFocusDown];
+      }
     } else {
       _nextFocusDown = nil;
     }
@@ -960,6 +986,9 @@ using namespace facebook::react;
     if (newViewProps.nextFocusLeft.has_value()) {
       UIView *rootView = [self containingRootView];
       _nextFocusLeft = [rootView viewWithTag:newViewProps.nextFocusLeft.value()];
+      if (self.isFocused) {
+        [self enableNextFocusLeft];
+      }
     } else {
       _nextFocusLeft = nil;
     }
@@ -969,6 +998,9 @@ using namespace facebook::react;
     if (newViewProps.nextFocusRight.has_value()) {
       UIView *rootView = [self containingRootView];
       _nextFocusRight = [rootView viewWithTag:newViewProps.nextFocusRight.value()];
+      if (self.isFocused) {
+        [self enableNextFocusRight];
+      }
     } else {
       _nextFocusRight = nil;
     }

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -336,6 +336,17 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 //
 - (void)enableDirectionalFocusGuides
 {
+  [self enableDirectionalFocusGuideUp];
+
+  [self enableDirectionalFocusGuideDown];
+ 
+  [self enableDirectionalFocusGuideLeft];
+
+  [self enableDirectionalFocusGuideRight];
+}
+
+- (void)enableDirectionalFocusGuideUp
+{
   if (self->_nextFocusUp != nil) {
     if (self.focusGuideUp == nil) {
       self.focusGuideUp = [UIFocusGuide new];
@@ -349,7 +360,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 
     self.focusGuideUp.preferredFocusEnvironments = @[self->_nextFocusUp];
   }
+}
 
+- (void)enableDirectionalFocusGuideDown
+{
   if (self->_nextFocusDown != nil) {
     if (self.focusGuideDown == nil) {
       self.focusGuideDown = [UIFocusGuide new];
@@ -363,7 +377,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 
     self.focusGuideDown.preferredFocusEnvironments = @[self->_nextFocusDown];
   }
+}
 
+- (void)enableDirectionalFocusGuideLeft
+{
   if (self->_nextFocusLeft != nil) {
     if (self.focusGuideLeft == nil) {
       self.focusGuideLeft = [UIFocusGuide new];
@@ -377,7 +394,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 
     self.focusGuideLeft.preferredFocusEnvironments = @[self->_nextFocusLeft];
   }
+}
 
+- (void)enableDirectionalFocusGuideRight
+{
   if (self->_nextFocusRight != nil) {
     if (self.focusGuideRight == nil) {
       self.focusGuideRight = [UIFocusGuide new];
@@ -455,18 +475,30 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 
 - (void)setNextFocusUp:(NSNumber *)nextFocusUp {
   self->_nextFocusUp = [self getViewById: nextFocusUp];
+  if (self.isFocused) {
+    [self enableDirectionalFocusGuideUp];
+  }
 }
 
 - (void)setNextFocusDown:(NSNumber *)nextFocusDown {
   self->_nextFocusDown = [self getViewById: nextFocusDown];
+  if (self.isFocused) {
+    [self enableDirectionalFocusGuideDown];
+  }
 }
 
 - (void)setNextFocusLeft:(NSNumber *)nextFocusLeft {
   self->_nextFocusLeft = [self getViewById: nextFocusLeft];
+  if (self.isFocused) {
+    [self enableDirectionalFocusGuideLeft];
+  }
 }
 
 - (void)setNextFocusRight:(NSNumber *)nextFocusRight {
   self->_nextFocusRight = [self getViewById: nextFocusRight];
+  if (self.isFocused) {
+    [self enableDirectionalFocusGuideRight];
+  }
 }
 
 - (void)setPreferredFocus:(BOOL)hasTVPreferredFocus


### PR DESCRIPTION


<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

In this PR I added fix for an issue with `nextFocusXXX` props that are set for the already focused component.

Native FocusGuides are added to the view while the item is focused and removed while blurred. If the `nextFocusXXX` is added to an already focused item the value is not updated (or the focus guide is not added if the previous value was not set)

In my solution, I split the `enableDirectionalFocusGuides` into a few smaller methods and used them in `nextFocusXXX` prop setter.

I check if the view in which we set the property is focused and if yes I refresh the suitable focusGuide environment.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:


For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

```
[iOS][Fixed] - Update focus guide environment while setting nextFocus prop for already focused component
```

## Test Plan:

Change the `nextFocusXXX` prop (nextFocusRight on the video) when the item is focused and check if the destination view is correct.

**Video before**

https://github.com/react-native-tvos/react-native-tvos/assets/16336501/322ac15f-8d56-4035-a887-87f95fe2e23b

**Video after**


https://github.com/react-native-tvos/react-native-tvos/assets/16336501/1b82d57d-aa2b-4c22-8a2c-dc775910c0a3



<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

<details>
<summary><b>Code snippet that can be pasted in examples</b></summary>

```
/**
 * Copyright (c) Facebook, Inc. and its affiliates.
 *
 * This source code is licensed under the MIT license found in the
 * LICENSE file in the root directory of this source tree.
 *
 * @format
 * @flow
 */

'use strict';

const React = require('react');
const ReactNative = require('react-native');

import {useRNTesterTheme} from '../../components/RNTesterTheme';

const {View, StyleSheet, Pressable, Text, TVFocusGuideView} = ReactNative;

const screenHeight = ReactNative.Dimensions.get('window').height;
const scale = screenHeight / 1080;
const width = 200 * scale;
const height = 120 * scale;

exports.framework = 'React';
exports.title = 'TV NextFocus example';
exports.description = 'NextFocus API';
exports.displayName = 'NextFocus example';
exports.examples = [
  {
    title: 'TVFocusGuide',
    render(): React.Node {
      return <TVFocusGuideExample />;
    },
  },
];

const Button = React.forwardRef((props: $FlowFixMeProps, _) => {
  const onRefAssign = ref => {
    props.onRefAssign?.(props.index, ref);
  };
  const theme = useRNTesterTheme();
  return (
    <Pressable
      onPress={props.onPress}
      nextFocusRight={props.nextFocusRight}
      style={({pressed, focused}) =>
        focused ? styles.buttonStyleFocused : styles.buttonStyle
      }
      ref={onRefAssign}>
      <Text style={[{color: theme.LinkColor}, styles.buttonText]}>
        {props.label}
      </Text>
    </Pressable>
  );
});

const TVFocusGuideExample = () => {
  const [nextFocusIndex, setNextFocusIndex] = React.useState(0);

  const refs = React.useRef({});
  const onRefAssign = (index, ref) => {
    refs.current[index] = ref;
  };

  return (
    <View style={styles.rowContainer}>
      <TVFocusGuideView autoFocus>
        <Button
          label={`Focus to ${nextFocusIndex}`}
          nextFocusRight={refs.current[nextFocusIndex]}
          onPress={() => {
            setNextFocusIndex((nextFocusIndex + 1) % 4);
          }}
        />
      </TVFocusGuideView>
      <View>
        <Button label={'Item nr 0'} onRefAssign={onRefAssign} index={0} />
        <Button label={'Item nr 1'} onRefAssign={onRefAssign} index={1} />
        <Button label={'Item nr 2'} onRefAssign={onRefAssign} index={2} />
        <Button label={'Item nr 3'} onRefAssign={onRefAssign} index={3} />
      </View>
    </View>
  );
};

const marginSize = 20 * scale;
const styles = StyleSheet.create({
  rowContainer: {
    flexDirection: 'row',
    padding: 100 * scale,
  },
  buttonText: {
    fontSize: 30 * scale,
  },
  buttonStyle: {
    marginLeft: marginSize,
    marginRight: marginSize,
    marginTop: marginSize,
    marginBottom: marginSize,
  },
  buttonStyleFocused: {
    opacity: 0.5,
    width,
    height,
    marginLeft: marginSize,
    marginRight: marginSize,
    marginTop: marginSize,
    marginBottom: marginSize,
  },
});

```

</details>
