### PR TITLE
fix: Add eventKeyAction to Apple NavigationEventNotification

### DIFF
--- a/packages/react-native/React/Base/RCTTVNavigationEventNotification.h
+++ b/packages/react-native/React/Base/RCTTVNavigationEventNotification.h
@@ -1,0 +1,37 @@
+/*
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef RCTTVNavigationEventNotification_h
+#define RCTTVNavigationEventNotification_h
+
+#import <Foundation/Foundation.h>
+#import "RCTTVNavigationEventNotificationConstants.h"
+#import "RCTTVRemoteHandlerConstants.h"
+
+@interface NSNotificationCenter (RCTTVNavigationEventNotification)
+
+- (void)postNavigationFocusEventWithTag:(NSNumber * _Nullable)eventTag
+                                 target:(NSNumber * _Nullable)eventTarget;
+
+- (void)postNavigationBlurEventWithTag:(NSNumber * _Nullable)eventTag
+                                target:(NSNumber * _Nullable)eventTarget;
+
+- (void)postNavigationPressEventWithType:(RCTTVRemoteEvent _Nonnull)eventType
+                               keyAction:(RCTTVRemoteEventKeyAction _Nullable)eventKeyAction
+                                     tag:(NSNumber * _Nullable)eventTag
+                                  target:(NSNumber * _Nullable)eventTarget;
+
+- (void)postNavigationTouchEventWithType:(RCTTVRemoteEvent _Nonnull)eventType
+                                    body:(NSDictionary * _Nullable)eventBody;
+@end
+
+@interface UIGestureRecognizer (RCTTVNavigationEventNotification)
+
+@property (readonly, nullable) RCTTVRemoteEventKeyAction eventKeyAction;
+@property (readonly, nonnull) NSDictionary *eventState;
+
+@end
+
+#endif /* RCTTVNavigationEventNotification_h */

--- a/packages/react-native/React/Base/RCTTVNavigationEventNotification.mm
+++ b/packages/react-native/React/Base/RCTTVNavigationEventNotification.mm
@@ -1,0 +1,106 @@
+/*
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTTVNavigationEventNotification.h"
+#import "RCTTVNavigationEventNotificationConstants.h"
+
+@implementation NSNotificationCenter (RCTTVNavigationEventNotification)
+- (void)postNavigationFocusEventWithTag:(NSNumber * _Nullable)eventTag
+                                 target:(NSNumber * _Nullable)eventTarget {
+    [self postNavigationEventWithtEventType:@"focus" keyAction:RCTTVRemoteEventKeyActionUnknown tag:eventTag target:eventTarget body:nil];
+}
+
+- (void)postNavigationBlurEventWithTag:(NSNumber * _Nullable)eventTag
+                                target:(NSNumber * _Nullable)eventTarget {
+    [self postNavigationEventWithtEventType:@"blur" keyAction:RCTTVRemoteEventKeyActionUnknown tag:eventTag target:eventTarget body:nil];
+}
+
+- (void)postNavigationPressEventWithType:(RCTTVRemoteEvent _Nonnull)eventType
+                               keyAction:(RCTTVRemoteEventKeyAction _Nullable)eventKeyAction
+                                     tag:(NSNumber * _Nullable)eventTag
+                                  target:(NSNumber * _Nullable)eventTarget {
+
+    [self postNavigationEventWithtEventType:eventType keyAction:eventKeyAction tag:eventTag target:eventTarget body:nil];
+
+}
+
+- (void)postNavigationTouchEventWithType:(RCTTVRemoteEvent _Nonnull)eventType
+                                    body:(NSDictionary * _Nullable)eventBody {
+    [self postNavigationEventWithtEventType:eventType keyAction:nil tag:nil target:nil body:eventBody];
+
+}
+
+#pragma mark - Private
+
+- (void)postNavigationEventWithtEventType:(NSString *)eventType
+                                keyAction:(RCTTVRemoteEventKeyAction _Nullable)eventKeyAction
+                                      tag:(NSNumber * _Nullable)eventTag
+                                   target:(NSNumber * _Nullable)eventTarget
+                                     body:(NSDictionary * _Nullable)eventBody
+
+{
+    NSMutableDictionary *payload = [@{RCTTVNavigationEventNotificationKeyEventType : eventType} mutableCopy];
+
+    if (eventKeyAction != nil) {
+        payload[RCTTVNavigationEventNotificationKeyEventKeyAction] = eventKeyAction;
+    }
+
+    if (eventTag != nil) {
+        payload[RCTTVNavigationEventNotificationKeyTag] = eventTag;
+    }
+
+    if (eventTarget != nil) {
+        payload[RCTTVNavigationEventNotificationKeyTarget] = eventTarget;
+    }
+
+    if (eventBody != nil && eventBody.count > 0) {
+        payload[RCTTVNavigationEventNotificationKeyBody] = eventBody;
+    }
+
+    [self postNotificationName:RCTTVNavigationEventNotificationName object:[payload copy]];
+}
+
+@end
+
+@implementation UIGestureRecognizer (RCTTVNavigationEventNotification)
+
+- (RCTTVRemoteEventKeyAction _Nullable)eventKeyAction
+{
+    switch (self.state) {
+        case UIGestureRecognizerStateBegan:
+            return RCTTVRemoteEventKeyActionDown;
+        case UIGestureRecognizerStateEnded:
+            return RCTTVRemoteEventKeyActionUp;
+        default:
+            return nil;
+    }
+}
+
+- (NSDictionary * _Nonnull)eventState {
+    NSString *eventBodyState = self.eventBodyState;
+    if (eventBodyState) {
+        return @{@"state": eventBodyState};
+    }
+    else {
+        return @{};
+    }
+}
+
+#pragma mark - Private
+
+- (NSString * _Nullable)eventBodyState {
+    switch (self.state) {
+        case UIGestureRecognizerStateBegan:
+            return @"Began";
+        case UIGestureRecognizerStateChanged:
+            return @"Changed";
+        case UIGestureRecognizerStateEnded:
+            return @"Ended";
+        default:
+            return nil;
+    }
+}
+
+@end

--- a/packages/react-native/React/Base/RCTTVNavigationEventNotificationConstants.h
+++ b/packages/react-native/React/Base/RCTTVNavigationEventNotificationConstants.h
@@ -1,0 +1,25 @@
+/*
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef RCTTVNavigationEventNotificationConstants_h
+#define RCTTVNavigationEventNotificationConstants_h
+
+#import <Foundation/Foundation.h>
+
+extern NSString * _Nonnull const RCTTVNavigationEventNotificationName;
+
+typedef NSString *RCTTVNavigationEventNotificationKey NS_TYPED_ENUM;
+extern RCTTVNavigationEventNotificationKey _Nonnull const RCTTVNavigationEventNotificationKeyEventType;
+extern RCTTVNavigationEventNotificationKey _Nonnull const RCTTVNavigationEventNotificationKeyEventKeyAction;
+extern RCTTVNavigationEventNotificationKey _Nonnull const RCTTVNavigationEventNotificationKeyTag;
+extern RCTTVNavigationEventNotificationKey _Nonnull const RCTTVNavigationEventNotificationKeyTarget;
+extern RCTTVNavigationEventNotificationKey _Nonnull const RCTTVNavigationEventNotificationKeyBody;
+
+typedef NSNumber *RCTTVRemoteEventKeyAction NS_TYPED_ENUM;
+extern RCTTVRemoteEventKeyAction _Nonnull const RCTTVRemoteEventKeyActionUnknown;
+extern RCTTVRemoteEventKeyAction _Nonnull const RCTTVRemoteEventKeyActionDown;
+extern RCTTVRemoteEventKeyAction _Nonnull const RCTTVRemoteEventKeyActionUp;
+
+#endif /* RCTTVNavigationEventNotificationConstants_h */

