### PR TITLE
feat: implement <TVTextScrollView /> for New Architecture

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -24,9 +24,14 @@
 #import "RCTEnhancedScrollView.h"
 #import "RCTFabricComponentsPlugins.h"
 
+#if TARGET_OS_TV
+#import "RCTTVRemoteHandler.h"
+#endif
+
 using namespace facebook::react;
 
 static const CGFloat kClippingLeeway = 44.0;
+static const float TV_DEFAULT_SWIPE_DURATION = 0.3;
 
 static UIScrollViewKeyboardDismissMode RCTUIKeyboardDismissModeFromProps(const ScrollViewProps &props)
 {
@@ -105,6 +110,9 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
   CGRect _prevFirstVisibleFrame;
   __weak UIView *_firstVisibleView;
+    
+  BOOL _blockFirstTouch;
+  NSMutableDictionary *_tvRemoteGestureRecognizers;
 }
 
 + (RCTScrollViewComponentView *_Nullable)findScrollViewComponentViewForView:(UIView *)view
@@ -139,6 +147,8 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     } else {
       _scrollEventThrottle = INFINITY;
     }
+      
+    _tvRemoteGestureRecognizers = [NSMutableDictionary new];
   }
 
   return self;
@@ -791,6 +801,242 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
     }
   }
 }
