### PR TITLE
Add missing `tvFocusable` type in ViewProps

### DIFF
--- a/packages/react-native/types/public/ReactNativeTVTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTVTypes.d.ts
@@ -6,7 +6,7 @@ declare module 'react-native' {
   /**
    * Android TV only prop
    */
-  tvFocusable?: number | undefined,
+  tvFocusable?: boolean | undefined,
   /**
    * TV next focus down (see documentation for the View component).
    */

--- a/packages/react-native/types/public/ReactNativeTVTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTVTypes.d.ts
@@ -4,6 +4,10 @@ import type { View, ScrollViewProps, HostComponent, TVParallaxProperties, EventS
 declare module 'react-native' {
   interface ViewProps {
   /**
+   * Android TV only prop
+   */
+  tvFocusable?: number | undefined,
+  /**
    * TV next focus down (see documentation for the View component).
    */
   nextFocusDown?: number | undefined,


### PR DESCRIPTION

## Summary:

`tvFocusable` - property tvFocusable does not exist on type ViewProps

but I see usage in code base: https://github.com/search?q=repo%3Areact-native-tvos%2Freact-native-tvos%20tvFocusable&type=code



## Changelog:

[GENERAL] [ADDED] - [Typescript] Add `tvFocusable` prop to view props

## Test Plan:

...