### PR TITLE
fix: Storybook virtualized list layout issue for non-TV platforms

### DIFF
--- a/packages/virtualized-lists/Lists/VirtualizedList.js
+++ b/packages/virtualized-lists/Lists/VirtualizedList.js
@@ -1110,22 +1110,35 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
           registerAsNestedChild: this._registerAsNestedChild,
           unregisterAsNestedChild: this._unregisterAsNestedChild,
         }}>
-        <TVFocusGuideView
-          trapFocusLeft={
-            horizontalOrDefault(this.props.horizontal) &&
-            this.state.cellsAroundViewport.first > 0
-          }
-          trapFocusRight={
-            horizontalOrDefault(this.props.horizontal) && this._hasMore
-          }
-          trapFocusUp={
-            !horizontalOrDefault(this.props.horizontal) &&
-            this.state.cellsAroundViewport.first > 0
-          }
-          trapFocusDown={
-            !horizontalOrDefault(this.props.horizontal) && this._hasMore
-          }>
-          {React.cloneElement(
+        {Platform.isTV ? (
+          <TVFocusGuideView
+            trapFocusLeft={
+              horizontalOrDefault(this.props.horizontal) &&
+              this.state.cellsAroundViewport.first > 0
+            }
+            trapFocusRight={
+              horizontalOrDefault(this.props.horizontal) && this._hasMore
+            }
+            trapFocusUp={
+              !horizontalOrDefault(this.props.horizontal) &&
+              this.state.cellsAroundViewport.first > 0
+            }
+            trapFocusDown={
+              !horizontalOrDefault(this.props.horizontal) && this._hasMore
+            }>
+            {React.cloneElement(
+              (
+                this.props.renderScrollComponent ||
+                this._defaultRenderScrollComponent
+              )(scrollProps),
+              {
+                ref: this._captureScrollRef,
+              },
+              cells,
+            )}
+          </TVFocusGuideView>
+        ) : (
+          React.cloneElement(
             (
               this.props.renderScrollComponent ||
               this._defaultRenderScrollComponent
@@ -1134,8 +1147,8 @@ class VirtualizedList extends StateSafePureComponent<Props, State> {
               ref: this._captureScrollRef,
             },
             cells,
-          )}
-        </TVFocusGuideView>
+          )
+        )}
       </VirtualizedListContextProvider>
     );
     let ret: React.Node = innerRet;


### PR DESCRIPTION
## Summary:

Our change to add a `TVFocusGuideView` wrapper around `VirtualizedList` should not be applied to non-TV platforms. This fix reverts that change for the case where `Platform.isTV` is false.

Fixes https://github.com/storybookjs/react-native/issues/568

## Changelog:

[General][Fixed] Layout issue for VirtualizedList for non-TV platforms

## Test Plan:

See the Storybook issue above for a way to verify the fix.
TV projects should still work unchanged, and TV tests should still pass.