--- a/packages/react-native/React/Base/RCTTVNavigationEventNotificationConstants.mm
+++ b/packages/react-native/React/Base/RCTTVNavigationEventNotificationConstants.mm
@@ -1,0 +1,18 @@
+/*
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTTVNavigationEventNotificationConstants.h"
+
+NSString *const RCTTVNavigationEventNotificationName = @"RCTTVNavigationEventNotification";
+
+RCTTVNavigationEventNotificationKey _Nonnull const RCTTVNavigationEventNotificationKeyEventType = @"eventType";
+RCTTVNavigationEventNotificationKey _Nonnull const RCTTVNavigationEventNotificationKeyEventKeyAction = @"eventKeyAction";
+RCTTVNavigationEventNotificationKey _Nonnull const RCTTVNavigationEventNotificationKeyTag = @"tag";
+RCTTVNavigationEventNotificationKey _Nonnull const RCTTVNavigationEventNotificationKeyTarget = @"target";
+RCTTVNavigationEventNotificationKey _Nonnull const RCTTVNavigationEventNotificationKeyBody = @"body";
+
+RCTTVRemoteEventKeyAction _Nonnull const RCTTVRemoteEventKeyActionUnknown = @(-1);
+RCTTVRemoteEventKeyAction _Nonnull const RCTTVRemoteEventKeyActionDown = @(0);
+RCTTVRemoteEventKeyAction _Nonnull const RCTTVRemoteEventKeyActionUp = @(1);

--- a/packages/react-native/React/Base/RCTTVRemoteHandler.h
+++ b/packages/react-native/React/Base/RCTTVRemoteHandler.h
@@ -16,32 +16,6 @@ extern NSString * _Nonnull const RCTTVDisablePanGestureNotification;
 extern NSString * _Nonnull const RCTTVEnableGestureHandlersCancelTouchesNotification;
 extern NSString * _Nonnull const RCTTVDisableGestureHandlersCancelTouchesNotification;
 
-extern NSString * _Nonnull const RCTTVRemoteEventMenu;
-extern NSString * _Nonnull const RCTTVRemoteEventPlayPause;
-extern NSString * _Nonnull const RCTTVRemoteEventSelect;
-
-extern NSString * _Nonnull const RCTTVRemoteEventLongPlayPause;
-extern NSString * _Nonnull const RCTTVRemoteEventLongSelect;
-extern NSString * _Nonnull const RCTTVRemoteEventLongUp;
-extern NSString * _Nonnull const RCTTVRemoteEventLongDown;
-extern NSString * _Nonnull const RCTTVRemoteEventLongLeft;
-extern NSString * _Nonnull const RCTTVRemoteEventLongRight;
-
-extern NSString * _Nonnull const RCTTVRemoteEventLeft;
-extern NSString * _Nonnull const RCTTVRemoteEventRight;
-extern NSString * _Nonnull const RCTTVRemoteEventUp;
-extern NSString * _Nonnull const RCTTVRemoteEventDown;
-
-extern NSString * _Nonnull const RCTTVRemoteEventPageUp;
-extern NSString * _Nonnull const RCTTVRemoteEventPageDown;
-
-extern NSString * _Nonnull const RCTTVRemoteEventSwipeLeft;
-extern NSString * _Nonnull const RCTTVRemoteEventSwipeRight;
-extern NSString * _Nonnull const RCTTVRemoteEventSwipeUp;
-extern NSString * _Nonnull const RCTTVRemoteEventSwipeDown;
-
-extern NSString * _Nonnull const RCTTVRemoteEventPan;
-
 @interface RCTTVRemoteHandler : NSObject
 
 - (instancetype _Nonnull )initWithView:(UIView * _Nonnull)view;

--- a/packages/react-native/React/Base/RCTTVRemoteHandler.m
+++ b/packages/react-native/React/Base/RCTTVRemoteHandler.m
@@ -15,6 +15,7 @@
 #import "RCTLog.h"
 #import "RCTRootView.h"
 #import "RCTTVNavigationEventEmitter.h"
+#import "RCTTVNavigationEventNotification.h"
 #import "RCTUIManager.h"
 #import "RCTUtils.h"
 #import "RCTView.h"
@@ -29,32 +30,6 @@ NSString *const RCTTVDisablePanGestureNotification = @"RCTTVDisablePanGestureNot
 NSString *const RCTTVEnableGestureHandlersCancelTouchesNotification = @"RCTTVEnableGestureHandlersCancelTouchesNotification";
 NSString *const RCTTVDisableGestureHandlersCancelTouchesNotification = @"RCTTVDisableGestureHandlersCancelTouchesNotification";
 
-NSString *const RCTTVRemoteEventMenu = @"menu";
-NSString *const RCTTVRemoteEventPlayPause = @"playPause";
-NSString *const RCTTVRemoteEventSelect = @"select";
-
-NSString *const RCTTVRemoteEventLongPlayPause = @"longPlayPause";
-NSString *const RCTTVRemoteEventLongSelect = @"longSelect";
-NSString *const RCTTVRemoteEventLongUp = @"longUp";
-NSString *const RCTTVRemoteEventLongDown = @"longDown";
-NSString *const RCTTVRemoteEventLongLeft = @"longLeft";
-NSString *const RCTTVRemoteEventLongRight = @"longRight";
-
-NSString *const RCTTVRemoteEventLeft = @"left";
-NSString *const RCTTVRemoteEventRight = @"right";
-NSString *const RCTTVRemoteEventUp = @"up";
-NSString *const RCTTVRemoteEventDown = @"down";
-
-NSString *const RCTTVRemoteEventPageUp = @"pageUp";
-NSString *const RCTTVRemoteEventPageDown = @"pageDown";
-
-NSString *const RCTTVRemoteEventSwipeLeft = @"swipeLeft";
-NSString *const RCTTVRemoteEventSwipeRight = @"swipeRight";
-NSString *const RCTTVRemoteEventSwipeUp = @"swipeUp";
-NSString *const RCTTVRemoteEventSwipeDown = @"swipeDown";
-
-NSString *const RCTTVRemoteEventPan = @"pan";
-
 @interface RCTTVRemoteHandler()
 
 @property (nonatomic, copy, readonly) NSDictionary<NSString *, UIGestureRecognizer *> *tvRemoteGestureRecognizers;
@@ -68,20 +43,12 @@ NSString *const RCTTVRemoteEventPan = @"pan";
   NSMutableDictionary<NSString *, UIGestureRecognizer *> *_tvRemoteGestureRecognizers;
 }
 
-static NSNumber * _Nonnull RCTTVRemoteEventKeyActionDown;
-static NSNumber * _Nonnull RCTTVRemoteEventKeyActionUp;
-
 #pragma mark -
 #pragma mark Static settings for menu key and pan gesture
 
 static __volatile BOOL __useMenuKey = NO;
 static __volatile BOOL __usePanGesture = NO;
 static __volatile BOOL __gestureHandlersCancelTouches = YES;
-
-+ (void)initialize {
-    RCTTVRemoteEventKeyActionDown = @0;
-    RCTTVRemoteEventKeyActionUp = @1;
-}
 
 + (BOOL)useMenuKey
 {
@@ -378,139 +345,117 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
 
 - (void)playPausePressed:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventPlayPause eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventPlayPause keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)menuPressed:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventMenu eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventMenu keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)selectPressed:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventSelect eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventSelect keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)longPlayPausePressed:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventLongPlayPause eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongPlayPause keyAction:r.eventKeyAction tag:nil target:nil];
 
 #if RCT_DEV
-  // If shake to show is enabled on device, use long play/pause event to show dev menu
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTShowDevMenuNotification" object:nil];
+    // If shake to show is enabled on device, use long play/pause event to show dev menu
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTShowDevMenuNotification" object:nil];
 #endif
 }
 
 - (void)longSelectPressed:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventLongSelect eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)longUpPressed:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventLongUp eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongUp keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)longDownPressed:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventLongDown eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongDown keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)longLeftPressed:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventLongLeft eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongLeft keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)longRightPressed:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventLongRight eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongRight keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)swipedUp:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventSwipeUp eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationTouchEventWithType:RCTTVRemoteEventSwipeUp body:r.eventState];
 }
 
 - (void)swipedDown:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventSwipeDown eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationTouchEventWithType:RCTTVRemoteEventSwipeDown body:r.eventState];
 }
 
 - (void)swipedLeft:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventSwipeLeft eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationTouchEventWithType:RCTTVRemoteEventSwipeLeft body:r.eventState];
 }
 
 - (void)swipedRight:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventSwipeRight eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationTouchEventWithType:RCTTVRemoteEventSwipeRight body:r.eventState];
 }
 
 - (void)tappedUp:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventUp eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventUp keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)tappedDown:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventDown eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventDown keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)tappedPageUp:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventPageUp eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventPageUp keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)tappedPageDown:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventPageDown eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventPageDown keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)tappedLeft:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventLeft eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLeft keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)tappedRight:(UIGestureRecognizer *)r
 {
-  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
-  [self sendAppleTVEvent:RCTTVRemoteEventRight eventKeyAction:eventKeyAction];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventRight keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)panned:(UIPanGestureRecognizer *)gesture {
     UIView *rootView = [self view];
-    NSString *gestureState = [self recognizerStateToString:gesture.state];
+    NSMutableDictionary *eventBody= [gesture.eventState mutableCopy];
     CGPoint translation = [gesture translationInView:rootView];
     CGPoint velocity = [gesture velocityInView:rootView];
 
-    if (gestureState) {
-        NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:gesture];
-        [self sendAppleTVEvent:RCTTVRemoteEventPan
-                eventKeyAction:eventKeyAction
-                          body:@{@"state": gestureState,
-                                 @"x": [NSNumber numberWithInt:translation.x],
-                                 @"y": [NSNumber numberWithInt:translation.y],
-                                 @"velocityX": [NSNumber numberWithFloat:velocity.x],
-                                 @"velocityY": [NSNumber numberWithFloat:velocity.y],
-                               }];
+    if (eventBody.count > 0) {
+        eventBody[@"x"] = [NSNumber numberWithInt:translation.x];
+        eventBody[@"y"] = [NSNumber numberWithInt:translation.y];
+        eventBody[@"velocityX"] = [NSNumber numberWithFloat:velocity.x];
+        eventBody[@"velocityY"] = [NSNumber numberWithFloat:velocity.y];
+
+        [[NSNotificationCenter defaultCenter] postNavigationTouchEventWithType:RCTTVRemoteEventPan body:[eventBody copy]];
     }
 }
 
@@ -546,63 +491,5 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
   recognizer.cancelsTouchesInView = __gestureHandlersCancelTouches;
 
   _tvRemoteGestureRecognizers[name] = recognizer;
-}
-
-#pragma mark -
-#pragma mark Helper methods
-
-- (void)sendAppleTVEvent:(NSString *)eventType eventKeyAction:(NSNumber * __nullable)eventKeyAction
-{
-    [self sendAppleTVEvent:eventType eventKeyAction:eventKeyAction body: nil];
-}
-
-- (void)sendAppleTVEvent:(NSString *)eventType
-          eventKeyAction:(NSNumber * __nullable)eventKeyAction
-                    body:(NSDictionary * __nullable)body
-{
-    NSMutableDictionary *payload = [@{@"eventType" : eventType} mutableCopy];
-
-    if (eventKeyAction != nil) {
-        payload[@"eventKeyAction"] = eventKeyAction;
-    }
-
-    if (body != nil) {
-        payload[@"body"] = body;
-    }
-
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-                                                        object:[payload copy]];
-}
-
-- (NSString * __nullable)recognizerStateToString:(UIGestureRecognizerState)state {
-    switch (state) {
-        case UIGestureRecognizerStateBegan:
-            return @"Began";
-        case UIGestureRecognizerStateChanged:
-            return @"Changed";
-        case UIGestureRecognizerStateEnded:
-            return @"Ended";
-        default:
-            return nil;
-    }
-}
-
-- (NSNumber * __nullable)eventKeyActionForGestureRecognizer:(UIGestureRecognizer * _Nonnull)gestureRecognizer
-{
-    UIGestureRecognizerState state = gestureRecognizer.state;
-    switch (state) {
-        case UIGestureRecognizerStateBegan:
-            return RCTTVRemoteEventKeyActionDown;
-        case UIGestureRecognizerStateEnded:
-            return RCTTVRemoteEventKeyActionUp;
-        case UIGestureRecognizerStatePossible:
-            return nil;
-        case UIGestureRecognizerStateChanged:
-            return nil;
-        case UIGestureRecognizerStateCancelled:
-            return nil;
-        case UIGestureRecognizerStateFailed:
-            return nil;
-    }
 }
 @end

--- a/packages/react-native/React/Base/RCTTVRemoteHandler.m
+++ b/packages/react-native/React/Base/RCTTVRemoteHandler.m
@@ -68,12 +68,20 @@ NSString *const RCTTVRemoteEventPan = @"pan";
   NSMutableDictionary<NSString *, UIGestureRecognizer *> *_tvRemoteGestureRecognizers;
 }
 
+static NSNumber * _Nonnull RCTTVRemoteEventKeyActionDown;
+static NSNumber * _Nonnull RCTTVRemoteEventKeyActionUp;
+
 #pragma mark -
 #pragma mark Static settings for menu key and pan gesture
 
 static __volatile BOOL __useMenuKey = NO;
 static __volatile BOOL __usePanGesture = NO;
 static __volatile BOOL __gestureHandlersCancelTouches = YES;
+
++ (void)initialize {
+    RCTTVRemoteEventKeyActionDown = @0;
+    RCTTVRemoteEventKeyActionUp = @1;
+}
 
 + (BOOL)useMenuKey
 {
@@ -370,22 +378,26 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
 
 - (void)playPausePressed:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventPlayPause];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventPlayPause eventKeyAction:eventKeyAction];
 }
 
 - (void)menuPressed:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventMenu];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventMenu eventKeyAction:eventKeyAction];
 }
 
 - (void)selectPressed:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventSelect];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventSelect eventKeyAction:eventKeyAction];
 }
 
 - (void)longPlayPausePressed:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventLongPlayPause];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventLongPlayPause eventKeyAction:eventKeyAction];
 
 #if RCT_DEV
   // If shake to show is enabled on device, use long play/pause event to show dev menu
@@ -395,77 +407,92 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
 
 - (void)longSelectPressed:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventLongSelect];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventLongSelect eventKeyAction:eventKeyAction];
 }
 
 - (void)longUpPressed:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventLongUp];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventLongUp eventKeyAction:eventKeyAction];
 }
 
 - (void)longDownPressed:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventLongDown];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventLongDown eventKeyAction:eventKeyAction];
 }
 
 - (void)longLeftPressed:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventLongLeft];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventLongLeft eventKeyAction:eventKeyAction];
 }
 
 - (void)longRightPressed:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventLongRight];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventLongRight eventKeyAction:eventKeyAction];
 }
 
 - (void)swipedUp:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventSwipeUp];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventSwipeUp eventKeyAction:eventKeyAction];
 }
 
 - (void)swipedDown:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventSwipeDown];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventSwipeDown eventKeyAction:eventKeyAction];
 }
 
 - (void)swipedLeft:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventSwipeLeft];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventSwipeLeft eventKeyAction:eventKeyAction];
 }
 
 - (void)swipedRight:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventSwipeRight];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventSwipeRight eventKeyAction:eventKeyAction];
 }
 
 - (void)tappedUp:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventUp];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventUp eventKeyAction:eventKeyAction];
 }
 
 - (void)tappedDown:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventDown];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventDown eventKeyAction:eventKeyAction];
 }
 
 - (void)tappedPageUp:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventPageUp];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventPageUp eventKeyAction:eventKeyAction];
 }
 
 - (void)tappedPageDown:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventPageDown];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventPageDown eventKeyAction:eventKeyAction];
 }
 
 - (void)tappedLeft:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventLeft];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventLeft eventKeyAction:eventKeyAction];
 }
 
 - (void)tappedRight:(UIGestureRecognizer *)r
 {
-  [self sendAppleTVEvent:RCTTVRemoteEventRight];
+  NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:r];
+  [self sendAppleTVEvent:RCTTVRemoteEventRight eventKeyAction:eventKeyAction];
 }
 
 - (void)panned:(UIPanGestureRecognizer *)gesture {
@@ -475,12 +502,15 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
     CGPoint velocity = [gesture velocityInView:rootView];
 
     if (gestureState) {
-        [self sendAppleTVEvent:RCTTVRemoteEventPan withBody:@{@"state": gestureState,
-                                                              @"x": [NSNumber numberWithInt:translation.x],
-                                                              @"y": [NSNumber numberWithInt:translation.y],
-                                                              @"velocityX": [NSNumber numberWithFloat:velocity.x],
-                                                              @"velocityY": [NSNumber numberWithFloat:velocity.y],
-                                                            }];
+        NSNumber *eventKeyAction = [self eventKeyActionForGestureRecognizer:gesture];
+        [self sendAppleTVEvent:RCTTVRemoteEventPan
+                eventKeyAction:eventKeyAction
+                          body:@{@"state": gestureState,
+                                 @"x": [NSNumber numberWithInt:translation.x],
+                                 @"y": [NSNumber numberWithInt:translation.y],
+                                 @"velocityX": [NSNumber numberWithFloat:velocity.x],
+                                 @"velocityY": [NSNumber numberWithFloat:velocity.y],
+                               }];
     }
 }
 
@@ -521,23 +551,30 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
 #pragma mark -
 #pragma mark Helper methods
 
-- (void)sendAppleTVEvent:(NSString *)eventType
+- (void)sendAppleTVEvent:(NSString *)eventType eventKeyAction:(NSNumber * __nullable)eventKeyAction
 {
-    [self sendAppleTVEvent:eventType withBody: nil];
+    [self sendAppleTVEvent:eventType eventKeyAction:eventKeyAction body: nil];
 }
 
 - (void)sendAppleTVEvent:(NSString *)eventType
-                withBody:(NSDictionary * __nullable)body
+          eventKeyAction:(NSNumber * __nullable)eventKeyAction
+                    body:(NSDictionary * __nullable)body
 {
-    NSDictionary *payload = (body != nil) ?
-                                @{@"eventType" : eventType, @"body": body} :
-                                @{@"eventType" : eventType};
+    NSMutableDictionary *payload = [@{@"eventType" : eventType} mutableCopy];
 
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-                                                      object:payload];
+    if (eventKeyAction != nil) {
+        payload[@"eventKeyAction"] = eventKeyAction;
+    }
+
+    if (body != nil) {
+        payload[@"body"] = body;
+    }
+
+    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
+                                                        object:[payload copy]];
 }
 
-- (NSString *)recognizerStateToString:(UIGestureRecognizerState)state {
+- (NSString * __nullable)recognizerStateToString:(UIGestureRecognizerState)state {
     switch (state) {
         case UIGestureRecognizerStateBegan:
             return @"Began";
@@ -550,4 +587,22 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
     }
 }
 
+- (NSNumber * __nullable)eventKeyActionForGestureRecognizer:(UIGestureRecognizer * _Nonnull)gestureRecognizer
+{
+    UIGestureRecognizerState state = gestureRecognizer.state;
+    switch (state) {
+        case UIGestureRecognizerStateBegan:
+            return RCTTVRemoteEventKeyActionDown;
+        case UIGestureRecognizerStateEnded:
+            return RCTTVRemoteEventKeyActionUp;
+        case UIGestureRecognizerStatePossible:
+            return nil;
+        case UIGestureRecognizerStateChanged:
+            return nil;
+        case UIGestureRecognizerStateCancelled:
+            return nil;
+        case UIGestureRecognizerStateFailed:
+            return nil;
+    }
+}
 @end

--- a/packages/react-native/React/Base/RCTTVRemoteHandlerConstants.h
+++ b/packages/react-native/React/Base/RCTTVRemoteHandlerConstants.h
@@ -1,0 +1,37 @@
+/*
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#ifndef RCTTVRemoteHandlerConstants_h
+#define RCTTVRemoteHandlerConstants_h
+
+typedef NSString *RCTTVRemoteEvent NS_TYPED_ENUM;
+
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventMenu;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventPlayPause;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventSelect;
+
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventLongPlayPause;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventLongSelect;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventLongUp;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventLongDown;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventLongLeft;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventLongRight;
+
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventLeft;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventRight;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventUp;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventDown;
+
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventPageUp;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventPageDown;
+
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventSwipeLeft;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventSwipeRight;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventSwipeUp;
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventSwipeDown;
+
+extern RCTTVRemoteEvent _Nonnull const RCTTVRemoteEventPan;
+
+#endif /* RCTTVRemoteHandlerConstants_h */