+
+#pragma mark Apple TV swipe and focus handling
+
+#if TARGET_OS_TV
+- (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context
+       withAnimationCoordinator:(UIFocusAnimationCoordinator *)coordinator
+{
+    if (context.previouslyFocusedView == context.nextFocusedView || !_props->isTVSelectable) {
+        return;
+    }
+    if (context.nextFocusedView == self) {
+        [self becomeFirstResponder];
+        [self addSwipeGestureRecognizers];
+        [self sendFocusNotification];
+        // if we enter the scroll view from different view then block first touch event since it is the event that triggered the focus
+        _blockFirstTouch = (unsigned long)context.focusHeading != 0;
+        [self addArrowsListeners];
+    } else if (context.previouslyFocusedView == self) {
+        [self removeArrowsListeners];
+        [self sendBlurNotification];
+        [self removeSwipeGestureRecognizers];
+        [self resignFirstResponder];
+        // if we leave the scroll view and go up, then scroll to top; if going down,
+        // scroll to bottom
+        // Similarly for left and right
+        RCTEnhancedScrollView *scrollView = (RCTEnhancedScrollView *)_scrollView;
+        if (context.focusHeading == UIFocusHeadingUp && scrollView.snapToStart) {
+            [self swipeVerticalScrollToOffset:0.0];
+        } else if(context.focusHeading == UIFocusHeadingDown && scrollView.snapToEnd) {
+            [self swipeVerticalScrollToOffset:scrollView.contentSize.height];
+        } else if(context.focusHeading == UIFocusHeadingLeft && scrollView.snapToStart) {
+            [self swipeHorizontalScrollToOffset:0.0];
+        } else if(context.focusHeading == UIFocusHeadingRight && scrollView.snapToEnd) {
+            [self swipeHorizontalScrollToOffset:scrollView.contentSize.width];
+        }
+    }
+}
+
+- (void)addArrowsListeners
+{
+    [[NSNotificationCenter defaultCenter] addObserver:self
+                                             selector:@selector(handleTVNavigationEventNotification:)
+                                                 name:@"RCTTVNavigationEventNotification"
+                                               object:nil];
+}
+
+- (void)removeArrowsListeners
+{
+    [[NSNotificationCenter defaultCenter] removeObserver:self
+                                                    name:@"RCTTVNavigationEventNotification"
+                                                  object:nil];
+}
+
+- (void)handleTVNavigationEventNotification:(NSNotification *)notif
+{
+    NSArray *supportedEvents = [NSArray arrayWithObjects:@"up", @"down", @"left", @"right", nil];
+
+    if (notif.object == nil || notif.object[@"eventType"] == nil || ![supportedEvents containsObject:notif.object[@"eventType"]] ) {
+        return;
+    }
+
+    if (_blockFirstTouch) {
+        _blockFirstTouch = NO;
+        return;
+    }
+
+    BOOL isHorizontal = _scrollView.contentSize.width > self.frame.size.width;
+    if (!isHorizontal) {
+        if ([notif.object[@"eventType"] isEqual: @"down"]) {
+            [self swipedDown];
+            return;
+        }
+
+        if ([notif.object[@"eventType"] isEqual: @"up"]) {
+            [self swipedUp];
+            return;
+        }
+    }
+
+    if ([notif.object[@"eventType"] isEqual: @"left"]) {
+        [self swipedLeft];
+        return;
+    }
+
+    if ([notif.object[@"eventType"] isEqual: @"right"]) {
+        [self swipedRight];
+        return;
+    }
+}
+
+- (BOOL)shouldUpdateFocusInContext:(UIFocusUpdateContext *)context
+{
+    BOOL isHorizontal = _scrollView.contentSize.width > self.frame.size.width;
+    // Keep focus inside the scroll view till the end of the content
+    if (isHorizontal) {
+        if ((context.focusHeading == UIFocusHeadingLeft && self.scrollView.contentOffset.x > 0)
+            || (context.focusHeading == UIFocusHeadingRight && self.scrollView.contentOffset.x < self.scrollView.contentSize.width - self.scrollView.visibleSize.width)
+        ) {
+            return [UIFocusSystem environment:self containsEnvironment:context.nextFocusedItem];
+        }
+    } else {
+        if ((context.focusHeading == UIFocusHeadingUp && self.scrollView.contentOffset.y > 0)
+            || (context.focusHeading == UIFocusHeadingDown && self.scrollView.contentOffset.y < self.scrollView.contentSize.height - self.scrollView.visibleSize.height)
+        ) {
+            return [UIFocusSystem environment:self containsEnvironment:context.nextFocusedItem];
+        }
+    }
+
+    return [super shouldUpdateFocusInContext:context];
+}
+
+- (void)sendFocusNotification
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
+                                                        object:@{ @"eventType": @"focus", @"tag": @([self tag]) }];
+}
+
+- (void)sendBlurNotification
+{
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
+                                                        object:@{ @"eventType": @"blur", @"tag": @([self tag]) }];
+}
+
+- (NSInteger)swipeVerticalInterval
+{
+    RCTEnhancedScrollView *scrollView = (RCTEnhancedScrollView *)_scrollView;
+    if (scrollView.snapToInterval) {
+        return scrollView.snapToInterval;
+    }
+    return scrollView.visibleSize.height / 2;
+}
+
+- (NSInteger)swipeHorizontalInterval
+{
+    RCTEnhancedScrollView *scrollView = (RCTEnhancedScrollView *)_scrollView;
+    if (scrollView.snapToInterval) {
+        return scrollView.snapToInterval;
+    }
+    return scrollView.visibleSize.width / 2;
+}
+
+- (NSTimeInterval)swipeDuration
+{
+    auto pressDuration = _props->tvParallaxProperties.pressDuration;
+    auto duration = pressDuration.has_value() ? pressDuration.value() : TV_DEFAULT_SWIPE_DURATION;
+    if (duration == 0.0) {
+        duration = TV_DEFAULT_SWIPE_DURATION;
+    }
+    return duration;
+}
+
+- (void)swipeVerticalScrollToOffset:(CGFloat)yOffset
+{
+    _blockFirstTouch = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        CGFloat limitedOffset = yOffset;
+        limitedOffset = MAX(limitedOffset, 0.0);
+        limitedOffset = MIN(limitedOffset, self.scrollView.contentSize.height - self.scrollView.visibleSize.height);
+        [UIView animateWithDuration:[self swipeDuration] animations:^{
+            self.scrollView.contentOffset =
+                CGPointMake(self.scrollView.contentOffset.x, limitedOffset);
+        }];
+    });
+}
+
+- (void)swipeHorizontalScrollToOffset:(CGFloat)xOffset
+{
+    _blockFirstTouch = NO;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        CGFloat limitedOffset = xOffset;
+        limitedOffset = MAX(limitedOffset, 0.0);
+        limitedOffset = MIN(limitedOffset, self.scrollView.contentSize.width - self.scrollView.visibleSize.width);
+        [UIView animateWithDuration:[self swipeDuration] animations:^{
+            self.scrollView.contentOffset =
+                CGPointMake(limitedOffset, self.scrollView.contentOffset.y);
+        }];
+    });
+}
+
+- (void)swipedUp
+{
+    CGFloat newOffset = self.scrollView.contentOffset.y - [self swipeVerticalInterval];
+    NSLog(@"Swiped up to %f", newOffset);
+    [self swipeVerticalScrollToOffset:newOffset];
+}
+
+- (void)swipedDown
+{
+    CGFloat newOffset = self.scrollView.contentOffset.y + [self swipeVerticalInterval];
+    NSLog(@"Swiped down to %f", newOffset);
+    [self swipeVerticalScrollToOffset:newOffset];
+}
+
+- (void)swipedLeft
+{
+    CGFloat newOffset = self.scrollView.contentOffset.x - [self swipeHorizontalInterval];
+    NSLog(@"Swiped left to %f", newOffset);
+    [self swipeHorizontalScrollToOffset:newOffset];
+}
+
+- (void)swipedRight
+{
+    CGFloat newOffset = self.scrollView.contentOffset.x + [self swipeHorizontalInterval];
+    NSLog(@"Swiped right to %f", newOffset);
+    [self swipeHorizontalScrollToOffset:newOffset];
+}
+
+- (void)addSwipeGestureRecognizers
+{
+    [self addSwipeGestureRecognizerWithSelector:@selector(swipedUp) direction:UISwipeGestureRecognizerDirectionUp name:RCTTVRemoteEventSwipeUp];
+    [self addSwipeGestureRecognizerWithSelector:@selector(swipedDown) direction:UISwipeGestureRecognizerDirectionDown name:RCTTVRemoteEventSwipeDown];
+    [self addSwipeGestureRecognizerWithSelector:@selector(swipedLeft) direction:UISwipeGestureRecognizerDirectionLeft name:RCTTVRemoteEventSwipeLeft];
+    [self addSwipeGestureRecognizerWithSelector:@selector(swipedRight) direction:UISwipeGestureRecognizerDirectionRight name:RCTTVRemoteEventSwipeRight];
+}
+
+- (void)addSwipeGestureRecognizerWithSelector:(nonnull SEL)selector
+                                    direction:(UISwipeGestureRecognizerDirection)direction
+                                         name:(NSString *)name
+{
+    UISwipeGestureRecognizer *recognizer = [[UISwipeGestureRecognizer alloc] initWithTarget:self action:selector];
+    recognizer.direction = direction;
+
+    _tvRemoteGestureRecognizers[name] = recognizer;
+    [self.scrollView addGestureRecognizer:recognizer];
+}
+
+- (void)removeSwipeGestureRecognizers
+{
+    NSArray *names = [self->_tvRemoteGestureRecognizers allKeys];
+    for (NSString *name in names) {
+        UIGestureRecognizer *r = self->_tvRemoteGestureRecognizers[name];
+        [self.scrollView removeGestureRecognizer:r];
+        [self->_tvRemoteGestureRecognizers removeObjectForKey:name];
+    }
+}
+#endif // TARGET_OS_TV
 
 @end
 

