### PR TITLE
feat: implement additionalRenderRegions feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,15 +204,24 @@ class Game2048 extends React.Component {
 
 - _TVFocusGuideView_: This component provides support for Apple's `UIFocusGuide` API and is implemented in the same way for Android TV, to help ensure that focusable controls can be navigated to, even if they are not directly in line with other controls.  An example is provided in `RNTester` that shows two different ways of using this component.
 
-| Prop | Value | Description | 
-|---|---|---|
-| destinations | any[]? | Array of `Component`s to register as destinations of the FocusGuideView |
-| autoFocus | boolean? | If true, `TVFocusGuide` will automatically manage focus for you. It will redirect the focus to the first focusable child on the first visit. It also remembers the last focused child and redirects the focus to it on the subsequent visits. `destinations` prop takes precedence over this prop when used together. |
-| trapFocus* (Up, Down, Left, Right) | Prevents focus escaping from the container for the given directions. |
+  | Prop | Value | Description | 
+  |---|---|---|
+  | destinations | any[]? | Array of `Component`s to register as destinations of the FocusGuideView |
+  | autoFocus | boolean? | If true, `TVFocusGuide` will automatically manage focus for you. It will redirect the focus to the first focusable child on the first visit. It also remembers the last focused child and redirects the focus to it on the subsequent visits. `destinations` prop takes precedence over this prop when used together. |
+  | trapFocus* (Up, Down, Left, Right) | Prevents focus escaping from the container for the given directions. |
+  
+  More information on the focus handling improvements above can be found in [this article](https://medium.com/xite-engineering/revolutionizing-focus-management-in-tv-applications-with-react-native-10ba69bd90).
+  
+  - _Next Focus Direction_: the props `nextFocus*` on `View` should work as expected on iOS too (previously android only). One caveat is that if there is no focusable in the `nextFocusable*` direction next to the starting view, iOS doesn't check if we want to override the destination. 
+  
+  - _TVTextScrollView_: On Apple TV, a ScrollView will not scroll unless there are focusable items inside it or above/below it.  This component wraps ScrollView and uses tvOS-specific native code to allow scrolling using swipe gestures from the remote control.
 
-More information on the focus handling improvements above can be found in [this article](https://medium.com/xite-engineering/revolutionizing-focus-management-in-tv-applications-with-react-native-10ba69bd90).
+- VirtualizedList: We extend `VirtualizedList` to make virtualization work well with focus management in mind. All of the improvements that we made are automatically available to all the VirtualizedList based components such as `FlatList`.
+  - Defaults
+    - VirtualizeList contents are automatically wrapped with a `TVFocusGuideView` with `trapFocus*` properties enabled depending on the orientation of the list. This default makes sure that focus doesn't leave the list accidentally due to a virtualization issue etc. until reaching the beginning or the end of the list.
 
-- _Next Focus Direction_: the props `nextFocus*` on `View` should work as expected on iOS too (previously android only). One caveat is that if there is no focusable in the `nextFocusable*` direction next to the starting view, iOS doesn't check if we want to override the destination. 
+  New Props:
 
-- _TVTextScrollView_: On Apple TV, a ScrollView will not scroll unless there are focusable items inside it or above/below it.  This component wraps ScrollView and uses tvOS-specific native code to allow scrolling using swipe gestures from the remote control.
-
+  | Prop | Value | Description | 
+  |---|---|---|
+  | additionalRenderRegions | {first: number; last: number;}[]? | Array of `RenderRegions` that allows you to define regions in the list that are not subject to virtualization, ensuring they are always rendered. This is particularly useful for preventing blank areas in critical parts of the list. These regions are rendered lazily after the initial render and are specified as an array of objects, each with `first` and `last` indices marking the beginning and end of the non-virtualized region based on index. See the [feature proposal](https://github.com/react-native-tvos/react-native-tvos/discussions/663) for more context. |

--- a/packages/rn-tester/js/examples/FlatList/FlatList-additionalRenderRegions.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-additionalRenderRegions.js
@@ -13,7 +13,7 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import {useRNTesterTheme} from '../../components/RNTesterTheme';
 import BaseFlatListExample from './BaseFlatListExample';
 import * as React from 'react';
-import {useRef} from 'react';
+import {useRef, useState} from 'react';
 import {
   FlatList,
   Pressable,
@@ -21,17 +21,25 @@ import {
   Text,
   Dimensions,
   TVFocusGuideView,
+  Switch,
 } from 'react-native';
 
 const screenHeight = Dimensions.get('window').height;
 const screenWidth = Dimensions.get('window').width;
 const scale = screenHeight / 1080;
 
+type ItemType = number;
+const data: ItemType[] = [
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+  22, 23, 24, 25,
+];
+
 const ITEM_SPACING = 5 * scale;
 const ITEM_WIDTH = 400 * scale;
 const ITEM_TOTAL_WIDTH = ITEM_WIDTH + ITEM_SPACING;
 const ITEM_HEIGHT = 100 * scale;
 const NUMBER_OF_VISIBLE_ITEMS = Math.ceil(screenWidth / ITEM_TOTAL_WIDTH);
+const MID_INDEX = Math.floor(data.length / 2);
 
 function Row({title, children}: {title: string, children: React.Node}) {
   return (
@@ -41,11 +49,6 @@ function Row({title, children}: {title: string, children: React.Node}) {
     </TVFocusGuideView>
   );
 }
-type ItemType = number;
-const data: ItemType[] = [
-  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
-  22, 23, 24, 25,
-];
 
 /**
  * Constructs a case that tests if `additionalRenderRegions` property works as expected.
@@ -60,6 +63,8 @@ const data: ItemType[] = [
 export function FlatList_additionalRenderRegions(): React.Node {
   const theme = useRNTesterTheme();
   const listRef = useRef<?FlatList<ItemType>>(null);
+  const [additionalRenderRegionsEnabled, setAdditionalRenderRegionsEnabled] =
+    useState(true);
 
   const renderItem: RenderItemType<ItemType> = ({index}) => (
     <Pressable
@@ -77,6 +82,14 @@ export function FlatList_additionalRenderRegions(): React.Node {
 
   return (
     <TVFocusGuideView autoFocus trapFocusLeft trapFocusRight>
+      <TVFocusGuideView style={styles.switchSection}>
+        <Text style={styles.switchText}>Enable `additionalRenderRegions`</Text>
+        <Switch
+          value={additionalRenderRegionsEnabled}
+          onValueChange={() => setAdditionalRenderRegionsEnabled(val => !val)}
+        />
+      </TVFocusGuideView>
+
       <Row title="Initial Row">
         <FlatList
           ref={listRef}
@@ -84,11 +97,13 @@ export function FlatList_additionalRenderRegions(): React.Node {
           data={data}
           renderItem={renderItem}
           windowSize={1}
-          initialScrollIndex={NUMBER_OF_VISIBLE_ITEMS}
-          contentOffset={{x: NUMBER_OF_VISIBLE_ITEMS * ITEM_TOTAL_WIDTH, y: 0}}
-          additionalRenderRegions={[
-            {first: 0, last: NUMBER_OF_VISIBLE_ITEMS - 1},
-          ]}
+          initialScrollIndex={MID_INDEX}
+          contentOffset={{x: MID_INDEX * ITEM_TOTAL_WIDTH, y: 0}}
+          additionalRenderRegions={
+            additionalRenderRegionsEnabled
+              ? [{first: 0, last: NUMBER_OF_VISIBLE_ITEMS - 1}]
+              : undefined
+          }
           getItemLayout={(_d, index) => ({
             length: ITEM_TOTAL_WIDTH,
             offset: index * ITEM_TOTAL_WIDTH,
@@ -118,4 +133,6 @@ const styles = StyleSheet.create({
   },
   pressableText: {fontSize: 24 * scale},
   rowTitle: {color: 'white', marginBottom: 5 * scale},
+  switchSection: {flexDirection: 'row', paddingTop: 10 * scale},
+  switchText: {color: 'white'},
 });

--- a/packages/rn-tester/js/examples/FlatList/FlatList-additionalRenderRegions.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-additionalRenderRegions.js
@@ -11,9 +11,7 @@
 import type {RenderItemType} from 'react-native/Libraries/Lists/VirtualizedList';
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 import {useRNTesterTheme} from '../../components/RNTesterTheme';
-import BaseFlatListExample from './BaseFlatListExample';
 import * as React from 'react';
-import {useRef, useState} from 'react';
 import {
   FlatList,
   Pressable,
@@ -62,9 +60,9 @@ function Row({title, children}: {title: string, children: React.Node}) {
  */
 export function FlatList_additionalRenderRegions(): React.Node {
   const theme = useRNTesterTheme();
-  const listRef = useRef<?FlatList<ItemType>>(null);
+  const listRef = React.useRef<?FlatList<ItemType>>(null);
   const [additionalRenderRegionsEnabled, setAdditionalRenderRegionsEnabled] =
-    useState(true);
+    React.useState(true);
 
   const renderItem: RenderItemType<ItemType> = ({index}) => (
     <Pressable

--- a/packages/rn-tester/js/examples/FlatList/FlatList-additionalRenderRegions.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatList-additionalRenderRegions.js
@@ -1,0 +1,121 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {RenderItemType} from 'react-native/Libraries/Lists/VirtualizedList';
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+import {useRNTesterTheme} from '../../components/RNTesterTheme';
+import BaseFlatListExample from './BaseFlatListExample';
+import * as React from 'react';
+import {useRef} from 'react';
+import {
+  FlatList,
+  Pressable,
+  StyleSheet,
+  Text,
+  Dimensions,
+  TVFocusGuideView,
+} from 'react-native';
+
+const screenHeight = Dimensions.get('window').height;
+const screenWidth = Dimensions.get('window').width;
+const scale = screenHeight / 1080;
+
+const ITEM_SPACING = 5 * scale;
+const ITEM_WIDTH = 400 * scale;
+const ITEM_TOTAL_WIDTH = ITEM_WIDTH + ITEM_SPACING;
+const ITEM_HEIGHT = 100 * scale;
+const NUMBER_OF_VISIBLE_ITEMS = Math.ceil(screenWidth / ITEM_TOTAL_WIDTH);
+
+function Row({title, children}: {title: string, children: React.Node}) {
+  return (
+    <TVFocusGuideView autoFocus>
+      <Text style={styles.rowTitle}>{title}</Text>
+      {children}
+    </TVFocusGuideView>
+  );
+}
+type ItemType = number;
+const data: ItemType[] = [
+  0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21,
+  22, 23, 24, 25,
+];
+
+/**
+ * Constructs a case that tests if `additionalRenderRegions` property works as expected.
+ * Starts the FlatList at the middle of the list. Every item immediately scrolls the list
+ * to the beginning of the list on `onPress` event which leads to focus recovery issues
+ * due to virtualization. `additionalRenderRegions` prop makes sure the items at the beginning
+ * of the list are always rendered which makes focus recovery work deterministically.
+ *
+ * It indicates everything work as expected if focus is recovered to the first element (the one with text `0`)
+ * after the pressing action.
+ */
+export function FlatList_additionalRenderRegions(): React.Node {
+  const theme = useRNTesterTheme();
+  const listRef = useRef<?FlatList<ItemType>>(null);
+
+  const renderItem: RenderItemType<ItemType> = ({index}) => (
+    <Pressable
+      onPress={() => {
+        listRef.current?.scrollToOffset({offset: 0, animated: false});
+      }}
+      style={state => [
+        {backgroundColor: theme.TertiarySystemFillColor},
+        styles.pressableBaseStyle,
+        state.focused && {borderColor: theme.BorderColor, borderWidth: 4},
+      ]}>
+      <Text style={styles.pressableText}>{index}</Text>
+    </Pressable>
+  );
+
+  return (
+    <TVFocusGuideView autoFocus trapFocusLeft trapFocusRight>
+      <Row title="Initial Row">
+        <FlatList
+          ref={listRef}
+          horizontal
+          data={data}
+          renderItem={renderItem}
+          windowSize={1}
+          initialScrollIndex={NUMBER_OF_VISIBLE_ITEMS}
+          contentOffset={{x: NUMBER_OF_VISIBLE_ITEMS * ITEM_TOTAL_WIDTH, y: 0}}
+          additionalRenderRegions={[
+            {first: 0, last: NUMBER_OF_VISIBLE_ITEMS - 1},
+          ]}
+          getItemLayout={(_d, index) => ({
+            length: ITEM_TOTAL_WIDTH,
+            offset: index * ITEM_TOTAL_WIDTH,
+            index,
+          })}
+        />
+      </Row>
+    </TVFocusGuideView>
+  );
+}
+
+export default ({
+  title: 'Additional Render Regions',
+  name: 'additionalRenderRegions',
+  description: 'Test additionalRenderRegions feature on FlatList',
+  render: () => <FlatList_additionalRenderRegions />,
+}: RNTesterModuleExample);
+
+const styles = StyleSheet.create({
+  pressableBaseStyle: {
+    width: ITEM_WIDTH,
+    height: ITEM_HEIGHT,
+    alignItems: 'center',
+    justifyContent: 'center',
+    borderRadius: 4,
+    marginRight: ITEM_SPACING,
+  },
+  pressableText: {fontSize: 24 * scale},
+  rowTitle: {color: 'white', marginBottom: 5 * scale},
+});

--- a/packages/rn-tester/js/examples/FlatList/FlatListExampleIndex.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatListExampleIndex.js
@@ -19,6 +19,7 @@ import WithSeparatorsExample from './FlatList-withSeparators';
 import MultiColumnExample from './FlatList-multiColumn';
 import StickyHeadersExample from './FlatList-stickyHeaders';
 import NestedExample from './FlatList-nested';
+import AdditionalRengerRegionsExample from './FlatList-additionalRenderRegions';
 
 export default ({
   framework: 'React',
@@ -38,5 +39,6 @@ export default ({
     MultiColumnExample,
     StickyHeadersExample,
     NestedExample,
+    AdditionalRengerRegionsExample,
   ],
 }: RNTesterModule);

--- a/packages/rn-tester/js/examples/FlatList/FlatListExampleIndex.js
+++ b/packages/rn-tester/js/examples/FlatList/FlatListExampleIndex.js
@@ -19,7 +19,7 @@ import WithSeparatorsExample from './FlatList-withSeparators';
 import MultiColumnExample from './FlatList-multiColumn';
 import StickyHeadersExample from './FlatList-stickyHeaders';
 import NestedExample from './FlatList-nested';
-import AdditionalRengerRegionsExample from './FlatList-additionalRenderRegions';
+import AdditionalRenderRegionsExample from './FlatList-additionalRenderRegions';
 
 export default ({
   framework: 'React',
@@ -39,6 +39,6 @@ export default ({
     MultiColumnExample,
     StickyHeadersExample,
     NestedExample,
-    AdditionalRengerRegionsExample,
+    AdditionalRenderRegionsExample,
   ],
 }: RNTesterModule);

--- a/packages/virtualized-lists/Lists/VirtualizedList.d.ts
+++ b/packages/virtualized-lists/Lists/VirtualizedList.d.ts
@@ -390,4 +390,12 @@ export interface VirtualizedListWithoutRenderItemProps<ItemT>
     | React.ComponentType<CellRendererProps<ItemT>>
     | null
     | undefined;
+
+  /**
+   * Defines regions within the list that are exempt from virtualization,
+   * ensuring they remain rendered at all times. Useful for cases where
+   * users can't afford blank areas in certain parts of the list.
+   * The specified regions are lazily rendered after the initial render.
+   */
+  additionalRenderRegions?: {first: number; last: number}[] | undefined;
 }

--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1900,13 +1900,19 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
     first: number,
     last: number,
   }> => {
+    let nonViewportRenderRegions = [];
+
+    if (props?.additionalRenderRegions?.length) {
+      nonViewportRenderRegions = [...props.additionalRenderRegions];
+    }
+
     // Keep a viewport's worth of content around the last focused cell to allow
     // random navigation around it without any blanking. E.g. tabbing from one
     // focused item out of viewport to another.
     if (
       !(this._lastFocusedCellKey && this._cellRefs[this._lastFocusedCellKey])
     ) {
-      return [];
+      return nonViewportRenderRegions;
     }
 
     const lastFocusedCellRenderer = this._cellRefs[this._lastFocusedCellKey];
@@ -1920,7 +1926,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       VirtualizedList._getItemKey(props, focusedCellIndex) !==
         this._lastFocusedCellKey
     ) {
-      return [];
+      return nonViewportRenderRegions;
     }
 
     let first = focusedCellIndex;
@@ -1952,7 +1958,7 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
       ).length;
     }
 
-    return [{first, last}];
+    return [...nonViewportRenderRegions, {first, last}];
   };
 
   _updateViewableItems(

--- a/packages/virtualized-lists/Lists/VirtualizedListProps.js
+++ b/packages/virtualized-lists/Lists/VirtualizedListProps.js
@@ -285,6 +285,13 @@ type OptionalProps = {|
    * The legacy implementation is no longer supported.
    */
   legacyImplementation?: empty,
+  /**
+   * Defines regions within the list that are exempt from virtualization,
+   * ensuring they remain rendered at all times. Useful for cases where
+   * users can't afford blank areas in certain parts of the list.
+   * The specified regions are lazily rendered after the initial render.
+   */
+  additionalRenderRegions?: Array<{first: number, last: number}>,
 |};
 
 export type Props = {|


### PR DESCRIPTION
## Summary:
This PR implements the feature requested in https://github.com/react-native-tvos/react-native-tvos/discussions/663.

Introduces `additionalRenderRegions` prop for `VirtualizedList` that accepts `{ first: number; last: number }[]` that allows you to define regions in the list that are not subject to virtualization, ensuring they are always rendered. This is particularly useful for preventing blank areas in critical parts of the list.

### With `additionalRenderRegions`:

https://github.com/react-native-tvos/react-native-tvos/assets/22980987/9e10cf21-e942-4482-bf86-7d72fe1556be


### Without `additionalRenderRegions`:

https://github.com/react-native-tvos/react-native-tvos/assets/22980987/2c6c636b-bee0-42a9-9858-364527d7e9e9


## Changelog:
[GENERAL] [ADDED] - `additionalRenderRegions` feature implemented for `VirtualizedList`.

## Test Plan:
Launch `RNTesterApp`
Navigate to `FlatList` section in `Component`
Navigate to `Additional Render Regions` sub section
Focus to one of the items in the middle of the list and press
Observe focus lands on the item `0`

Set `additionalRenderRegions` to disabled (using the switch)
Scroll to the middle of the list 
Focus to one of the items in the middle of the list and press
Observe focus lands on `Components` on the top left