--- a/packages/react-native/React/Base/RCTTVRemoteHandlerConstants.mm
+++ b/packages/react-native/React/Base/RCTTVRemoteHandlerConstants.mm
@@ -1,0 +1,32 @@
+/*
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import "RCTTVRemoteHandlerConstants.h"
+
+RCTTVRemoteEvent const RCTTVRemoteEventMenu = @"menu";
+RCTTVRemoteEvent const RCTTVRemoteEventPlayPause = @"playPause";
+RCTTVRemoteEvent const RCTTVRemoteEventSelect = @"select";
+
+RCTTVRemoteEvent const RCTTVRemoteEventLongPlayPause = @"longPlayPause";
+RCTTVRemoteEvent const RCTTVRemoteEventLongSelect = @"longSelect";
+RCTTVRemoteEvent const RCTTVRemoteEventLongUp = @"longUp";
+RCTTVRemoteEvent const RCTTVRemoteEventLongDown = @"longDown";
+RCTTVRemoteEvent const RCTTVRemoteEventLongLeft = @"longLeft";
+RCTTVRemoteEvent const RCTTVRemoteEventLongRight = @"longRight";
+
+RCTTVRemoteEvent const RCTTVRemoteEventLeft = @"left";
+RCTTVRemoteEvent const RCTTVRemoteEventRight = @"right";
+RCTTVRemoteEvent const RCTTVRemoteEventUp = @"up";
+RCTTVRemoteEvent const RCTTVRemoteEventDown = @"down";
+
+RCTTVRemoteEvent const RCTTVRemoteEventPageUp = @"pageUp";
+RCTTVRemoteEvent const RCTTVRemoteEventPageDown = @"pageDown";
+
+RCTTVRemoteEvent const RCTTVRemoteEventSwipeLeft = @"swipeLeft";
+RCTTVRemoteEvent const RCTTVRemoteEventSwipeRight = @"swipeRight";
+RCTTVRemoteEvent const RCTTVRemoteEventSwipeUp = @"swipeUp";
+RCTTVRemoteEvent const RCTTVRemoteEventSwipeDown = @"swipeDown";
+
+RCTTVRemoteEvent const RCTTVRemoteEventPan = @"pan";

--- a/packages/react-native/React/CoreModules/RCTTVNavigationEventEmitter.mm
+++ b/packages/react-native/React/CoreModules/RCTTVNavigationEventEmitter.mm
@@ -6,6 +6,7 @@
  */
 
 #import "RCTTVNavigationEventEmitter.h"