--- a/packages/rn-tester/js/examples/TVTextScrollView/TVTextScrollViewExample.js
+++ b/packages/rn-tester/js/examples/TVTextScrollView/TVTextScrollViewExample.js
@@ -31,7 +31,7 @@ exports.examples = [
     title: '<TVTextScrollView> with long text on TV platforms\n',
     description:
       'Ensure that TV platforms can scroll through a single block of text that is greater than the screen height',
-    render: function(): React.Node {
+    render: function (): React.Node {
       class BigTextBlock extends React.Component<
         {},
         {
@@ -63,6 +63,7 @@ exports.examples = [
                 {scrollDurations.map((s, i) => {
                   return (
                     <Button
+                      key={i}
                       selected={this.state.scrollDurationIndex === i}
                       label={scrollDurationLabels[i]}
                       onPress={() => {
@@ -81,6 +82,7 @@ exports.examples = [
                 {pageSizes.map((s, i) => {
                   return (
                     <Button
+                      key={i}
                       selected={this.state.pageSizeIndex === i}
                       label={pageSizeLabels[i]}
                       onPress={() => {


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When upstreaming [TVTextScrollView patch](https://github.com/react-native-tvos/react-native-tvos/pull/648) last month, we found that TVTextScrollView was not implemented at all for new architecture.

This PR adds swipe and focus handling in `RCTScrollViewComponentView` class (similar to `RCTScrollView`)

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

- [tvOS] [Fixed] - make TVTextScrollView component working when New Architecture is enabled

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

1. Go to tvOS `rn-tester` project and install pods with `RCT_NEW_ARCH_ENABLED=1` env
2. Run the RNTester app and go to `TVTextScrollViewExample`
3. Check that scrollviews can be scrolled using tv remote with swipes or dpad buttons
