### PR TITLE
 Add additional long press KeyEvents for HWInputDeviceHelper

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
@@ -75,6 +75,9 @@ public class ReactAndroidHWInputDeviceHelper {
           .put(KeyEvent.KEYCODE_DPAD_RIGHT, "longRight")
           .put(KeyEvent.KEYCODE_DPAD_DOWN, "longDown")
           .put(KeyEvent.KEYCODE_DPAD_LEFT, "longLeft")
+          .put(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, "longPlayPause")
+          .put(KeyEvent.KEYCODE_MEDIA_REWIND, "longRewind")
+          .put(KeyEvent.KEYCODE_MEDIA_FAST_FORWARD, "longFastForward")
           .build();
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
@@ -78,6 +78,8 @@ public class ReactAndroidHWInputDeviceHelper {
           .put(KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE, "longPlayPause")
           .put(KeyEvent.KEYCODE_MEDIA_REWIND, "longRewind")
           .put(KeyEvent.KEYCODE_MEDIA_FAST_FORWARD, "longFastForward")
+          .put(KeyEvent.KEYCODE_CHANNEL_DOWN, "longChannelDown")
+          .put(KeyEvent.KEYCODE_CHANNEL_UP, "longChannelUp")
           .build();
 
   /**


### PR DESCRIPTION
## Summary:

Added three new long press KeyEvent handlers for Android : longPlayPause, longRewind and longFastForward. They can be useful in applications with video player to better control the stream.
They avoid to use modify the tweak with ReactFeatureFlags.enableKeyDownEvents = true and deal with the development of a new JS long press event for those key events.
longPlayPause key event is used in some application to start over a live stream (get back from the beginning)

## Changelog:

[ANDROID] [CHANGED] - Add additional long press KeyEvents for HWInputDeviceHelper
