### PR TITLE
Fix - [Apple TV] TVTextScrollView is scrollable when scrollEnabled={false}

### DIFF
--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -1002,13 +1002,13 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
         // scroll to bottom
         // Similarly for left and right
         if (context.focusHeading == UIFocusHeadingUp && self.snapToStart) {
-            [self swipeVerticalScrollToOffset:0.0];
+            [self scrollToVerticalOffset:0.0];
         } else if(context.focusHeading == UIFocusHeadingDown && self.snapToEnd) {
-            [self swipeVerticalScrollToOffset:self.scrollView.contentSize.height];
+            [self scrollToVerticalOffset:self.scrollView.contentSize.height];
         } else if(context.focusHeading == UIFocusHeadingLeft && self.snapToStart) {
-            [self swipeHorizontalScrollToOffset:0.0];
+            [self scrollToHorizontalOffset:0.0];
         } else if(context.focusHeading == UIFocusHeadingRight && self.snapToEnd) {
-            [self swipeHorizontalScrollToOffset:self.scrollView.contentSize.width];
+            [self scrollToHorizontalOffset:self.scrollView.contentSize.width];
         }
 
     }
@@ -1119,7 +1119,7 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
     return duration;
 }
 
-- (void)swipeVerticalScrollToOffset:(CGFloat)yOffset
+- (void)scrollToVerticalOffset:(CGFloat)yOffset
 {
     _blockFirstTouch = NO;
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -1133,7 +1133,7 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
     });
 }
 
-- (void)swipeHorizontalScrollToOffset:(CGFloat)xOffset
+- (void)scrollToHorizontalOffset:(CGFloat)xOffset
 {
     _blockFirstTouch = NO;
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -1151,28 +1151,28 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
 {
     CGFloat newOffset = self.scrollView.contentOffset.y - [self swipeVerticalInterval];
     NSLog(@"Swiped up to %f", newOffset);
-    [self swipeVerticalScrollToOffset:newOffset];
+    [self scrollToVerticalOffset:newOffset];
 }
 
 - (void)swipedDown
 {
     CGFloat newOffset = self.scrollView.contentOffset.y + [self swipeVerticalInterval];
     NSLog(@"Swiped down to %f", newOffset);
-    [self swipeVerticalScrollToOffset:newOffset];
+    [self scrollToVerticalOffset:newOffset];
 }
 
 - (void)swipedLeft
 {
   CGFloat newOffset = self.scrollView.contentOffset.x - [self swipeHorizontalInterval];
   NSLog(@"Swiped left to %f", newOffset);
-  [self swipeHorizontalScrollToOffset:newOffset];
+  [self scrollToHorizontalOffset:newOffset];
 }
 
 - (void)swipedRight
 {
   CGFloat newOffset = self.scrollView.contentOffset.x + [self swipeHorizontalInterval];
   NSLog(@"Swiped right to %f", newOffset);
-  [self swipeHorizontalScrollToOffset:newOffset];
+  [self scrollToHorizontalOffset:newOffset];
 }
 
 - (void)addSwipeGestureRecognizers

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -1149,6 +1149,10 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
 
 - (void)swipedUp
 {
+    if (!self.scrollView.scrollEnabled) {
+        return;
+    }
+
     CGFloat newOffset = self.scrollView.contentOffset.y - [self swipeVerticalInterval];
     NSLog(@"Swiped up to %f", newOffset);
     [self scrollToVerticalOffset:newOffset];
@@ -1156,6 +1160,10 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
 
 - (void)swipedDown
 {
+    if (!self.scrollView.scrollEnabled) {
+        return;
+    }
+
     CGFloat newOffset = self.scrollView.contentOffset.y + [self swipeVerticalInterval];
     NSLog(@"Swiped down to %f", newOffset);
     [self scrollToVerticalOffset:newOffset];
@@ -1163,16 +1171,24 @@ RCT_SCROLL_EVENT_HANDLER(scrollViewDidScrollToTop, onScrollToTop)
 
 - (void)swipedLeft
 {
-  CGFloat newOffset = self.scrollView.contentOffset.x - [self swipeHorizontalInterval];
-  NSLog(@"Swiped left to %f", newOffset);
-  [self scrollToHorizontalOffset:newOffset];
+    if (!self.scrollView.scrollEnabled) {
+        return;
+    }
+
+    CGFloat newOffset = self.scrollView.contentOffset.x - [self swipeHorizontalInterval];
+    NSLog(@"Swiped left to %f", newOffset);
+    [self scrollToHorizontalOffset:newOffset];
 }
 
 - (void)swipedRight
 {
-  CGFloat newOffset = self.scrollView.contentOffset.x + [self swipeHorizontalInterval];
-  NSLog(@"Swiped right to %f", newOffset);
-  [self scrollToHorizontalOffset:newOffset];
+    if (!self.scrollView.scrollEnabled) {
+        return;
+    }
+
+    CGFloat newOffset = self.scrollView.contentOffset.x + [self swipeHorizontalInterval];
+    NSLog(@"Swiped right to %f", newOffset);
+    [self scrollToHorizontalOffset:newOffset];
 }
 
 - (void)addSwipeGestureRecognizers


### PR DESCRIPTION
## Summary:

Fixes #726.

This PR prevents a scroll view from scrolling when disabled while the user swipes horizontally or vertically on Apple TV.

- Rename methods to scroll to vertical & horizontal offset. The scroll to vertical & horizontal offset methods are called when swiping and during focus updates. So, renaming methods to be more generic.
- Prevent horizontal or vertical scrolling when swiping & scrolling disabled

## Changelog:


[IOS][FIXED] - Prevent ScrollView from scrolling when disabled.


## Test Plan:

Changes can be tested in the following branch:
[react-native-tvos-scrolling-bug/patch](https://github.com/cgoldsby/react-native-tvos-scrolling-bug/tree/patch)
```
cd react-native-tvos-scrolling-bug
yarn
yarn tvos
```

In the example app, the User can enable scrolling, vertical and horizontal layout, and short and long text.

The bug can be reproduced in the default branch of [react-native-tvos-scrolling-bug](https://github.com/cgoldsby/react-native-tvos-scrolling-bug/tree/main)

Code compiles on tvOS and iOS (but there is a jS error because the component is specific to tvOS)
