### PR TITLE
fix: [Apple TV] remove menu key from enableGestureHandlerCancelsTouches

### DIFF
--- a/packages/react-native/React/Base/RCTTVRemoteHandler.m
+++ b/packages/react-native/React/Base/RCTTVRemoteHandler.m
@@ -324,7 +324,8 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
     for (NSString *name in [self.tvRemoteGestureRecognizers allKeys]) {
       self.tvRemoteGestureRecognizers[name].cancelsTouchesInView = YES;
     }
-    [self.tvMenuKeyRecognizer setCancelsTouchesInView:YES];
+    // Issue #678: menu key should not be included
+    // [self.tvMenuKeyRecognizer setCancelsTouchesInView:YES];
     [self.tvPanGestureRecognizer setCancelsTouchesInView:YES];
   });
 }
@@ -335,7 +336,8 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
     for (NSString *name in [self.tvRemoteGestureRecognizers allKeys]) {
       self.tvRemoteGestureRecognizers[name].cancelsTouchesInView = NO;
     }
-    [self.tvMenuKeyRecognizer setCancelsTouchesInView:NO];
+    // Issue #678: menu key should not be included
+    // [self.tvMenuKeyRecognizer setCancelsTouchesInView:NO];
     [self.tvPanGestureRecognizer setCancelsTouchesInView:NO];
   });
 }

--- a/packages/rn-tester/js/RNTesterAppShared.js
+++ b/packages/rn-tester/js/RNTesterAppShared.js
@@ -66,8 +66,6 @@ const RNTesterApp = (): React.Node => {
 
   // Setup hardware back button press listener
   React.useEffect(() => {
-    // For RNTester, menu key back navigation needs this enabled
-    TVEventControl.enableGestureHandlersCancelTouches();
     if (activeModuleKey) {
       TVEventControl.enableTVMenuKey();
     } else {


### PR DESCRIPTION
## Summary:

Apply the fix suggested in #678 .

## Changelog:

[iOS][Fixed] Remove menu key from TVEventControl enable/disable gesture handler cancels touches

## Test Plan:

Modified RNTester to remove the workaround for this issue.