### PR TITLE
chore: [Typescript] Update `TVEventHandler` types to reflect the latest implementation

### DIFF
--- a/packages/react-native/types/__typetests__/tv-only.tsx
+++ b/packages/react-native/types/__typetests__/tv-only.tsx
@@ -1,0 +1,17 @@
+import {TVEventHandler} from 'react-native';
+
+function testTVEventHandler(){
+  TVEventHandler.addListener(event => {
+    const eventType: string = event.eventType;
+    // @ts-expect-error - eventType is a string not a boolean
+    const eventType2: boolean = event.eventType;
+    const x: number | undefined = event.body?.x;
+    // @ts-expect-error - x is an optional number not a string
+    const x2: string | undefined = event.body?.x;
+  })?.remove();
+
+  // @ts-expect-error - `enable` deprecated in favor of `addListener`
+  TVEventHandler.enable();
+  // @ts-expect-error - `disable` deprecated in favor of `addListener` subscription result
+  TVEventHandler.disable();
+}

--- a/packages/react-native/types/public/ReactNativeTVTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTVTypes.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { View, ScrollViewProps, HostComponent, TVParallaxProperties } from 'react-native';
+import type { View, ScrollViewProps, HostComponent, TVParallaxProperties, EventSubscription } from 'react-native';
 
 declare module 'react-native' {
   interface ViewProps {
@@ -59,13 +59,9 @@ declare module 'react-native' {
     } | undefined
   };
 
-  export class TVEventHandler {
-    enable<T extends React.Component<unknown>>(
-      component?: T,
-      callback?: (component: T, data: HWEvent) => void
-    ): void;
-    disable(): void;
-  }
+  export const TVEventHandler:  {
+    addListener: (listener: (event: HWEvent) => void) => EventSubscription | undefined
+  };
 
   export interface FocusGuideProps extends ViewProps {
      /**


### PR DESCRIPTION

## Summary:

TS libdefs. isn't correct after merging: https://github.com/react-native-tvos/react-native-tvos/commit/dbbe0c2605434805ece24bd98aaa4da5767c1ee7 

https://github.com/react-native-tvos/react-native-tvos/blob/6d1eb49c20b8cbae9ec51ea332c13e8799bb619f/packages/react-native/Libraries/Components/TV/TVEventHandler.js#L21-L43

## Changelog:

[GENERAL] [CHANGED] - [Typescript] Update `TVEventHandler` types to reflect the latest implementation


## Test Plan:

...
