### PR TITLE
fix: Remove spurious onClick events for Android TV

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -388,19 +388,15 @@ function Pressable(props: Props, forwardedRef): React.Node {
           setFocused(false);
         }
       }
-      // Use these on tvOS only. Android press events go to onClick() so we don't
-      // need to call onPress() again here
-      if (Platform.isTVOS) {
-        // $FlowFixMe[prop-missing]
-        if (focused && evt.eventType === 'select') {
-          // $FlowFixMe[incompatible-exact]
-          onPress && onPress(evt);
-        }
-        // $FlowFixMe[prop-missing]
-        if (focused && evt.eventType === 'longSelect') {
-          // $FlowFixMe[incompatible-exact]
-          onLongPress && onLongPress(evt);
-        }
+      // $FlowFixMe[prop-missing]
+      if (focused && evt.eventType === 'select') {
+        // $FlowFixMe[incompatible-exact]
+        onPress && onPress(evt);
+      }
+      // $FlowFixMe[prop-missing]
+      if (focused && evt.eventType === 'longSelect') {
+        // $FlowFixMe[incompatible-exact]
+        onLongPress && onLongPress(evt);
       }
     },
     [focused, onBlur, onFocus, onLongPress, onPress, focusable, isTVSelectable],

--- a/packages/react-native/Libraries/Components/Touchable/TVTouchable.js
+++ b/packages/react-native/Libraries/Components/Touchable/TVTouchable.js
@@ -51,7 +51,7 @@ export default class TVTouchable {
             config.onPress(tvData);
           }
         } else if (tvData.eventType === 'longSelect') {
-          if (Platform.OS !== 'android' && !config.getDisabled()) {
+          if (!config.getDisabled()) {
             config.onLongPress(tvData);
           }
         }

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -400,12 +400,12 @@ class TouchableHighlight extends React.Component<Props, State> {
           }
         },
         onPress: event => {
-          if (this.props.onPress != null && Platform.OS !== 'android') {
+          if (this.props.onPress != null) {
             this.props.onPress(event);
           }
         },
         onLongPress: event => {
-          if (this.props.onLongPress != null && Platform.OS !== 'android') {
+          if (this.props.onLongPress != null) {
             this.props.onLongPress(event);
           }
         },

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -355,12 +355,12 @@ class TouchableNativeFeedback extends React.Component<Props, State> {
           }
         },
         onPress: event => {
-          if (this.props.onPress != null && Platform.OS !== 'android') {
+          if (this.props.onPress != null) {
             this.props.onPress(event);
           }
         },
         onLongPress: event => {
-          if (this.props.onLongPress != null && Platform.OS !== 'android') {
+          if (this.props.onLongPress != null) {
             this.props.onLongPress(event);
           }
         },

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -329,12 +329,12 @@ class TouchableOpacity extends React.Component<Props, State> {
           }
         },
         onPress: event => {
-          if (this.props.onPress != null && Platform.OS !== 'android') {
+          if (this.props.onPress != null) {
             this.props.onPress(event);
           }
         },
         onLongPress: event => {
-          if (this.props.onLongPress != null && Platform.OS !== 'android') {
+          if (this.props.onLongPress != null) {
             this.props.onLongPress(event);
           }
         },

--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -572,6 +572,11 @@ export default class Pressability {
           return;
         }
 
+        // Remove spurious onClick events with empty event object generated on Android TV
+        if (Platform.isTV && !event?.eventType) {
+          return;
+        }
+
         const {onPress, disabled} = this._config;
         if (onPress != null && disabled !== true) {
           onPress(event);

--- a/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
+++ b/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
@@ -14,63 +14,206 @@ import * as React from 'react';
 import ReactNative from 'react-native';
 import type {TVRemoteEvent} from '../../../../../Libraries/Types/CoreEventTypes';
 
-const {Platform, View, Text, TouchableOpacity, TVEventControl, useTVEventHandler} = ReactNative;
+const {
+  StyleSheet,
+  Text,
+  View,
+  useTVEventHandler,
+  Platform,
+  Pressable,
+  TouchableHighlight,
+  TouchableNativeFeedback,
+  TouchableOpacity,
+  TVEventControl,
+} = ReactNative;
+
+const PressableButton = (props: {
+  title: string,
+  log: (entry: string) => void,
+}) => {
+  return (
+    <Pressable
+      onFocus={() => props.log(`${props.title} focus`)}
+      onBlur={() => props.log(`${props.title} blur`)}
+      onPress={() => props.log(`${props.title} pressed`)}
+      onLongPress={() => props.log(`${props.title} long press`)}
+      style={({pressed, focused}) =>
+        pressed || focused ? styles.pressableFocused : styles.pressable
+      }>
+      {({focused}) => {
+        return (
+          <Text style={styles.pressableText}>
+            {focused ? `${props.title} focused` : props.title}
+          </Text>
+        );
+      }}
+    </Pressable>
+  );
+};
+
+const TouchableOpacityButton = (props: {
+  title: string,
+  log: (entry: string) => void,
+}) => {
+  return (
+    <TouchableOpacity
+      style={styles.pressable}
+      onFocus={() => props.log(`${props.title} focus`)}
+      onBlur={() => props.log(`${props.title} blur`)}
+      onPress={() => props.log(`${props.title} pressed`)}
+      onLongPress={() => props.log(`${props.title} long press`)}>
+      <Text style={styles.pressableText}>{props.title}</Text>
+    </TouchableOpacity>
+  );
+};
+
+const TouchableHighlightButton = (props: {
+  title: string,
+  log: (entry: string) => void,
+}) => {
+  return (
+    <TouchableHighlight
+      style={styles.pressable}
+      onFocus={() => props.log(`${props.title} focus`)}
+      onBlur={() => props.log(`${props.title} blur`)}
+      onPress={() => props.log(`${props.title} pressed`)}
+      onLongPress={() => props.log(`${props.title} long press`)}>
+      <Text style={styles.pressableText}>{props.title}</Text>
+    </TouchableHighlight>
+  );
+};
+
+const TouchableNativeFeedbackButton = (props: {
+  title: string,
+  log: (entry: string) => void,
+}) => {
+  return (
+    <TouchableNativeFeedback
+      background={TouchableNativeFeedback.SelectableBackground()}
+      onFocus={() => props.log(`${props.title} focus`)}
+      onBlur={() => props.log(`${props.title} blur`)}
+      onPress={() => props.log(`${props.title} pressed`)}
+      onLongPress={() => props.log(`${props.title} long press`)}>
+      <View style={styles.pressable}>
+        <Text style={styles.pressableText}>{props.title}</Text>
+      </View>
+    </TouchableNativeFeedback>
+  );
+};
+
+const scale = Platform.isTV && Platform.OS === 'ios' ? 2 : 1;
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    backgroundColor: '#fff',
+    alignItems: 'flex-start',
+    justifyContent: 'center',
+  },
+  logContainer: {
+    flexDirection: 'row',
+    padding: 5 * scale,
+    margin: 5 * scale,
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+  },
+  logText: {
+    height: 100 * scale,
+    width: 150 * scale,
+    fontSize: 10 * scale,
+    margin: 5 * scale,
+    alignSelf: 'flex-start',
+    justifyContent: 'flex-start',
+  },
+  pressable: {
+    borderColor: 'blue',
+    backgroundColor: 'blue',
+    borderWidth: 1,
+    borderRadius: 5 * scale,
+    margin: 5 * scale,
+  },
+  pressableFocused: {
+    borderColor: 'blue',
+    backgroundColor: '#000088',
+    borderWidth: 1,
+    borderRadius: 5 * scale,
+    margin: 5 * scale,
+  },
+  pressableText: {
+    color: 'white',
+    fontSize: 15 * scale,
+  },
+});
 
 const TVEventHandlerView: () => React.Node = () => {
-  const [lastEventType, setLastEventType] = React.useState('');
-  const [lastEventAction, setLastEventAction] = React.useState('');
-  const [eventLog, setEventLog] = React.useState([]);
+  const [remoteEventLog, setRemoteEventLog] = React.useState<string[]>([]);
+  const [pressableEventLog, setPressableEventLog] = React.useState<string[]>(
+    [],
+  );
 
-  const isAndroid = Platform.OS === 'android';
-
-  function appendEvent(eventType, eventKeyAction, body) {
+  const logWithAppendedEntry = (log: string[], entry: string) => {
     const limit = 6;
-    const newEventLog = eventLog.slice(0, limit - 1);
-    if (isAndroid) {
-      newEventLog.unshift(`type=${eventType}, action=${eventKeyAction !== undefined ? eventKeyAction : '' }`);
-    } else {
-      if (eventType === 'pan') {
-        newEventLog.unshift(`type=${eventType}, body=${JSON.stringify(body || {})}`);
-      } else {
-        newEventLog.unshift(`type=${eventType}`);
-      }
-    }
-    setEventLog(newEventLog);
-  }
-
-  const myTVEventHandler = (evt: TVRemoteEvent) => {
-    appendEvent(evt.eventType, evt.eventKeyAction, evt.body);
+    const newEventLog = log.slice(0, limit - 1);
+    newEventLog.unshift(entry);
+    return newEventLog;
   };
 
-  if (Platform.isTV) {
-    // Apple TV: enable detection of pan gesture events (and disable on unmount)
-    React.useEffect(() => {
-      TVEventControl.enableTVPanGesture();
-      return () => TVEventControl.disableTVPanGesture();
-    }, []);
-    useTVEventHandler(myTVEventHandler); // eslint-disable-line react-hooks/rules-of-hooks
+  const updatePressableLog = (entry: string) => {
+    setPressableEventLog(log => logWithAppendedEntry(log, entry));
+  };
+
+  useTVEventHandler(event => {
+    const {eventType, eventKeyAction} = event;
+    if (eventType !== 'focus' && eventType !== 'blur') {
+      setRemoteEventLog(log =>
+        logWithAppendedEntry(
+          log,
+          `type=${eventType}, action=${
+            eventKeyAction !== undefined ? eventKeyAction : ''
+          }`,
+        ),
+      );
+    }
+  });
+
+  if (!Platform.isTV) {
     return (
       <View>
-        <TouchableOpacity onPress={() => {}}>
-          <Text>
-            This example enables an instance of TVEventHandler to show the last
-            event detected from the Apple TV Siri remote or from a keyboard.
-          </Text>
-        </TouchableOpacity>
-        {eventLog.map((e, ii) => (
-          <Text style={{color: 'blue'}} key={ii}>
-            {e}
-          </Text>
-        ))}
-      </View>
-    );
-  } else {
-    return (
-      <View>
-        <Text>This example is intended to be run on Apple TV.</Text>
+        <Text>This example is intended to be run on TV.</Text>
       </View>
     );
   }
+
+  // Apple TV: enable detection of pan gesture events (and disable on unmount)
+  React.useEffect(() => {
+    TVEventControl.enableTVPanGesture();
+    return () => TVEventControl.disableTVPanGesture();
+  }, []);
+
+  return (
+    <View style={styles.container}>
+      <PressableButton title="Pressable" log={updatePressableLog} />
+      <TouchableOpacityButton
+        title="TouchableOpacity"
+        log={updatePressableLog}
+      />
+      <TouchableHighlightButton
+        title="TouchableHighlight"
+        log={updatePressableLog}
+      />
+      {Platform.OS === 'android' ? (
+        <TouchableNativeFeedbackButton
+          title="TouchableNativeFeedback"
+          log={updatePressableLog}
+        />
+      ) : null}
+
+      <View style={styles.logContainer}>
+        <Text style={styles.logText}>{remoteEventLog.join('\n')}</Text>
+        <Text style={styles.logText}>{pressableEventLog.join('\n')}</Text>
+      </View>
+    </View>
+  );
 };
 
 exports.framework = 'React';


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

There has been special code in the `Touchable` components to ensure that Android TV does not fire duplicate `onPress` events for the same press of the DPad.

This problem has now been traced to the root cause, which was `onPress` events fired with empty events from the `onClick` handler in `Pressability`.

These have been suppressed for TV, and the Android special handling removed from the `Touchable` classes.

## Changelog:

[Android][Fixed] Remove spurious onClick events for Android TV

## Test Plan:

The `TVEventHandlerExample` in RNTester has been modernized and expanded to show remote control events as well as events from `Touchable` and `Pressable` components.

