### PR TITLE
feat(Touchable): Implement slim version of Touchable component, dedicated for TVs, to improve performance

### DIFF
--- a/.github/workflow-scripts/addDescriptiveLabels.js
+++ b/.github/workflow-scripts/addDescriptiveLabels.js
@@ -83,6 +83,7 @@ const components = [
   'TouchableHighlight',
   'TouchableNativeFeedback',
   'TouchableOpacity',
+  'TouchableTV',
   'TouchableWithoutFeedback',
   'ViewPagerAndroid',
   'VirtualizedList',

--- a/packages/react-native-babel-preset/src/configs/lazy-imports.js
+++ b/packages/react-native-babel-preset/src/configs/lazy-imports.js
@@ -42,6 +42,7 @@ module.exports = new Set([
   'TouchableHighlight',
   'TouchableNativeFeedback',
   'TouchableOpacity',
+  'TouchableTV',
   'TouchableWithoutFeedback',
   'View',
   'VirtualizedList',

--- a/packages/react-native/Libraries/Components/Touchable/TouchableTV.d.ts
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableTV.d.ts
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @format
+ */
+
+import type * as React from 'react';
+import {Constructor} from '../../../types/private/Utilities';
+import {TimerMixin} from '../../../types/private/TimerMixin';
+import {NativeMethods} from '../../../types/public/ReactNativeTypes';
+import {TVParallaxProperties} from '../View/ViewPropTypes';
+import {TouchableMixin} from './Touchable';
+import {TouchableWithoutFeedbackProps} from './TouchableWithoutFeedback';
+import type {TVProps} from './TouchableOpacity';
+
+/**
+ * @see https://reactnative.dev/docs/touchableopacity#props
+ */
+export interface TouchableTVProps
+  extends TouchableWithoutFeedbackProps,
+    TVProps {
+  /**
+   * *(Apple TV only)* Object with properties to control Apple TV parallax effects.
+   *
+   * enabled: If true, parallax effects are enabled.  Defaults to true.
+   * shiftDistanceX: Defaults to 2.0.
+   * shiftDistanceY: Defaults to 2.0.
+   * tiltAngle: Defaults to 0.05.
+   * magnification: Defaults to 1.0.
+   * pressMagnification: Defaults to 1.0.
+   * pressDuration: Defaults to 0.3.
+   * pressDelay: Defaults to 0.0.
+   *
+   * @platform android
+   */
+  tvParallaxProperties?: TVParallaxProperties | undefined;
+}
+
+/**
+ * A wrapper for making views respond properly to touches.
+ * On press down, the opacity of the wrapped view is decreased, dimming it.
+ * This is done without actually changing the view hierarchy,
+ * and in general is easy to add to an app without weird side-effects.
+ *
+ * @see https://reactnative.dev/docs/touchableopacity
+ */
+declare class TouchableTVComponent extends React.Component<TouchableTVProps> {}
+declare const TouchableTVBase: Constructor<TimerMixin> &
+  Constructor<TouchableMixin> &
+  Constructor<NativeMethods> &
+  typeof TouchableTVComponent;
+export class TouchableTV extends TouchableTVBase {}

--- a/packages/react-native/Libraries/Components/Touchable/TouchableTV.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableTV.js
@@ -1,0 +1,257 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {ViewStyleProp} from '../../StyleSheet/StyleSheet';
+import typeof TouchableWithoutFeedback from './TouchableWithoutFeedback';
+
+import View from '../View/View';
+import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
+import TVTouchable from './TVTouchable';
+import Platform from '../../Utilities/Platform';
+import type {TVParallaxPropertiesType} from '../TV/TVViewPropTypes';
+import tagForComponentOrHandle from '../TV/tagForComponentOrHandle';
+
+import * as React from 'react';
+
+type TVProps = $ReadOnly<{|
+  hasTVPreferredFocus?: ?boolean,
+  isTVSelectable?: ?boolean,
+  tvParallaxProperties?: TVParallaxPropertiesType,
+  nextFocusDown?: ?number,
+  nextFocusForward?: ?number,
+  nextFocusLeft?: ?number,
+  nextFocusRight?: ?number,
+  nextFocusUp?: ?number,
+|}>;
+
+type Props = $ReadOnly<{|
+  ...React.ElementConfig<TouchableWithoutFeedback>,
+  ...TVProps,
+
+  style?: ?ViewStyleProp,
+
+  hostRef?: ?React.Ref<typeof Animated.View>,
+|}>;
+
+/**
+ * A wrapper for making views respond properly to touches. This one, unlike TouchableOpacity,
+ * has no visual feedback that component has been pressed. It's the user responsibility,
+ * to implement such if required.
+ *
+ * Example:
+ *
+ * ```
+ * renderButton: function() {
+ *   return (
+ *     <TouchableTV onPress={this._onPressButton}>
+ *       <Image
+ *         style={styles.button}
+ *         source={require('./myButton.png')}
+ *       />
+ *     </TouchableTV>
+ *   );
+ * },
+ * ```
+ * ### Example
+ *
+ * ```ReactNativeWebPlayer
+ * import React, { Component } from 'react'
+ * import {
+ *   AppRegistry,
+ *   StyleSheet,
+ *   TouchableTV,
+ *   Text,
+ *   View,
+ * } from 'react-native'
+ *
+ * class App extends Component {
+ *   state = { count: 0 }
+ *
+ *   onPress = () => {
+ *     this.setState(state => ({
+ *       count: state.count + 1
+ *     }));
+ *   };
+ *
+ *  render() {
+ *    return (
+ *      <View style={styles.container}>
+ *        <TouchableTV
+ *          style={styles.button}
+ *          onPress={this.onPress}>
+ *          <Text> Touch Here </Text>
+ *        </TouchableTV>
+ *        <View style={[styles.countContainer]}>
+ *          <Text style={[styles.countText]}>
+ *             { this.state.count !== 0 ? this.state.count: null}
+ *           </Text>
+ *         </View>
+ *       </View>
+ *     )
+ *   }
+ * }
+ *
+ * const styles = StyleSheet.create({
+ *   container: {
+ *     flex: 1,
+ *     justifyContent: 'center',
+ *     paddingHorizontal: 10
+ *   },
+ *   button: {
+ *     alignItems: 'center',
+ *     backgroundColor: '#DDDDDD',
+ *     padding: 10
+ *   },
+ *   countContainer: {
+ *     alignItems: 'center',
+ *     padding: 10
+ *   },
+ *   countText: {
+ *     color: '#FF00FF'
+ *   }
+ * })
+ *
+ * AppRegistry.registerComponent('App', () => App)
+ * ```
+ *
+ */
+class TouchableTV extends React.Component<Props> {
+  _tvTouchable: ?TVTouchable;
+
+  render(): React.Node {
+    let _accessibilityState = {
+      busy: this.props['aria-busy'] ?? this.props.accessibilityState?.busy,
+      checked:
+        this.props['aria-checked'] ?? this.props.accessibilityState?.checked,
+      disabled:
+        this.props['aria-disabled'] ?? this.props.accessibilityState?.disabled,
+      expanded:
+        this.props['aria-expanded'] ?? this.props.accessibilityState?.expanded,
+      selected:
+        this.props['aria-selected'] ?? this.props.accessibilityState?.selected,
+    };
+
+    _accessibilityState =
+      this.props.disabled != null
+        ? {
+            ..._accessibilityState,
+            disabled: this.props.disabled,
+          }
+        : _accessibilityState;
+
+    const accessibilityValue = {
+      max: this.props['aria-valuemax'] ?? this.props.accessibilityValue?.max,
+      min: this.props['aria-valuemin'] ?? this.props.accessibilityValue?.min,
+      now: this.props['aria-valuenow'] ?? this.props.accessibilityValue?.now,
+      text: this.props['aria-valuetext'] ?? this.props.accessibilityValue?.text,
+    };
+
+    const accessibilityLiveRegion =
+      this.props['aria-live'] === 'off'
+        ? 'none'
+        : this.props['aria-live'] ?? this.props.accessibilityLiveRegion;
+
+    const accessibilityLabel =
+      this.props['aria-label'] ?? this.props.accessibilityLabel;
+    return (
+      <View
+        accessible={this.props.accessible !== false}
+        accessibilityLabel={accessibilityLabel}
+        accessibilityHint={this.props.accessibilityHint}
+        accessibilityLanguage={this.props.accessibilityLanguage}
+        accessibilityRole={this.props.accessibilityRole}
+        accessibilityState={_accessibilityState}
+        accessibilityActions={this.props.accessibilityActions}
+        onAccessibilityAction={this.props.onAccessibilityAction}
+        accessibilityValue={accessibilityValue}
+        importantForAccessibility={
+          this.props['aria-hidden'] === true
+            ? 'no-hide-descendants'
+            : this.props.importantForAccessibility
+        }
+        accessibilityViewIsModal={
+          this.props['aria-modal'] ?? this.props.accessibilityViewIsModal
+        }
+        accessibilityLiveRegion={accessibilityLiveRegion}
+        accessibilityElementsHidden={
+          this.props['aria-hidden'] ?? this.props.accessibilityElementsHidden
+        }
+        style={this.props.style}
+        nativeID={this.props.id ?? this.props.nativeID}
+        testID={this.props.testID}
+        onLayout={this.props.onLayout}
+		onClick={this.props.onPress}
+        nextFocusDown={tagForComponentOrHandle(this.props.nextFocusDown)}
+        nextFocusForward={tagForComponentOrHandle(this.props.nextFocusForward)}
+        nextFocusLeft={tagForComponentOrHandle(this.props.nextFocusLeft)}
+        nextFocusRight={tagForComponentOrHandle(this.props.nextFocusRight)}
+        nextFocusUp={tagForComponentOrHandle(this.props.nextFocusUp)}
+        hasTVPreferredFocus={this.props.hasTVPreferredFocus === true}
+        isTVSelectable={
+          this.props.isTVSelectable !== false && this.props.accessible !== false
+        }
+        tvParallaxProperties={this.props.tvParallaxProperties}
+        hitSlop={this.props.hitSlop}
+        focusable={
+          this.props.focusable !== false && this.props.onPress !== undefined
+        }
+        ref={this.props.hostRef}>
+        {this.props.children}
+        {__DEV__ ? (
+          <PressabilityDebugView color="cyan" hitSlop={this.props.hitSlop} />
+        ) : null}
+      </View>
+    );
+  }
+
+  componentDidMount(): void {
+    if (Platform.isTV) {
+      this._tvTouchable = new TVTouchable(this, {
+        getDisabled: () => this.props.disabled === true,
+        onBlur: event => {
+          if (this.props.onBlur != null) {
+            this.props.onBlur(event);
+          }
+        },
+        onFocus: event => {
+          if (this.props.onFocus != null) {
+            this.props.onFocus(event);
+          }
+        },
+        onPress: event => {
+          if (this.props.onPress != null) {
+            this.props.onPress(event);
+          }
+        },
+        onLongPress: event => {
+          if (this.props.onLongPress != null) {
+            this.props.onLongPress(event);
+          }
+        },
+      });
+    }
+  }
+
+  componentWillUnmount(): void {
+    if (Platform.isTV) {
+      if (this._tvTouchable != null) {
+        this._tvTouchable.destroy();
+      }
+    }
+  }
+}
+
+const Touchable = (React.forwardRef((props, ref) => (
+  <TouchableTV {...props} hostRef={ref} />
+)): React.AbstractComponent<Props, React.ElementRef<typeof View>>);
+
+Touchable.displayName = 'TouchableTV';
+
+module.exports = Touchable;

--- a/packages/react-native/index.js
+++ b/packages/react-native/index.js
@@ -35,6 +35,7 @@ import typeof Touchable from './Libraries/Components/Touchable/Touchable';
 import typeof TouchableHighlight from './Libraries/Components/Touchable/TouchableHighlight';
 import typeof TouchableNativeFeedback from './Libraries/Components/Touchable/TouchableNativeFeedback';
 import typeof TouchableOpacity from './Libraries/Components/Touchable/TouchableOpacity';
+import typeof TouchableTV from './Libraries/Components/Touchable/TouchableTV';
 import typeof TouchableWithoutFeedback from './Libraries/Components/Touchable/TouchableWithoutFeedback';
 import typeof View from './Libraries/Components/View/View';
 import typeof VirtualizedList from './Libraries/Lists/VirtualizedList';
@@ -194,6 +195,9 @@ module.exports = {
   },
   get TouchableOpacity(): TouchableOpacity {
     return require('./Libraries/Components/Touchable/TouchableOpacity');
+  },
+  get TouchableTV(): TouchableTV {
+    return require('./Libraries/Components/Touchable/TouchableTV');
   },
   get TouchableWithoutFeedback(): TouchableWithoutFeedback {
     return require('./Libraries/Components/Touchable/TouchableWithoutFeedback');

--- a/packages/react-native/types/index.d.ts
+++ b/packages/react-native/types/index.d.ts
@@ -98,6 +98,7 @@ export * from '../Libraries/Components/Touchable/Touchable';
 export * from '../Libraries/Components/Touchable/TouchableHighlight';
 export * from '../Libraries/Components/Touchable/TouchableNativeFeedback';
 export * from '../Libraries/Components/Touchable/TouchableOpacity';
+export * from '../Libraries/Components/Touchable/TouchableTV';
 export * from '../Libraries/Components/Touchable/TouchableWithoutFeedback';
 export * from '../Libraries/Components/View/View';
 export * from '../Libraries/Components/View/ViewAccessibility';


### PR DESCRIPTION
## Summary:

Goal of the PR is to introduce new `TouchableTV` component that is going to be a slim version of `TouchableOpacity` to maximise the performance, especially on low end devices. Two main things are removed from the component:
- `animations` - opacity change upon press may be not required, so there's no need to waste the resources on such animation, especially if it's replaced by some custom one. Let's allow for user of the component to decide if the animation is required.
- `pressability` - logic was designed for the mobiles and touch interactions, it's seems to be redundant for TVs, so we can save some CPU cycles by removing `componentDidUpdate` and `pressability` related parts.

I've noticed focus movement transition improvements, depending on scenario, area of application and complexity of the components:
~ up to 0.11 s (40% of total execution time) when moving focus once between touchable elements,

## Changelog:

[GENERAL] [ADDED] - Implement slim version of Touchable component, dedicated for TVs, to improve performance

## Test Plan:

Verify that `TouchableTV` covers the same functionality as `TouchableOpacity` on TV devices, but without animations.