### PR TITLE
fix: Refactor TV event handler and focus handler for RNTV 0.73

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -411,12 +411,12 @@ function Pressable(props: Props, forwardedRef): React.Node {
       return;
     }
     // $FlowFixMe[prop-missing]
-    const viewTag = viewRef?.current?._nativeTag;
+    const viewTag = tagForComponentOrHandle(viewRef?.current);
     tvFocusEventHandler.register(viewTag, pressableTVFocusEventHandler);
     return () => {
       tvFocusEventHandler.unregister(viewTag);
     };
-  }, [pressableTVFocusEventHandler]);
+  }, [pressableTVFocusEventHandler, viewRef]);
 
   return (
     <View

--- a/packages/react-native/Libraries/Components/TV/TVEventHandler.js
+++ b/packages/react-native/Libraries/Components/TV/TVEventHandler.js
@@ -16,38 +16,30 @@ import {type EventSubscription} from '../../vendor/emitter/EventEmitter';
 import NativeTVNavigationEventEmitter from './NativeTVNavigationEventEmitter';
 import type {TVRemoteEvent} from '../../Types/CoreEventTypes';
 
-class TVEventHandler {
-  __nativeTVNavigationEventListener: ?EventSubscription = null;
-  __nativeTVNavigationEventEmitter: ?NativeEventEmitter<TVRemoteEvent> = null;
+let __nativeTVNavigationEventEmitter: ?NativeEventEmitter<TVRemoteEvent> = null;
 
-  enable(component: ?any, callback: Function): void {
+const TVEventHandler = {
+  addListener: (callback: Function) => {
     if (Platform.OS === 'ios' && !NativeTVNavigationEventEmitter) {
       return;
     }
-
-    this.__nativeTVNavigationEventEmitter = new NativeEventEmitter<TVRemoteEvent>(
-      NativeTVNavigationEventEmitter,
-    );
-    this.__nativeTVNavigationEventListener = this.__nativeTVNavigationEventEmitter.addListener(
-      // $FlowFixMe[prop-missing]
-      'onHWKeyEvent',
-      data => {
-        if (callback) {
-          callback(component, data);
-        }
-      },
-    );
-  }
-
-  disable(): void {
-    if (this.__nativeTVNavigationEventListener) {
-      this.__nativeTVNavigationEventListener.remove();
-      delete this.__nativeTVNavigationEventListener;
+    if (!__nativeTVNavigationEventEmitter) {
+      __nativeTVNavigationEventEmitter = new NativeEventEmitter<TVRemoteEvent>(
+        NativeTVNavigationEventEmitter,
+      );
     }
-    if (this.__nativeTVNavigationEventEmitter) {
-      delete this.__nativeTVNavigationEventEmitter;
-    }
-  }
-}
+    const subscription: EventSubscription =
+      __nativeTVNavigationEventEmitter.addListener(
+        // $FlowFixMe[prop-missing]
+        'onHWKeyEvent',
+        data => {
+          if (callback) {
+            callback(data);
+          }
+        },
+      );
+    return subscription;
+  },
+};
 
 module.exports = TVEventHandler;

--- a/packages/react-native/Libraries/Components/TV/TVFocusEventHandler.js
+++ b/packages/react-native/Libraries/Components/TV/TVFocusEventHandler.js
@@ -10,35 +10,22 @@
 
 'use strict';
 
-import NativeEventEmitter from '../../EventEmitter/NativeEventEmitter';
 import Platform from '../../Utilities/Platform';
 import {type EventSubscription} from '../../vendor/emitter/EventEmitter';
-import NativeTVNavigationEventEmitter from './NativeTVNavigationEventEmitter';
 import type {TVRemoteEvent} from '../../Types/CoreEventTypes';
+import TVEventHandler from './TVEventHandler';
 
 class TVFocusEventHandler {
-  __nativeTVNavigationEventListener: ?EventSubscription = null;
-  __nativeTVNavigationEventEmitter: ?NativeEventEmitter<TVRemoteEvent> = null;
+  __subscription: ?EventSubscription = null;
   __callbackMap: Map<any, Function> = new Map();
 
   constructor() {
-    if (Platform.OS === 'ios' && !NativeTVNavigationEventEmitter) {
-      return;
-    }
-
-    this.__nativeTVNavigationEventEmitter = new NativeEventEmitter<TVRemoteEvent>(
-      NativeTVNavigationEventEmitter,
-    );
-    this.__nativeTVNavigationEventListener = this.__nativeTVNavigationEventEmitter.addListener(
-       // $FlowFixMe[prop-missing]
-      'onHWKeyEvent',
-      data => {
-        const callback = this.__callbackMap.get(data.tag);
-        if (callback) {
-          callback(data);
-        }
-      },
-    );
+    this.__subscription = TVEventHandler.addListener((data: TVRemoteEvent) => {
+      const callback = this.__callbackMap.get(data.tag);
+      if (callback) {
+        callback(data);
+      }
+    });
   }
 
   register(componentTag: ?any, callback: Function): void {
@@ -50,4 +37,6 @@ class TVFocusEventHandler {
   }
 }
 
-export const tvFocusEventHandler: TVFocusEventHandler | null = Platform.isTV ? new TVFocusEventHandler() : null;
+export const tvFocusEventHandler: TVFocusEventHandler | null = Platform.isTV
+  ? new TVFocusEventHandler()
+  : null;

--- a/packages/react-native/Libraries/Components/TV/TVTextScrollView.js
+++ b/packages/react-native/Libraries/Components/TV/TVTextScrollView.js
@@ -10,10 +10,9 @@
 
 const React = require('react');
 const ScrollView = require('../ScrollView/ScrollView');
-const TVEventHandler = require('./TVEventHandler');
-const findNodeHandle = require('../../Renderer/shims/ReactNative')
-  .findNodeHandle;
+const {tvFocusEventHandler} = require('./TVFocusEventHandler');
 
+import tagForComponentOrHandle from './tagForComponentOrHandle';
 import typeof Props from '../ScrollView/ScrollView';
 
 /**
@@ -62,13 +61,12 @@ class TVTextScrollView extends React.Component<{
    */
   onBlur?: (evt: Event) => void,
 }> {
-  _tvEventHandler: ?TVEventHandler;
+  _subscription: any;
 
   componentDidMount() {
-    this._tvEventHandler = new TVEventHandler();
-    this._tvEventHandler.enable(this, function(cmp, evt) {
-      const myTag = findNodeHandle(cmp);
-      evt.dispatchConfig = {};
+    const cmp = this;
+    const myTag = tagForComponentOrHandle(cmp);
+    tvFocusEventHandler.register(myTag, function (evt) {
       if (myTag === evt.tag) {
         if (evt.eventType === 'focus') {
           cmp.props.onFocus && cmp.props.onFocus(evt);
@@ -80,10 +78,8 @@ class TVTextScrollView extends React.Component<{
   }
 
   componentWillUnmount() {
-    if (this._tvEventHandler) {
-      this._tvEventHandler.disable();
-      delete this._tvEventHandler;
-    }
+    const myTag = tagForComponentOrHandle(this);
+    tvFocusEventHandler.unregister(myTag);
   }
 
   render(): React.Node | React.Element<string> {

--- a/packages/react-native/Libraries/Components/TV/tagForComponentOrHandle.js
+++ b/packages/react-native/Libraries/Components/TV/tagForComponentOrHandle.js
@@ -4,7 +4,7 @@
 
 // TODO: make this work for Fabric
 
-// import {findNodeHandle} from '../../Renderer/shims/ReactNative';
+const findNodeHandle = require('../../ReactNative/RendererProxy').findNodeHandle;
 
 type TagForComponentOrHandleType = (
     component: ?(
@@ -19,6 +19,11 @@ const tagForComponentOrHandle: TagForComponentOrHandleType = (
     | number
   ),
 ): ?number => {
+  if (component === null || component === undefined) {
+    return undefined;
+  }
+  return findNodeHandle(component, true); // suppress warning
+/*
   if (typeof component === 'number') {
     return component;
   }
@@ -29,6 +34,7 @@ const tagForComponentOrHandle: TagForComponentOrHandleType = (
     return component?.canonical?._nativeTag;
   }
   return undefined;
+ */
 };
 
 export default tagForComponentOrHandle;

--- a/packages/react-native/Libraries/Components/TV/useTVEventHandler.js
+++ b/packages/react-native/Libraries/Components/TV/useTVEventHandler.js
@@ -2,15 +2,16 @@
 import React from 'react';
 import TVEventHandler from './TVEventHandler';
 import type {TVRemoteEvent} from '../../Types/CoreEventTypes';
+import {type EventSubscription} from '../../vendor/emitter/EventEmitter';
+
 
 const useTVEventHandler = (handleEvent: (evt: TVRemoteEvent) => void) => {
   React.useEffect(() => {
-    const handler: TVEventHandler = new TVEventHandler();
-    handler.enable(null, function(cmp, evt) {
-        handleEvent(evt);
+    const subscription: EventSubscription = TVEventHandler.addListener(function(evt) {
+      handleEvent(evt);
     });
     return () => {
-      handler.disable();
+      subscription.remove();
     };
   }, [handleEvent]);
 };

--- a/packages/react-native/Libraries/Components/Touchable/TVTouchable.js
+++ b/packages/react-native/Libraries/Components/Touchable/TVTouchable.js
@@ -11,14 +11,14 @@
 'use strict';
 
 import invariant from 'invariant';
-import ReactNative from '../../Renderer/shims/ReactNative';
+import tagForComponentOrHandle from '../TV/tagForComponentOrHandle';
 import type {
   BlurEvent,
   FocusEvent,
   PressEvent,
 } from '../../Types/CoreEventTypes';
 import Platform from '../../Utilities/Platform';
-import TVEventHandler from '../../Components/TV/TVEventHandler';
+import {tvFocusEventHandler} from '../TV/TVFocusEventHandler';
 
 type TVTouchableConfig = $ReadOnly<{|
   getDisabled: () => boolean,
@@ -29,19 +29,22 @@ type TVTouchableConfig = $ReadOnly<{|
 |}>;
 
 export default class TVTouchable {
-  _tvEventHandler: TVEventHandler = null;
   _enabled: boolean = false;
+  _focusEventHandler: ?any = null;
+  _viewTag: ?number = null;
 
   constructor(component: any, config: TVTouchableConfig) {
     invariant(Platform.isTV, 'TVTouchable: Requires `Platform.isTV`.');
-    this._tvEventHandler = new TVEventHandler();
+    if (!Platform.isTV) {
+      return;
+    }
     const _tvtouchable = this;
-    this._tvEventHandler.enable(component, (_, tvData) => {
-      tvData.dispatchConfig = {};
+    this._viewTag = tagForComponentOrHandle(component);
+    tvFocusEventHandler.register(this._viewTag, tvData => {
       if (!_tvtouchable._enabled) {
         return;
       }
-      if (ReactNative.findNodeHandle(component) === tvData.tag) {
+      if (tagForComponentOrHandle(component) === tvData.tag) {
         if (tvData.eventType === 'focus') {
           config.onFocus(tvData);
         } else if (tvData.eventType === 'blur') {
@@ -62,7 +65,6 @@ export default class TVTouchable {
 
   destroy(): void {
     this._enabled = false;
-    this._tvEventHandler.disable();
-    this._tvEventHandler = null;
+    tvFocusEventHandler.unregister(this._viewTag);
   }
 }

--- a/packages/react-native/Libraries/Components/Touchable/Touchable.js
+++ b/packages/react-native/Libraries/Components/Touchable/Touchable.js
@@ -22,6 +22,7 @@ import {tvFocusEventHandler} from '../TV/TVFocusEventHandler';
 import BoundingDimensions from './BoundingDimensions';
 import Position from './Position';
 import * as React from 'react';
+import tagForComponentOrHandle from '../TV/tagForComponentOrHandle';
 
 const extractSingleTouch = (nativeEvent: {
   +changedTouches: $ReadOnlyArray<PressEvent['nativeEvent']>,
@@ -382,7 +383,7 @@ const TouchableMixin = {
       return;
     }
 
-    this._componentTag = ReactNative.findNodeHandle(this);
+    this._componentTag = tagForComponentOrHandle(this);
     tvFocusEventHandler.register(this._componentTag, evt => {
       evt.dispatchConfig = {};
       if (evt.eventType === 'focus') {

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -378,7 +378,6 @@ class TouchableHighlight extends React.Component<Props, State> {
   }
 
   componentDidMount(): void {
-    this.state.pressability.configure(this._createPressabilityConfig());
     this._isMounted = true;
     if (Platform.isTV) {
       this._tvTouchable = new TVTouchable(this, {

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -312,7 +312,6 @@ class TouchableOpacity extends React.Component<Props, State> {
   }
 
   componentDidMount(): void {
-    this.state.pressability.configure(this._createPressabilityConfig());
     if (Platform.isTV) {
       this._tvTouchable = new TVTouchable(this, {
         getDisabled: () => this.props.disabled === true,
@@ -340,6 +339,7 @@ class TouchableOpacity extends React.Component<Props, State> {
         },
       });
     }
+    this.state.pressability.configure(this._createPressabilityConfig());
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {

--- a/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactFabric-dev.js
@@ -24219,11 +24219,11 @@ function findHostInstance_DEPRECATED(componentOrHandle) {
   return hostInstance;
 }
 
-function findNodeHandle(componentOrHandle) {
+function findNodeHandle(componentOrHandle, suppressWarning) {
   {
     var owner = ReactCurrentOwner$3.current;
 
-    if (owner !== null && owner.stateNode !== null) {
+    if (owner !== null && owner.stateNode !== null && !suppressWarning) {
       if (!owner.stateNode._warnedAboutRefsInRender) {
         error(
           "%s is accessing findNodeHandle inside its render(). " +

--- a/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
+++ b/packages/react-native/Libraries/Renderer/implementations/ReactNativeRenderer-dev.js
@@ -24540,11 +24540,11 @@ function findHostInstance_DEPRECATED(componentOrHandle) {
   return hostInstance;
 }
 
-function findNodeHandle(componentOrHandle) {
+function findNodeHandle(componentOrHandle, suppressWarning) {
   {
     var owner = ReactCurrentOwner$3.current;
 
-    if (owner !== null && owner.stateNode !== null) {
+    if (owner !== null && owner.stateNode !== null && !suppressWarning) {
       if (!owner.stateNode._warnedAboutRefsInRender) {
         error(
           "%s is accessing findNodeHandle inside its render(). " +

--- a/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.d.ts
@@ -264,3 +264,11 @@ export interface PointerEvents {
   onPointerUp?: ((event: PointerEvent) => void) | undefined;
   onPointerUpCapture?: ((event: PointerEvent) => void) | undefined;
 }
+
+export interface TVRemoteEvent {
+  tag?: number | undefined;
+  target?: number | undefined;
+  eventType: string;
+  eventKeyAction?: string | undefined;
+  body?: any | undefined;
+}

--- a/packages/react-native/Libraries/Types/CoreEventTypes.js
+++ b/packages/react-native/Libraries/Types/CoreEventTypes.js
@@ -292,11 +292,11 @@ export type MouseEvent = SyntheticEvent<
   |}>,
 >;
 
-export type TVRemoteEvent = 
-  $ReadOnly<{|
-    eventType: string,
-    eventKeyAction?: string,
-    // $FlowFixMe[unclear-type]
-    body?: any,
-  |}>;
-
+export type TVRemoteEvent = $ReadOnly<{|
+  tag?: number,
+  target?: number,
+  eventType: string,
+  eventKeyAction?: string,
+  // $FlowFixMe[unclear-type]
+  body?: any,
+|}>;

--- a/packages/react-native/Libraries/Utilities/BackHandler.ios.js
+++ b/packages/react-native/Libraries/Utilities/BackHandler.ios.js
@@ -65,10 +65,9 @@ type TBackHandler = {|
 let BackHandler: TBackHandler;
 
 if (Platform.isTV) {
-  const _tvEventHandler = new TVEventHandler();
   const _backPressSubscriptions = new Set();
 
-  _tvEventHandler.enable(this, function(cmp, evt) {
+  TVEventHandler.addListener(function (evt) {
     if (evt && evt.eventType === 'menu') {
       let invokeDefault = true;
       const subscriptions = Array.from(
@@ -91,7 +90,7 @@ if (Platform.isTV) {
   BackHandler = {
     exitApp: emptyFunction,
 
-    addEventListener: function(
+    addEventListener: function (
       eventName: BackPressEventName,
       handler: () => ?boolean,
     ): {remove: () => void, ...} {
@@ -101,7 +100,7 @@ if (Platform.isTV) {
       };
     },
 
-    removeEventListener: function(
+    removeEventListener: function (
       eventName: BackPressEventName,
       handler: () => ?boolean,
     ): void {


### PR DESCRIPTION
## Summary:

Backport the changes to `TVEventHandler` and `TVFocusEventHandler` that were done for 0.74 branch.

## Changelog:

[General][Fixed] Fixes and improvements to the event handler and the focus event handler, and related modules.

## Test Plan:

RNTester and local test apps should still work correctly with no changes.