### PR TITLE
fix(Android TV): Modal key and focus events with bridgeless

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
@@ -16,6 +16,7 @@ import com.facebook.react.bridge.WritableNativeMap;
 import com.facebook.react.common.MapBuilder;
 import com.facebook.react.common.SystemClock;
 import com.facebook.react.config.ReactFeatureFlags;
+import com.facebook.react.uimanager.ThemedReactContext;
 
 import java.util.Map;
 
@@ -209,7 +210,9 @@ public class ReactAndroidHWInputDeviceHelper {
 
   public void emitNamedEvent(String eventName, WritableMap event, ReactContext context) {
     if (context != null) {
-      context.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+      ((ThemedReactContext)context)
+        .getReactApplicationContext()
+        .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
         .emit(eventName, event);
     }
   }


### PR DESCRIPTION
## Summary:

After 0.74.1-0, the Modal component would cause a crash when an Android TV app was running in bridgeless mode and an arrow key was pressed.

This fixes the issue by ensuring the correct context is used when emitting events.

## Changelog:

[Android][Fixed] hardware key events in Modal and bridgeless

## Test Plan:

- RNTester Modal example could reproduce the issue. After the fix, the issue is no longer reproducible.
- Test with TVInputDemo with and without Fabric and bridgeless.