+#import "RCTTVNavigationEventNotificationConstants.h"
 
 #import <FBReactNativeSpec/FBReactNativeSpec.h>
 #import "CoreModulesPlugins.h"
@@ -29,7 +30,7 @@ RCT_EXPORT_MODULE()
   if (self = [super init]) {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleTVNavigationEventNotification:)
-                                                 name:@"RCTTVNavigationEventNotification"
+                                                 name:RCTTVNavigationEventNotificationName
                                                object:nil];
   }
   return self;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -11,6 +11,7 @@
 #import <React/RCTBridge+Private.h>
 #import <React/RCTConstants.h>
 #import <React/RCTScrollEvent.h>
+#import <React/RCTTVNavigationEventNotification.h>
 
 #import <react/renderer/components/scrollview/RCTComponentViewHelpers.h>
 #import <react/renderer/components/scrollview/ScrollViewComponentDescriptor.h>
@@ -843,22 +844,22 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleTVNavigationEventNotification:)
-                                                 name:@"RCTTVNavigationEventNotification"
+                                                 name:RCTTVNavigationEventNotificationName
                                                object:nil];
 }
 
 - (void)removeArrowsListeners
 {
     [[NSNotificationCenter defaultCenter] removeObserver:self
-                                                    name:@"RCTTVNavigationEventNotification"
+                                                    name:RCTTVNavigationEventNotificationName
                                                   object:nil];
 }
 
 - (void)handleTVNavigationEventNotification:(NSNotification *)notif
 {
-    NSArray *supportedEvents = [NSArray arrayWithObjects:@"up", @"down", @"left", @"right", nil];
+    NSArray *supportedEvents = @[RCTTVRemoteEventUp, RCTTVRemoteEventDown, RCTTVRemoteEventLeft, RCTTVRemoteEventRight];
 
-    if (notif.object == nil || notif.object[@"eventType"] == nil || ![supportedEvents containsObject:notif.object[@"eventType"]] ) {
+    if (notif.object == nil || notif.object[RCTTVNavigationEventNotificationKeyEventType] == nil || ![supportedEvents containsObject:notif.object[RCTTVNavigationEventNotificationKeyEventType]] ) {
         return;
     }
 
@@ -869,23 +870,23 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
     BOOL isHorizontal = _scrollView.contentSize.width > self.frame.size.width;
     if (!isHorizontal) {
-        if ([notif.object[@"eventType"] isEqual: @"down"]) {
+        if ([notif.object[RCTTVNavigationEventNotificationKeyEventType] isEqual:RCTTVRemoteEventDown]) {
             [self swipedDown];
             return;
         }
 
-        if ([notif.object[@"eventType"] isEqual: @"up"]) {
+        if ([notif.object[RCTTVNavigationEventNotificationKeyEventType] isEqual:RCTTVRemoteEventUp]) {
             [self swipedUp];
             return;
         }
     }
 
-    if ([notif.object[@"eventType"] isEqual: @"left"]) {
+    if ([notif.object[RCTTVNavigationEventNotificationKeyEventType] isEqual:RCTTVRemoteEventLeft]) {
         [self swipedLeft];
         return;
     }
 
-    if ([notif.object[@"eventType"] isEqual: @"right"]) {
+    if ([notif.object[RCTTVNavigationEventNotificationKeyEventType] isEqual:RCTTVRemoteEventRight]) {
         [self swipedRight];
         return;
     }
@@ -914,14 +915,12 @@ static void RCTSendScrollEventForNativeAnimations_DEPRECATED(UIScrollView *scrol
 
 - (void)sendFocusNotification
 {
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-                                                        object:@{ @"eventType": @"focus", @"tag": @([self tag]) }];
+    [[NSNotificationCenter defaultCenter] postNavigationFocusEventWithTag:@(self.tag) target:nil];
 }
 
 - (void)sendBlurNotification
 {
-    [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-                                                        object:@{ @"eventType": @"blur", @"tag": @([self tag]) }];
+    [[NSNotificationCenter defaultCenter] postNavigationBlurEventWithTag:@(self.tag) target:nil];
 }
 
 - (NSInteger)swipeVerticalInterval

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -19,6 +19,7 @@
 #import <React/RCTLog.h>
 
 #import <React/RCTRootComponentView.h>
+#import <React/RCTTVNavigationEventNotification.h>
 
 #import <react/renderer/components/view/ViewComponentDescriptor.h>
 #import <react/renderer/components/view/ViewEventEmitter.h>
@@ -237,35 +238,25 @@ using namespace facebook::react;
 
 - (void)sendFocusNotification:(__unused UIFocusUpdateContext *)context
 {
-    [self sendNotificationWithEventType:@"focus"];
+    [[NSNotificationCenter defaultCenter] postNavigationFocusEventWithTag:@(self.tag) target:@(self.tag)];
 }
 
 - (void)sendBlurNotification:(__unused UIFocusUpdateContext *)context
 {
-    [self sendNotificationWithEventType:@"blur"];
+    [[NSNotificationCenter defaultCenter] postNavigationBlurEventWithTag:@(self.tag) target:@(self.tag)];
 }
 
 - (void)sendSelectNotification:(UIGestureRecognizer *)recognizer
 {
-    [self sendNotificationWithEventType:@"select"];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventSelect keyAction:RCTTVRemoteEventKeyActionUp tag:@(self.tag) target:@(self.tag)];
 }
 
 - (void)sendLongSelectNotification:(UIGestureRecognizer *)recognizer
 {
-  [self sendNotificationWithEventType:@"longSelect"];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:recognizer.eventKeyAction tag:@(self.tag) target:@(self.tag)];
 }
 
-- (void)sendNotificationWithEventType:(NSString * __nonnull)eventType
-{
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-                                                      object:@{
-                                                          @"eventType":eventType,
-                                                          @"tag":@([self tag]),
-                                                          @"target":@([self tag])
-                                                      }];
-}
-
-- (void)handleSelect:(__unused UIGestureRecognizer *)r
+- (void)handleSelect:(UIGestureRecognizer *)r
 {
   if (_tvParallaxProperties.enabled == YES) {
     float magnification = _tvParallaxProperties.magnification;
@@ -300,9 +291,7 @@ using namespace facebook::react;
 
 - (void)handleLongSelect:(UIGestureRecognizer *)r
 {
-  if (r.state == UIGestureRecognizerStateBegan) {
     [self sendLongSelectNotification:r];
-  }
 }
 
 - (void)addParallaxMotionEffects

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -18,6 +18,7 @@
 #import "RCTView.h"
 #import "UIView+React.h"
 #import <React/RCTUIManager.h>
+#import <React/RCTTVNavigationEventNotification.h>
 
 @implementation RCTTVView {
   __weak RCTBridge *_bridge;
@@ -98,7 +99,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   }
 }
 
-- (void)handleSelect:(__unused UIGestureRecognizer *)r
+- (void)handleSelect:(UIGestureRecognizer *)r
 {
   if ([self.tvParallaxProperties[@"enabled"] boolValue] == YES) {
     float magnification = [self.tvParallaxProperties[@"magnification"] floatValue];
@@ -133,9 +134,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 
 - (void)handleLongSelect:(UIGestureRecognizer *)r
 {
-  if (r.state == UIGestureRecognizerStateBegan) {
     [self sendLongSelectNotification:r];
-  }
 }
 
 - (BOOL)isTVFocusGuide
@@ -434,32 +433,22 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 
 - (void)sendFocusNotification:(__unused UIFocusUpdateContext *)context
 {
-    [self sendNotificationWithEventType:@"focus"];
+    [[NSNotificationCenter defaultCenter] postNavigationFocusEventWithTag:self.reactTag target:self.reactTag];
 }
 
 - (void)sendBlurNotification:(__unused UIFocusUpdateContext *)context
 {
-    [self sendNotificationWithEventType:@"blur"];
+    [[NSNotificationCenter defaultCenter] postNavigationBlurEventWithTag:self.reactTag target:self.reactTag];
 }
 
 - (void)sendSelectNotification:(UIGestureRecognizer *)recognizer
 {
-    [self sendNotificationWithEventType:@"select"];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventSelect keyAction:RCTTVRemoteEventKeyActionUp tag:self.reactTag target:self.reactTag];
 }
 
 - (void)sendLongSelectNotification:(UIGestureRecognizer *)recognizer
 {
-    [self sendNotificationWithEventType:@"longSelect"];
-}
-
-- (void)sendNotificationWithEventType:(NSString * __nonnull)eventType
-{
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-                                                      object:@{
-                                                          @"eventType":eventType,
-                                                          @"tag":self.reactTag,
-                                                          @"target":self.reactTag
-                                                      }];
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:recognizer.eventKeyAction tag:self.reactTag target:self.reactTag];
 }
 
 - (RCTTVView *)getViewById:(NSNumber *)viewId {

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -12,6 +12,7 @@
 #import "RCTConvert.h"
 #import "RCTLog.h"
 #import "RCTScrollEvent.h"
+#import "RCTTVNavigationEventNotification.h"
 #import "RCTUIManager.h"
 #import "RCTUIManagerObserverCoordinator.h"
 #import "RCTUIManagerUtils.h"
@@ -1017,22 +1018,22 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
 - (void) addArrowsListeners {
     [[NSNotificationCenter defaultCenter] addObserver:self
                                              selector:@selector(handleTVNavigationEventNotification:)
-                                                 name:@"RCTTVNavigationEventNotification"
+                                                 name:RCTTVNavigationEventNotificationName
                                                object:nil];
 }
 
 - (void) removeArrowsListeners {
     [[NSNotificationCenter defaultCenter] removeObserver:self
-                                                    name:@"RCTTVNavigationEventNotification"
+                                                    name:RCTTVNavigationEventNotificationName
                                                   object:nil];
 }
 
 
 - (void)handleTVNavigationEventNotification:(NSNotification *)notif
 {
-    NSArray *supportedEvents = [NSArray arrayWithObjects:@"up", @"down", @"left", @"right", nil];
+    NSArray *supportedEvents = [NSArray arrayWithObjects:RCTTVRemoteEventUp, RCTTVRemoteEventDown, RCTTVRemoteEventLeft, RCTTVRemoteEventRight, nil];
 
-    if (notif.object == nil || notif.object[@"eventType"] == nil || ![supportedEvents containsObject:notif.object[@"eventType"]] ) {
+    if (notif.object == nil || notif.object[RCTTVNavigationEventNotificationKeyEventType] == nil || ![supportedEvents containsObject:notif.object[RCTTVNavigationEventNotificationKeyEventType]]) {
         return;
     }
     
@@ -1042,23 +1043,23 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
     }
 
     if (![self isHorizontal:self.scrollView]) {
-        if ([notif.object[@"eventType"]  isEqual: @"down"]) {
+        if ([notif.object[RCTTVNavigationEventNotificationKeyEventType] isEqual:RCTTVRemoteEventDown]) {
             [self swipedDown];
             return;
         }
         
-        if ([notif.object[@"eventType"]  isEqual: @"up"]) {
+        if ([notif.object[RCTTVNavigationEventNotificationKeyEventType] isEqual:RCTTVRemoteEventUp]) {
             [self swipedUp];
             return;
         }
     }
   
-    if ([notif.object[@"eventType"]  isEqual: @"left"]) {
+    if ([notif.object[RCTTVNavigationEventNotificationKeyEventType] isEqual:RCTTVRemoteEventLeft]) {
         [self swipedLeft];
         return;
     }
     
-    if ([notif.object[@"eventType"]  isEqual: @"right"]) {
+    if ([notif.object[RCTTVNavigationEventNotificationKeyEventType] isEqual:RCTTVRemoteEventRight]) {
         [self swipedRight];
         return;
     }
@@ -1086,14 +1087,12 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
 
 - (void)sendFocusNotification
 {
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-  object:@{@"eventType":@"focus",@"tag":self.reactTag}];
+    [[NSNotificationCenter defaultCenter] postNavigationFocusEventWithTag:self.reactTag target:nil];
 }
 
 - (void)sendBlurNotification
 {
-  [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTTVNavigationEventNotification"
-  object:@{@"eventType":@"blur",@"tag":self.reactTag}];
+    [[NSNotificationCenter defaultCenter] postNavigationBlurEventWithTag:self.reactTag target:nil];
 }
 
 - (NSInteger)swipeVerticalInterval


### PR DESCRIPTION
## Summary:
Proposed fix for #687.

On tvOS, the `NavigationEventNotification` will post an `eventKeyAction` value on the payload. The intent is to send data similar to that of Android. Android's [getAction](https://developer.android.com/reference/android/view/KeyEvent#getAction()) sends an `eventKeyAction` with a value of 0 for key down and 1 for key up.

The fix also helps identify the two events being sent for long gestures. Currently, there is no way to identify a long gesture event as an up or down action.

## Changelog:

[IOS][ADDED] - Added up and down`eventKeyAction` to tvOS navigation event notifications

## Test Plan:
After creating a TestApp, I logged events to the console and verified the `eventKeyAction`.

```javascript
  const myTVEventHandler = evt => {
    console.log(evt);
  };

  useTVEventHandler(myTVEventHandler);
  ```
