### PR TITLE
fix: velocityX/velocityY TS types

### DIFF
--- a/packages/react-native/types/public/ReactNativeTVTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTVTypes.d.ts
@@ -54,8 +54,8 @@ declare module 'react-native' {
       state: 'Began' | 'Changed' | 'Ended',
       x: number,
       y: number,
-      velocityx: number,
-      velocityy: number
+      velocityX: number,
+      velocityY: number
     } | undefined
   };
 


### PR DESCRIPTION
## Summary:

Fix #732 (a casing error in TV types)

## Changelog:

[General][Fixed] Correct casing error in TV types

## Test Plan:

- Check that TS errors reported by VSCode in an application project have been removed.
