### PR TITLE
chore: Remove absolute position in RNTester header on TV

### DIFF
--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -25,7 +25,14 @@ import {
   initialNavigationState,
 } from './utils/testerStateUtils';
 import * as React from 'react';
-import {BackHandler, Platform, StyleSheet, useColorScheme, TVEventControl, View} from 'react-native';
+import {
+  BackHandler,
+  Platform,
+  StyleSheet,
+  useColorScheme,
+  TVEventControl,
+  View,
+} from 'react-native';
 
 // RNTester App currently uses in memory storage for storing navigation state
 
@@ -154,6 +161,15 @@ const RNTesterApp = (): React.Node => {
 
   return (
     <RNTesterThemeContext.Provider value={theme}>
+      {Platform.isTV ? (
+        <View style={styles.tvNavBar}>
+          <RNTesterNavBar
+            screen={screen || Screens.COMPONENTS}
+            isExamplePageOpen={!!activeModule}
+            handleNavBarPress={handleNavBarPress}
+          />
+        </View>
+      ) : null}
       <RNTTitleBar
         title={title}
         theme={theme}
@@ -181,13 +197,15 @@ const RNTesterApp = (): React.Node => {
           />
         )}
       </View>
-      <View style={Platform.isTV ? styles.tvNavBar : styles.bottomNavbar}>
-        <RNTesterNavBar
-          screen={screen || Screens.COMPONENTS}
-          isExamplePageOpen={!!activeModule}
-          handleNavBarPress={handleNavBarPress}
-        />
-      </View>
+      {!Platform.isTV ? (
+        <View style={styles.bottomNavbar}>
+          <RNTesterNavBar
+            screen={screen || Screens.COMPONENTS}
+            isExamplePageOpen={!!activeModule}
+            handleNavBarPress={handleNavBarPress}
+          />
+        </View>
+      ) : null}
     </RNTesterThemeContext.Provider>
   );
 };
@@ -197,14 +215,12 @@ export default RNTesterApp;
 const styles = StyleSheet.create({
   container: {
     flex: 1,
+    justifyContent: 'center',
   },
   tvNavBar: {
-    top: 20,
-    left: '5%',
-    width: '90%',
+    width: '100%',
     display: 'flex',
     flexDirection: 'column',
-    position: 'absolute',
     height: navBarHeight,
   },
   bottomNavbar: {

--- a/packages/rn-tester/js/components/RNTesterNavbar.js
+++ b/packages/rn-tester/js/components/RNTesterNavbar.js
@@ -156,11 +156,13 @@ const RNTesterNavbar = ({
           handleNavBarPress={handleNavBarPress}
           theme={theme}
         />
-        <BookmarkTab
-          isBookmarkActive={isBookmarkActive}
-          handleNavBarPress={handleNavBarPress}
-          theme={theme}
-        />
+        {!Platform.isTV ? (
+          <BookmarkTab
+            isBookmarkActive={isBookmarkActive}
+            handleNavBarPress={handleNavBarPress}
+            theme={theme}
+          />
+        ) : null}
         <APITab
           isAPIActive={isAPIActive}
           handleNavBarPress={handleNavBarPress}


### PR DESCRIPTION
Makes navigating the RNTester app much simpler and more reliable on TV.


[General] [Internal] Remove absolute positioning in RNTester header for TV