### PR TITLE
fix: [Apple TV] restore missing event handlers in Modal

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.h
@@ -9,6 +9,10 @@
 
 @protocol RCTFabricModalHostViewControllerDelegate <NSObject>
 - (void)boundsDidChange:(CGRect)newBounds;
+#if TARGET_OS_TV
+- (void)enableEventHandlers;
+- (void)disableEventHandlers;
+#endif
 @end
 
 @interface RCTFabricModalHostViewController : UIViewController

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTFabricModalHostViewController.mm
@@ -42,16 +42,26 @@
   [_touchHandler attachToView:self.view];
 }
 
-#if !TARGET_OS_TV
-- (UIStatusBarStyle)preferredStatusBarStyle
-{
-  return [RCTSharedApplication() statusBarStyle];
-}
-
 - (void)viewDidDisappear:(BOOL)animated
 {
   [super viewDidDisappear:animated];
   _lastViewBounds = CGRectZero;
+}
+
+#if TARGET_OS_TV
+- (void)viewDidAppear:(BOOL)animated
+{
+  [self.delegate enableEventHandlers];
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+  [self.delegate disableEventHandlers];
+}
+#else
+- (UIStatusBarStyle)preferredStatusBarStyle
+{
+  return [RCTSharedApplication() statusBarStyle];
 }
 
 - (BOOL)prefersStatusBarHidden

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/Modal/RCTModalHostViewComponentView.mm
@@ -19,6 +19,10 @@
 
 #import "RCTFabricModalHostViewController.h"
 
+#if TARGET_OS_TV
+#import <React/RCTTVRemoteHandler.h>
+#endif
+
 using namespace facebook::react;
 
 #if !TARGET_OS_TV
@@ -115,6 +119,10 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
   BOOL _shouldPresent;
   BOOL _isPresented;
   UIView *_modalContentsSnapshot;
+#if TARGET_OS_TV
+  UITapGestureRecognizer *_menuButtonGestureRecognizer;
+  RCTTVRemoteHandler *_tvRemoteHandler;
+#endif
 }
 
 - (instancetype)initWithFrame:(CGRect)frame
@@ -123,12 +131,49 @@ static ModalHostViewEventEmitter::OnOrientationChange onOrientationChangeStruct(
     static const auto defaultProps = std::make_shared<const ModalHostViewProps>();
     _props = defaultProps;
     _shouldAnimatePresentation = YES;
+#if TARGET_OS_TV
+    _menuButtonGestureRecognizer = [[UITapGestureRecognizer alloc] initWithTarget:self
+                                                                           action:@selector(menuButtonPressed)];
+    _menuButtonGestureRecognizer.allowedPressTypes = @[ @(UIPressTypeMenu) ];
+#endif
 
     _isPresented = NO;
   }
 
   return self;
 }
+
+#if TARGET_OS_TV
+- (void)menuButtonPressed {
+  UIView *snapshot = _modalContentsSnapshot;
+  [self.viewController.view addSubview:snapshot];
+  [self dismissViewController:self.viewController
+                     animated:_shouldAnimatePresentation
+                   completion:^{
+                     [snapshot removeFromSuperview];
+                     auto eventEmitter = [self modalEventEmitter];
+                     if (eventEmitter) {
+                       eventEmitter->onDismiss(ModalHostViewEventEmitter::OnDismiss{});
+                       eventEmitter->onRequestClose(ModalHostViewEventEmitter::OnRequestClose{});
+                     }
+                   }];
+}
+
+- (void)enableEventHandlers
+{
+  _tvRemoteHandler = [[RCTTVRemoteHandler alloc] initWithView:_viewController.view];
+  [_tvRemoteHandler disableTVMenuKey];
+
+  [_viewController.view addGestureRecognizer:_menuButtonGestureRecognizer];
+}
+
+- (void)disableEventHandlers
+{
+  _tvRemoteHandler = nil;
+  [_viewController.view removeGestureRecognizer:_menuButtonGestureRecognizer];
+}
+
+#endif
 
 - (RCTFabricModalHostViewController *)viewController
 {

--- a/packages/react-native/React/Views/RCTModalHostViewController.m
+++ b/packages/react-native/React/Views/RCTModalHostViewController.m
@@ -34,6 +34,32 @@
   return self;
 }
 
+- (void)viewDidAppear:(BOOL)animated
+{
+#if TARGET_OS_TV
+  [self.modalHostView enableEventHandlers];
+#endif
+}
+
+- (void)viewWillDisappear:(BOOL)animated
+{
+#if TARGET_OS_TV
+  [self.modalHostView disableEventHandlers];
+  if (self.modalHostView.onRequestClose) {
+    self.modalHostView.onRequestClose(nil);
+  }
+#endif
+}
+
+- (void)viewDidDisappear:(BOOL)animated
+{
+#if TARGET_OS_TV
+  if (self.modalHostView.onDismiss) {
+    self.modalHostView.onDismiss(nil);
+  }
+#endif
+}
+
 - (void)viewDidLayoutSubviews
 {
   [super viewDidLayoutSubviews];


### PR DESCRIPTION
## Summary:

On Apple TV, the `Modal` component would dismiss via a menu key press, but the expected callbacks like `onRequestClose` and `onDismiss` were not being called, leaving the app in an unusable state.

Found that the needed view controller methods were missing from the modal view controller after the merge from 0.72 to 0.73. Restored those methods, and also fixed up the corresponding event handlers and view controller methods in the Fabric implementation.

Fixes #705 

## Changelog:

[Apple TV][Fixed] Modal dismiss with menu key

## Test Plan:

Tested with the code submitted in #705 . For Fabric, that code should call `setShowModal(false)` in either the `onRequestClose` or `onDismiss` handler, as recommended in React Native docs for the `Modal` component.