### PR TITLE
RNTester tvOS fixes

### DIFF
--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.74.3-0)
+  - FBLazyVector (0.74.5-0)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - hermes-engine (0.74.3-0):
-    - hermes-engine/Pre-built (= 0.74.3-0)
-  - hermes-engine/Pre-built (0.74.3-0)
-  - MyNativeView (0.74.85):
+  - hermes-engine (0.74.5-0):
+    - hermes-engine/Pre-built (= 0.74.5-0)
+  - hermes-engine/Pre-built (0.74.5-0)
+  - MyNativeView (0.74.87):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -28,7 +28,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - NativeCxxModuleExample (0.74.85):
+  - NativeCxxModuleExample (0.74.87):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -66,26 +66,26 @@ PODS:
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCTDeprecation (0.74.3-0)
-  - RCTRequired (0.74.3-0)
-  - RCTTypeSafety (0.74.3-0):
-    - FBLazyVector (= 0.74.3-0)
-    - RCTRequired (= 0.74.3-0)
-    - React-Core (= 0.74.3-0)
-  - React (0.74.3-0):
-    - React-Core (= 0.74.3-0)
-    - React-Core/DevSupport (= 0.74.3-0)
-    - React-Core/RCTWebSocket (= 0.74.3-0)
-    - React-RCTActionSheet (= 0.74.3-0)
-    - React-RCTAnimation (= 0.74.3-0)
-    - React-RCTBlob (= 0.74.3-0)
-    - React-RCTImage (= 0.74.3-0)
-    - React-RCTLinking (= 0.74.3-0)
-    - React-RCTNetwork (= 0.74.3-0)
-    - React-RCTSettings (= 0.74.3-0)
-    - React-RCTText (= 0.74.3-0)
-  - React-callinvoker (0.74.3-0)
-  - React-Codegen (0.74.3-0):
+  - RCTDeprecation (0.74.5-0)
+  - RCTRequired (0.74.5-0)
+  - RCTTypeSafety (0.74.5-0):
+    - FBLazyVector (= 0.74.5-0)
+    - RCTRequired (= 0.74.5-0)
+    - React-Core (= 0.74.5-0)
+  - React (0.74.5-0):
+    - React-Core (= 0.74.5-0)
+    - React-Core/DevSupport (= 0.74.5-0)
+    - React-Core/RCTWebSocket (= 0.74.5-0)
+    - React-RCTActionSheet (= 0.74.5-0)
+    - React-RCTAnimation (= 0.74.5-0)
+    - React-RCTBlob (= 0.74.5-0)
+    - React-RCTImage (= 0.74.5-0)
+    - React-RCTLinking (= 0.74.5-0)
+    - React-RCTNetwork (= 0.74.5-0)
+    - React-RCTSettings (= 0.74.5-0)
+    - React-RCTText (= 0.74.5-0)
+  - React-callinvoker (0.74.5-0)
+  - React-Codegen (0.74.5-0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -105,12 +105,12 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.74.3-0):
+  - React-Core (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.74.3-0)
+    - React-Core/Default (= 0.74.5-0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -122,58 +122,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.74.3-0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/Default (0.74.3-0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/DevSupport (0.74.3-0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.74.3-0)
-    - React-Core/RCTWebSocket (= 0.74.3-0)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.74.3-0):
+  - React-Core/CoreModulesHeaders (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -190,7 +139,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.74.3-0):
+  - React-Core/Default (0.74.5-0):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/DevSupport (0.74.5-0):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.74.5-0)
+    - React-Core/RCTWebSocket (= 0.74.5-0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -207,7 +190,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.74.3-0):
+  - React-Core/RCTAnimationHeaders (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -224,7 +207,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.74.3-0):
+  - React-Core/RCTBlobHeaders (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -241,7 +224,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.74.3-0):
+  - React-Core/RCTImageHeaders (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -258,7 +241,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.74.3-0):
+  - React-Core/RCTLinkingHeaders (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -275,7 +258,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.74.3-0):
+  - React-Core/RCTNetworkHeaders (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -292,7 +275,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.74.3-0):
+  - React-Core/RCTPushNotificationHeaders (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -309,7 +292,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.74.3-0):
+  - React-Core/RCTSettingsHeaders (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -326,12 +309,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.74.3-0):
+  - React-Core/RCTTextHeaders (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.74.3-0)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -343,36 +326,53 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-CoreModules (0.74.3-0):
+  - React-Core/RCTWebSocket (0.74.5-0):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.74.5-0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-CoreModules (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
-    - RCTTypeSafety (= 0.74.3-0)
+    - RCTTypeSafety (= 0.74.5-0)
     - React-Codegen
-    - React-Core/CoreModulesHeaders (= 0.74.3-0)
-    - React-jsi (= 0.74.3-0)
+    - React-Core/CoreModulesHeaders (= 0.74.5-0)
+    - React-jsi (= 0.74.5-0)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.74.3-0)
+    - React-RCTImage (= 0.74.5-0)
     - ReactCommon
     - SocketRocket (= 0.7.0)
-  - React-cxxreact (0.74.3-0):
+  - React-cxxreact (0.74.5-0):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.3-0)
-    - React-debug (= 0.74.3-0)
-    - React-jsi (= 0.74.3-0)
+    - React-callinvoker (= 0.74.5-0)
+    - React-debug (= 0.74.5-0)
+    - React-jsi (= 0.74.5-0)
     - React-jsinspector
-    - React-logger (= 0.74.3-0)
-    - React-perflogger (= 0.74.3-0)
-    - React-runtimeexecutor (= 0.74.3-0)
-  - React-debug (0.74.3-0)
-  - React-Fabric (0.74.3-0):
+    - React-logger (= 0.74.5-0)
+    - React-perflogger (= 0.74.5-0)
+    - React-runtimeexecutor (= 0.74.5-0)
+  - React-debug (0.74.5-0)
+  - React-Fabric (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -383,20 +383,20 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.74.3-0)
-    - React-Fabric/attributedstring (= 0.74.3-0)
-    - React-Fabric/componentregistry (= 0.74.3-0)
-    - React-Fabric/componentregistrynative (= 0.74.3-0)
-    - React-Fabric/components (= 0.74.3-0)
-    - React-Fabric/core (= 0.74.3-0)
-    - React-Fabric/imagemanager (= 0.74.3-0)
-    - React-Fabric/leakchecker (= 0.74.3-0)
-    - React-Fabric/mounting (= 0.74.3-0)
-    - React-Fabric/scheduler (= 0.74.3-0)
-    - React-Fabric/telemetry (= 0.74.3-0)
-    - React-Fabric/templateprocessor (= 0.74.3-0)
-    - React-Fabric/textlayoutmanager (= 0.74.3-0)
-    - React-Fabric/uimanager (= 0.74.3-0)
+    - React-Fabric/animations (= 0.74.5-0)
+    - React-Fabric/attributedstring (= 0.74.5-0)
+    - React-Fabric/componentregistry (= 0.74.5-0)
+    - React-Fabric/componentregistrynative (= 0.74.5-0)
+    - React-Fabric/components (= 0.74.5-0)
+    - React-Fabric/core (= 0.74.5-0)
+    - React-Fabric/imagemanager (= 0.74.5-0)
+    - React-Fabric/leakchecker (= 0.74.5-0)
+    - React-Fabric/mounting (= 0.74.5-0)
+    - React-Fabric/scheduler (= 0.74.5-0)
+    - React-Fabric/telemetry (= 0.74.5-0)
+    - React-Fabric/templateprocessor (= 0.74.5-0)
+    - React-Fabric/textlayoutmanager (= 0.74.5-0)
+    - React-Fabric/uimanager (= 0.74.5-0)
     - React-graphics
     - React-jsi
     - React-jsiexecutor
@@ -405,26 +405,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.74.3-0):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.74.3-0):
+  - React-Fabric/animations (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -443,7 +424,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.74.3-0):
+  - React-Fabric/attributedstring (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -462,7 +443,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.74.3-0):
+  - React-Fabric/componentregistry (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -481,37 +462,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.74.3-0):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/inputaccessory (= 0.74.3-0)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.74.3-0)
-    - React-Fabric/components/modal (= 0.74.3-0)
-    - React-Fabric/components/rncore (= 0.74.3-0)
-    - React-Fabric/components/root (= 0.74.3-0)
-    - React-Fabric/components/safeareaview (= 0.74.3-0)
-    - React-Fabric/components/scrollview (= 0.74.3-0)
-    - React-Fabric/components/text (= 0.74.3-0)
-    - React-Fabric/components/textinput (= 0.74.3-0)
-    - React-Fabric/components/unimplementedview (= 0.74.3-0)
-    - React-Fabric/components/view (= 0.74.3-0)
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/inputaccessory (0.74.3-0):
+  - React-Fabric/componentregistrynative (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -530,7 +481,37 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.74.3-0):
+  - React-Fabric/components (0.74.5-0):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/inputaccessory (= 0.74.5-0)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.74.5-0)
+    - React-Fabric/components/modal (= 0.74.5-0)
+    - React-Fabric/components/rncore (= 0.74.5-0)
+    - React-Fabric/components/root (= 0.74.5-0)
+    - React-Fabric/components/safeareaview (= 0.74.5-0)
+    - React-Fabric/components/scrollview (= 0.74.5-0)
+    - React-Fabric/components/text (= 0.74.5-0)
+    - React-Fabric/components/textinput (= 0.74.5-0)
+    - React-Fabric/components/unimplementedview (= 0.74.5-0)
+    - React-Fabric/components/view (= 0.74.5-0)
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/inputaccessory (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -549,7 +530,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/modal (0.74.3-0):
+  - React-Fabric/components/legacyviewmanagerinterop (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -568,7 +549,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/rncore (0.74.3-0):
+  - React-Fabric/components/modal (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -587,7 +568,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.74.3-0):
+  - React-Fabric/components/rncore (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -606,7 +587,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/safeareaview (0.74.3-0):
+  - React-Fabric/components/root (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -625,7 +606,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.74.3-0):
+  - React-Fabric/components/safeareaview (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -644,7 +625,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/text (0.74.3-0):
+  - React-Fabric/components/scrollview (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -663,7 +644,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/textinput (0.74.3-0):
+  - React-Fabric/components/text (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -682,7 +663,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/unimplementedview (0.74.3-0):
+  - React-Fabric/components/textinput (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -701,7 +682,26 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.74.3-0):
+  - React-Fabric/components/unimplementedview (0.74.5-0):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -721,7 +721,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.74.3-0):
+  - React-Fabric/core (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -740,7 +740,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.74.3-0):
+  - React-Fabric/imagemanager (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -759,7 +759,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.74.3-0):
+  - React-Fabric/leakchecker (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -778,7 +778,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.74.3-0):
+  - React-Fabric/mounting (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -797,7 +797,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.74.3-0):
+  - React-Fabric/scheduler (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -816,7 +816,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.74.3-0):
+  - React-Fabric/telemetry (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -835,7 +835,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.74.3-0):
+  - React-Fabric/templateprocessor (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -854,7 +854,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/textlayoutmanager (0.74.3-0):
+  - React-Fabric/textlayoutmanager (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -874,7 +874,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.74.3-0):
+  - React-Fabric/uimanager (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -893,45 +893,45 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricImage (0.74.3-0):
+  - React-FabricImage (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired (= 0.74.3-0)
-    - RCTTypeSafety (= 0.74.3-0)
+    - RCTRequired (= 0.74.5-0)
+    - RCTTypeSafety (= 0.74.5-0)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.74.3-0)
+    - React-jsiexecutor (= 0.74.5-0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.74.3-0)
-  - React-graphics (0.74.3-0):
+  - React-featureflags (0.74.5-0)
+  - React-graphics (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - React-Core/Default (= 0.74.3-0)
+    - React-Core/Default (= 0.74.5-0)
     - React-utils
-  - React-hermes (0.74.3-0):
+  - React-hermes (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.74.3-0)
+    - React-cxxreact (= 0.74.5-0)
     - React-jsi
-    - React-jsiexecutor (= 0.74.3-0)
+    - React-jsiexecutor (= 0.74.5-0)
     - React-jsinspector
-    - React-perflogger (= 0.74.3-0)
+    - React-perflogger (= 0.74.5-0)
     - React-runtimeexecutor
-  - React-ImageManager (0.74.3-0):
+  - React-ImageManager (0.74.5-0):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -940,45 +940,45 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.74.3-0):
+  - React-jserrorhandler (0.74.5-0):
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-debug
     - React-jsi
     - React-Mapbuffer
-  - React-jsi (0.74.3-0):
+  - React-jsi (0.74.5-0):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-  - React-jsiexecutor (0.74.3-0):
+  - React-jsiexecutor (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.74.3-0)
-    - React-jsi (= 0.74.3-0)
+    - React-cxxreact (= 0.74.5-0)
+    - React-jsi (= 0.74.5-0)
     - React-jsinspector
-    - React-perflogger (= 0.74.3-0)
-  - React-jsinspector (0.74.3-0):
+    - React-perflogger (= 0.74.5-0)
+  - React-jsinspector (0.74.5-0):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-featureflags
     - React-jsi
-    - React-runtimeexecutor (= 0.74.3-0)
-  - React-jsitracing (0.74.3-0):
+    - React-runtimeexecutor (= 0.74.5-0)
+  - React-jsitracing (0.74.5-0):
     - React-jsi
-  - React-logger (0.74.3-0):
+  - React-logger (0.74.5-0):
     - glog
-  - React-Mapbuffer (0.74.3-0):
+  - React-Mapbuffer (0.74.5-0):
     - glog
     - React-debug
-  - React-nativeconfig (0.74.3-0)
-  - React-NativeModulesApple (0.74.3-0):
+  - React-nativeconfig (0.74.5-0)
+  - React-NativeModulesApple (0.74.5-0):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -989,10 +989,10 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.74.3-0)
-  - React-RCTActionSheet (0.74.3-0):
-    - React-Core/RCTActionSheetHeaders (= 0.74.3-0)
-  - React-RCTAnimation (0.74.3-0):
+  - React-perflogger (0.74.5-0)
+  - React-RCTActionSheet (0.74.5-0):
+    - React-Core/RCTActionSheetHeaders (= 0.74.5-0)
+  - React-RCTAnimation (0.74.5-0):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1000,7 +1000,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTAppDelegate (0.74.3-0):
+  - React-RCTAppDelegate (0.74.5-0):
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1024,7 +1024,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon
-  - React-RCTBlob (0.74.3-0):
+  - React-RCTBlob (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - hermes-engine
@@ -1037,7 +1037,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.74.3-0):
+  - React-RCTFabric (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1057,7 +1057,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.74.3-0):
+  - React-RCTImage (0.74.5-0):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1066,14 +1066,14 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.74.3-0):
+  - React-RCTLinking (0.74.5-0):
     - React-Codegen
-    - React-Core/RCTLinkingHeaders (= 0.74.3-0)
-    - React-jsi (= 0.74.3-0)
+    - React-Core/RCTLinkingHeaders (= 0.74.5-0)
+    - React-jsi (= 0.74.5-0)
     - React-NativeModulesApple
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.74.3-0)
-  - React-RCTNetwork (0.74.3-0):
+    - ReactCommon/turbomodule/core (= 0.74.5-0)
+  - React-RCTNetwork (0.74.5-0):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1081,14 +1081,14 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTPushNotification (0.74.3-0):
+  - React-RCTPushNotification (0.74.5-0):
     - RCTTypeSafety
     - React-Codegen
     - React-Core/RCTPushNotificationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTSettings (0.74.3-0):
+  - React-RCTSettings (0.74.5-0):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1096,22 +1096,22 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTTest (0.74.3-0):
+  - React-RCTTest (0.74.5-0):
     - RCT-Folly (= 2024.01.01.00)
-    - React-Core (= 0.74.3-0)
-    - React-CoreModules (= 0.74.3-0)
-    - React-jsi (= 0.74.3-0)
-    - ReactCommon/turbomodule/core (= 0.74.3-0)
-  - React-RCTText (0.74.3-0):
-    - React-Core/RCTTextHeaders (= 0.74.3-0)
+    - React-Core (= 0.74.5-0)
+    - React-CoreModules (= 0.74.5-0)
+    - React-jsi (= 0.74.5-0)
+    - ReactCommon/turbomodule/core (= 0.74.5-0)
+  - React-RCTText (0.74.5-0):
+    - React-Core/RCTTextHeaders (= 0.74.5-0)
     - Yoga
-  - React-rendererdebug (0.74.3-0):
+  - React-rendererdebug (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-  - React-rncore (0.74.3-0)
-  - React-RuntimeApple (0.74.3-0):
+  - React-rncore (0.74.5-0)
+  - React-RuntimeApple (0.74.5-0):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-callinvoker
@@ -1129,7 +1129,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - React-utils
-  - React-RuntimeCore (0.74.3-0):
+  - React-RuntimeCore (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1142,9 +1142,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.74.3-0):
-    - React-jsi (= 0.74.3-0)
-  - React-RuntimeHermes (0.74.3-0):
+  - React-runtimeexecutor (0.74.5-0):
+    - React-jsi (= 0.74.5-0)
+  - React-RuntimeHermes (0.74.5-0):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-featureflags
@@ -1155,7 +1155,7 @@ PODS:
     - React-nativeconfig
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.74.3-0):
+  - React-runtimescheduler (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -1167,15 +1167,15 @@ PODS:
     - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
-  - React-utils (0.74.3-0):
+  - React-utils (0.74.5-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-    - React-jsi (= 0.74.3-0)
-  - ReactCommon (0.74.3-0):
-    - ReactCommon/turbomodule (= 0.74.3-0)
-  - ReactCommon-Samples (0.74.3-0):
+    - React-jsi (= 0.74.5-0)
+  - ReactCommon (0.74.5-0):
+    - ReactCommon/turbomodule (= 0.74.5-0)
+  - ReactCommon-Samples (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - hermes-engine
@@ -1186,44 +1186,44 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - ReactCommon/turbomodule (0.74.3-0):
+  - ReactCommon/turbomodule (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.3-0)
-    - React-cxxreact (= 0.74.3-0)
-    - React-jsi (= 0.74.3-0)
-    - React-logger (= 0.74.3-0)
-    - React-perflogger (= 0.74.3-0)
-    - ReactCommon/turbomodule/bridging (= 0.74.3-0)
-    - ReactCommon/turbomodule/core (= 0.74.3-0)
-  - ReactCommon/turbomodule/bridging (0.74.3-0):
+    - React-callinvoker (= 0.74.5-0)
+    - React-cxxreact (= 0.74.5-0)
+    - React-jsi (= 0.74.5-0)
+    - React-logger (= 0.74.5-0)
+    - React-perflogger (= 0.74.5-0)
+    - ReactCommon/turbomodule/bridging (= 0.74.5-0)
+    - ReactCommon/turbomodule/core (= 0.74.5-0)
+  - ReactCommon/turbomodule/bridging (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.3-0)
-    - React-cxxreact (= 0.74.3-0)
-    - React-jsi (= 0.74.3-0)
-    - React-logger (= 0.74.3-0)
-    - React-perflogger (= 0.74.3-0)
-  - ReactCommon/turbomodule/core (0.74.3-0):
+    - React-callinvoker (= 0.74.5-0)
+    - React-cxxreact (= 0.74.5-0)
+    - React-jsi (= 0.74.5-0)
+    - React-logger (= 0.74.5-0)
+    - React-perflogger (= 0.74.5-0)
+  - ReactCommon/turbomodule/core (0.74.5-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.3-0)
-    - React-cxxreact (= 0.74.3-0)
-    - React-debug (= 0.74.3-0)
-    - React-jsi (= 0.74.3-0)
-    - React-logger (= 0.74.3-0)
-    - React-perflogger (= 0.74.3-0)
-    - React-utils (= 0.74.3-0)
-  - ScreenshotManager (0.74.85):
+    - React-callinvoker (= 0.74.5-0)
+    - React-cxxreact (= 0.74.5-0)
+    - React-debug (= 0.74.5-0)
+    - React-jsi (= 0.74.5-0)
+    - React-logger (= 0.74.5-0)
+    - React-perflogger (= 0.74.5-0)
+    - React-utils (= 0.74.5-0)
+  - ScreenshotManager (0.74.87):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1440,65 +1440,65 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 88202336c3ba1e7a264a83c0c888784b0f360c28
   DoubleConversion: 00143ab27d470b28035933623e1a3ea37e68889c
-  FBLazyVector: efebcbe4c5aee297390c37084326b8b06b1648a7
+  FBLazyVector: a3df5e0e93ad03f65526deee8647cbfd9eea095f
   fmt: 1568fa7b2f242362c45c42d4a15e9dd4b2e621b3
   glog: 5941fa5836fea300e249178dd5a75c96e0207bb9
-  hermes-engine: fdb92d647326e1a9f1a9ffedb340bfec04a21475
-  MyNativeView: 8398cfa69a5aa33a3e8a1b110b6db5bc445748a7
-  NativeCxxModuleExample: 9f704759a218b5beb2ed19f764ab6d233459996e
+  hermes-engine: f344cfa62a1c446c55649bd734e7dd3be23d18bc
+  MyNativeView: 1cd60c7b928ff04620cb1330580d148202a7901e
+  NativeCxxModuleExample: f940a878ca982eb48676c0dd0888b158c6a7d954
   OCMock: 300b1b1b9155cb6378660b981c2557448830bdc6
   RCT-Folly: b54b39c7532acfa0216d988bdeb706883e71416e
-  RCTDeprecation: f7b846bce4154b856ab90894ad4c16bcf663f0de
-  RCTRequired: 8a5f633665b5cbd4db30d96f9e65ab5d5efa08b6
-  RCTTypeSafety: 3125b2fcf10730b0901159e146a193ab4d655fd4
-  React: b6699168a1afd324c9ad59c99512a846d02ce2c9
-  React-callinvoker: 6a7b3db9bd97524d1a260c3764889154643f28ee
-  React-Codegen: 2d33e67eae0de6bca61002791c6aea98029384c2
-  React-Core: feed612e1c16bbb39f50223bc31329d3c783f6ac
-  React-CoreModules: ec7bfac20d3ba81783018f8f082b9e3662585363
-  React-cxxreact: 183e1c5d081bbdd8beda65ca610463fb0b23ffc7
-  React-debug: d349089d7d26fcb0ea5a2bdfbfc30b6f86868905
-  React-Fabric: 1090f7bea5445fa46bb081a66a42d9acdce8d733
-  React-FabricImage: 99f116b0e3f6dc491d5cbbc1817b68a026611bd1
-  React-featureflags: 411d48be9dff9ca265c8e34f243fa8830832e42d
-  React-graphics: c7c501a3de2906856a1e0af2231d092ba0b50b0f
-  React-hermes: f196cb018f03a2325a59092fc6fee278af567d1f
-  React-ImageManager: 1b132f98fab1ad9da129c6f3cb812ca25c979d41
-  React-jserrorhandler: 697a876182f33777ed41096d1b69c239cecb57be
-  React-jsi: 0003db80d35cf084cb0014dc5850efb5dd8ad979
-  React-jsiexecutor: eae10252ff1592632054629d62a9554bd164fbe5
-  React-jsinspector: 43ea35a80ce22c4cec7bfc818dca2a555000fe4a
-  React-jsitracing: 574a2fab47b3fe3d031b3676cfde464628d40984
-  React-logger: 19894e59913bfbd7b2f2f5fc2d9d6cc19790c211
-  React-Mapbuffer: 231bc59e70c8a09acdd1c61791b2e4fd2c482abc
-  React-nativeconfig: 16f4b40e276f81eab5fd09a71d3fe94d63dd94c7
-  React-NativeModulesApple: 94835bd3120c1e57e2ce9bd3d903d311468bb767
-  React-perflogger: 29778d3d7b87e51b517834b2e836a4d8fbae4ece
-  React-RCTActionSheet: 1f27f6e1f6c429c3ef17c991b89f6b8a45916e00
-  React-RCTAnimation: 7419aac16be2064d66b08bf6df10e73970c7fa97
-  React-RCTAppDelegate: 12d632d558f835e441145bceb652e4314d9454fc
-  React-RCTBlob: 378fd8abb657cf8797f2fe85aec85ef2d9e13b51
-  React-RCTFabric: 8f225e29abe7334641aaa657d77d260151640c12
-  React-RCTImage: c1a14d8366a617de9dce9a71baa0cbb9832ed3b0
-  React-RCTLinking: 3bc59251b9012c69817656a0f951f48f0fdc9fa4
-  React-RCTNetwork: e2e86c8c2afa1a1990aa5de8f74958e1e27c177d
-  React-RCTPushNotification: 13e8d5f9e32285560b44946cb21e9ff12208e3cf
-  React-RCTSettings: ff964d2e79583710f4b0de39771f3651bb19c693
-  React-RCTTest: 72bfea58494c62984a99a8e4b060131287570b32
-  React-RCTText: a77677e03ff6dc32ba7cba3b52205ca8e6f45553
-  React-rendererdebug: 6e5ef9313a3f9652a134d0ace6334d97aabcaf29
-  React-rncore: fb844f5276144e40f3863d3c752b9651d93e64c4
-  React-RuntimeApple: 2213c97fbb84ae6c880cbcd1f368d16b307477ce
-  React-RuntimeCore: f9587350021c1e3acea14d88397331f41f714de8
-  React-runtimeexecutor: 98a1483bf4dbc57e2bc4197cbda6be7c7182d5b9
-  React-RuntimeHermes: 9270e94bcbba051e8f5b22a9f409bddea1a8ae12
-  React-runtimescheduler: 57136aa718e5851ad3a8a7c85fd3b560928eeb13
-  React-utils: c81447161a12c311f08d31607889180371231a55
-  ReactCommon: 55ec5949191f314403e61ced6d5bb0798d493585
-  ReactCommon-Samples: 0cd7c41f1d3f42c640be3ba2608ada3c3a08e249
-  ScreenshotManager: 76aaf7b872963e4bcf6595d28de46f2d7e9f483c
+  RCTDeprecation: 83e9728446042462a2c6ae65acd436a8fa1e509d
+  RCTRequired: 33588674977a47c3605698ecf2880504aa439097
+  RCTTypeSafety: 3943c78fc40e684a8ad635565ac116a59a3118b7
+  React: fae3784df668d10c62fefe37fe1da4b5acb01739
+  React-callinvoker: 2d3ca4381b6c6018ed6cf727f52c376a4c48b392
+  React-Codegen: 0fa35e7d12e3d48ae4e5f4397cbaed7b13a5bf8b
+  React-Core: ee5e87b028fec71d4aed7302e762f440018e2a94
+  React-CoreModules: 86f34311827188b1fa8e9e70ba3674daefaed82b
+  React-cxxreact: 60793d385cb9f340cdf599aacbba2dd132f795d0
+  React-debug: a1ddbe1f74eb8ef9846cd3f1ff547edf8d56f039
+  React-Fabric: 8bc427f0061846caf0fd2b6cd771d14262df70f9
+  React-FabricImage: cbe812e9bfd5869dd28cb60ec361f84ab5123779
+  React-featureflags: 9ec0386f9a87b398a3211195f7f65e6b4129e883
+  React-graphics: 662c9c7b7f11686d229d25f343e7bb9f50d6ddd3
+  React-hermes: 9f77384c4ca8782c27ef1d9befdee9ed43895d74
+  React-ImageManager: 116b4848ed7718b619ebed65f913df5dea9da46f
+  React-jserrorhandler: f171c4f84cdb758d6ef6b5ecb388f5f4feeedb42
+  React-jsi: 1654a8d64b08c81b0601e7a25cfdc1962ac2f4dd
+  React-jsiexecutor: 95ca4d9069db3f2d99f5089e38c99aed726c83f6
+  React-jsinspector: fd86201bfff8493aac7368b87ff1e054f8d95ba7
+  React-jsitracing: e85fa8f607d38c6a3e169f5785777812289beba4
+  React-logger: c0654977aab00b4a39279fa4f9514ac9f7f5fa66
+  React-Mapbuffer: 25578953b1a52c45a875fe1a3a4dbd6ad3cbfc37
+  React-nativeconfig: 5d3d749a2fefcdb71a9d2d839078aaeb73a9ed57
+  React-NativeModulesApple: 9f6e0609c724b374263553607d5d90fdc177f875
+  React-perflogger: dc7aac6511117fb94a24d337114f165fd0df5602
+  React-RCTActionSheet: 7ed0b9a4b92a0949810f7bbbc3db2138321098e2
+  React-RCTAnimation: d7ec6371b1e08de51432c13fcdee5a1e16e8eeac
+  React-RCTAppDelegate: dac87ff9d1022871a2d7d2fc600cf4ed638a6262
+  React-RCTBlob: 89f4409d954ceb839d8ecc34c99c0a954e9d1ce4
+  React-RCTFabric: 7a470ca597759e14c885dc04a27a1951cad61367
+  React-RCTImage: 27f100e1a6a9f5b601fb1982617b8274f5cb921d
+  React-RCTLinking: 5bac4f926af49c605a2f0931f49c9fcdf8021d93
+  React-RCTNetwork: 16a1ec6208e36ae0166224c30f610522d96cfdde
+  React-RCTPushNotification: 2e26dea1514dd59f7338127e9275b3de033819cd
+  React-RCTSettings: 318c37f264ce65d6031d32a846b190c61cf9c81d
+  React-RCTTest: 0272fa9118baa257a46ec00c19f91dc1ba927d50
+  React-RCTText: 977ea327b3bf2be6599a516e76c538045a14cbb9
+  React-rendererdebug: 716efb6d02f34316f1bd2458f4aaf2646656ed39
+  React-rncore: 20ab18903a607eb08612ee72b663f8fbfbde2fbb
+  React-RuntimeApple: 691c8edde215c064e2f5924e80eb55e5b2159164
+  React-RuntimeCore: 2542d0c05e577cb571b150b6e653653d87ac3e68
+  React-runtimeexecutor: 50d003e35f94a6a8556d13f11c160bf4cd287ac4
+  React-RuntimeHermes: fe6cbfb3e26028b822c1f4499407c72ab85d96e1
+  React-runtimescheduler: 8b6df7507ef57e43698e07c17f2f640a551c7744
+  React-utils: 0722628556f07211936d98debee53d0df33227c1
+  ReactCommon: 1a11abd52b3c972770d105a523cbbbcc2ca678f9
+  ReactCommon-Samples: d4bf326f2b52f2e9227261ef2b4bb2cfcfd76b27
+  ScreenshotManager: 702c67f5583d7e29a1c0434904ccd620bc7c55ae
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: 67339ae9c4da2254f6ac2b73ac266332c5962ce0
+  Yoga: 69701a97cb6d539d522352f92334fa2b383f559c
 
 PODFILE CHECKSUM: 13ecd40d4b3f8802df1b52487c2663a1677f35d5
 

--- a/packages/rn-tester/Podfile.lock
+++ b/packages/rn-tester/Podfile.lock
@@ -1,13 +1,13 @@
 PODS:
   - boost (1.83.0)
   - DoubleConversion (1.1.6)
-  - FBLazyVector (0.74.5-0)
+  - FBLazyVector (0.74.3-0)
   - fmt (9.1.0)
   - glog (0.3.5)
-  - hermes-engine (0.74.5-0):
-    - hermes-engine/Pre-built (= 0.74.5-0)
-  - hermes-engine/Pre-built (0.74.5-0)
-  - MyNativeView (0.74.87):
+  - hermes-engine (0.74.3-0):
+    - hermes-engine/Pre-built (= 0.74.3-0)
+  - hermes-engine/Pre-built (0.74.3-0)
+  - MyNativeView (0.74.85):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -28,7 +28,7 @@ PODS:
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
     - Yoga
-  - NativeCxxModuleExample (0.74.87):
+  - NativeCxxModuleExample (0.74.85):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -66,26 +66,26 @@ PODS:
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
-  - RCTDeprecation (0.74.5-0)
-  - RCTRequired (0.74.5-0)
-  - RCTTypeSafety (0.74.5-0):
-    - FBLazyVector (= 0.74.5-0)
-    - RCTRequired (= 0.74.5-0)
-    - React-Core (= 0.74.5-0)
-  - React (0.74.5-0):
-    - React-Core (= 0.74.5-0)
-    - React-Core/DevSupport (= 0.74.5-0)
-    - React-Core/RCTWebSocket (= 0.74.5-0)
-    - React-RCTActionSheet (= 0.74.5-0)
-    - React-RCTAnimation (= 0.74.5-0)
-    - React-RCTBlob (= 0.74.5-0)
-    - React-RCTImage (= 0.74.5-0)
-    - React-RCTLinking (= 0.74.5-0)
-    - React-RCTNetwork (= 0.74.5-0)
-    - React-RCTSettings (= 0.74.5-0)
-    - React-RCTText (= 0.74.5-0)
-  - React-callinvoker (0.74.5-0)
-  - React-Codegen (0.74.5-0):
+  - RCTDeprecation (0.74.3-0)
+  - RCTRequired (0.74.3-0)
+  - RCTTypeSafety (0.74.3-0):
+    - FBLazyVector (= 0.74.3-0)
+    - RCTRequired (= 0.74.3-0)
+    - React-Core (= 0.74.3-0)
+  - React (0.74.3-0):
+    - React-Core (= 0.74.3-0)
+    - React-Core/DevSupport (= 0.74.3-0)
+    - React-Core/RCTWebSocket (= 0.74.3-0)
+    - React-RCTActionSheet (= 0.74.3-0)
+    - React-RCTAnimation (= 0.74.3-0)
+    - React-RCTBlob (= 0.74.3-0)
+    - React-RCTImage (= 0.74.3-0)
+    - React-RCTLinking (= 0.74.3-0)
+    - React-RCTNetwork (= 0.74.3-0)
+    - React-RCTSettings (= 0.74.3-0)
+    - React-RCTText (= 0.74.3-0)
+  - React-callinvoker (0.74.3-0)
+  - React-Codegen (0.74.3-0):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -105,12 +105,12 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-Core (0.74.5-0):
+  - React-Core (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.74.5-0)
+    - React-Core/Default (= 0.74.3-0)
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -122,58 +122,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/CoreModulesHeaders (0.74.5-0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/Default (0.74.5-0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/DevSupport (0.74.5-0):
-    - glog
-    - hermes-engine
-    - RCT-Folly (= 2024.01.01.00)
-    - RCTDeprecation
-    - React-Core/Default (= 0.74.5-0)
-    - React-Core/RCTWebSocket (= 0.74.5-0)
-    - React-cxxreact
-    - React-featureflags
-    - React-hermes
-    - React-jsi
-    - React-jsiexecutor
-    - React-jsinspector
-    - React-perflogger
-    - React-runtimescheduler
-    - React-utils
-    - SocketRocket (= 0.7.0)
-    - Yoga
-  - React-Core/RCTActionSheetHeaders (0.74.5-0):
+  - React-Core/CoreModulesHeaders (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -190,7 +139,41 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTAnimationHeaders (0.74.5-0):
+  - React-Core/Default (0.74.3-0):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/DevSupport (0.74.3-0):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.74.3-0)
+    - React-Core/RCTWebSocket (= 0.74.3-0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-Core/RCTActionSheetHeaders (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -207,7 +190,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTBlobHeaders (0.74.5-0):
+  - React-Core/RCTAnimationHeaders (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -224,7 +207,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTImageHeaders (0.74.5-0):
+  - React-Core/RCTBlobHeaders (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -241,7 +224,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTLinkingHeaders (0.74.5-0):
+  - React-Core/RCTImageHeaders (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -258,7 +241,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTNetworkHeaders (0.74.5-0):
+  - React-Core/RCTLinkingHeaders (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -275,7 +258,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTPushNotificationHeaders (0.74.5-0):
+  - React-Core/RCTNetworkHeaders (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -292,7 +275,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTSettingsHeaders (0.74.5-0):
+  - React-Core/RCTPushNotificationHeaders (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -309,7 +292,7 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTTextHeaders (0.74.5-0):
+  - React-Core/RCTSettingsHeaders (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -326,12 +309,12 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-Core/RCTWebSocket (0.74.5-0):
+  - React-Core/RCTTextHeaders (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - RCTDeprecation
-    - React-Core/Default (= 0.74.5-0)
+    - React-Core/Default
     - React-cxxreact
     - React-featureflags
     - React-hermes
@@ -343,36 +326,53 @@ PODS:
     - React-utils
     - SocketRocket (= 0.7.0)
     - Yoga
-  - React-CoreModules (0.74.5-0):
+  - React-Core/RCTWebSocket (0.74.3-0):
+    - glog
+    - hermes-engine
+    - RCT-Folly (= 2024.01.01.00)
+    - RCTDeprecation
+    - React-Core/Default (= 0.74.3-0)
+    - React-cxxreact
+    - React-featureflags
+    - React-hermes
+    - React-jsi
+    - React-jsiexecutor
+    - React-jsinspector
+    - React-perflogger
+    - React-runtimescheduler
+    - React-utils
+    - SocketRocket (= 0.7.0)
+    - Yoga
+  - React-CoreModules (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
-    - RCTTypeSafety (= 0.74.5-0)
+    - RCTTypeSafety (= 0.74.3-0)
     - React-Codegen
-    - React-Core/CoreModulesHeaders (= 0.74.5-0)
-    - React-jsi (= 0.74.5-0)
+    - React-Core/CoreModulesHeaders (= 0.74.3-0)
+    - React-jsi (= 0.74.3-0)
     - React-jsinspector
     - React-NativeModulesApple
     - React-RCTBlob
-    - React-RCTImage (= 0.74.5-0)
+    - React-RCTImage (= 0.74.3-0)
     - ReactCommon
     - SocketRocket (= 0.7.0)
-  - React-cxxreact (0.74.5-0):
+  - React-cxxreact (0.74.3-0):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.5-0)
-    - React-debug (= 0.74.5-0)
-    - React-jsi (= 0.74.5-0)
+    - React-callinvoker (= 0.74.3-0)
+    - React-debug (= 0.74.3-0)
+    - React-jsi (= 0.74.3-0)
     - React-jsinspector
-    - React-logger (= 0.74.5-0)
-    - React-perflogger (= 0.74.5-0)
-    - React-runtimeexecutor (= 0.74.5-0)
-  - React-debug (0.74.5-0)
-  - React-Fabric (0.74.5-0):
+    - React-logger (= 0.74.3-0)
+    - React-perflogger (= 0.74.3-0)
+    - React-runtimeexecutor (= 0.74.3-0)
+  - React-debug (0.74.3-0)
+  - React-Fabric (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -383,20 +383,20 @@ PODS:
     - React-Core
     - React-cxxreact
     - React-debug
-    - React-Fabric/animations (= 0.74.5-0)
-    - React-Fabric/attributedstring (= 0.74.5-0)
-    - React-Fabric/componentregistry (= 0.74.5-0)
-    - React-Fabric/componentregistrynative (= 0.74.5-0)
-    - React-Fabric/components (= 0.74.5-0)
-    - React-Fabric/core (= 0.74.5-0)
-    - React-Fabric/imagemanager (= 0.74.5-0)
-    - React-Fabric/leakchecker (= 0.74.5-0)
-    - React-Fabric/mounting (= 0.74.5-0)
-    - React-Fabric/scheduler (= 0.74.5-0)
-    - React-Fabric/telemetry (= 0.74.5-0)
-    - React-Fabric/templateprocessor (= 0.74.5-0)
-    - React-Fabric/textlayoutmanager (= 0.74.5-0)
-    - React-Fabric/uimanager (= 0.74.5-0)
+    - React-Fabric/animations (= 0.74.3-0)
+    - React-Fabric/attributedstring (= 0.74.3-0)
+    - React-Fabric/componentregistry (= 0.74.3-0)
+    - React-Fabric/componentregistrynative (= 0.74.3-0)
+    - React-Fabric/components (= 0.74.3-0)
+    - React-Fabric/core (= 0.74.3-0)
+    - React-Fabric/imagemanager (= 0.74.3-0)
+    - React-Fabric/leakchecker (= 0.74.3-0)
+    - React-Fabric/mounting (= 0.74.3-0)
+    - React-Fabric/scheduler (= 0.74.3-0)
+    - React-Fabric/telemetry (= 0.74.3-0)
+    - React-Fabric/templateprocessor (= 0.74.3-0)
+    - React-Fabric/textlayoutmanager (= 0.74.3-0)
+    - React-Fabric/uimanager (= 0.74.3-0)
     - React-graphics
     - React-jsi
     - React-jsiexecutor
@@ -405,26 +405,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/animations (0.74.5-0):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/attributedstring (0.74.5-0):
+  - React-Fabric/animations (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -443,7 +424,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistry (0.74.5-0):
+  - React-Fabric/attributedstring (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -462,7 +443,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/componentregistrynative (0.74.5-0):
+  - React-Fabric/componentregistry (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -481,37 +462,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components (0.74.5-0):
-    - DoubleConversion
-    - fmt (= 9.1.0)
-    - glog
-    - hermes-engine
-    - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired
-    - RCTTypeSafety
-    - React-Core
-    - React-cxxreact
-    - React-debug
-    - React-Fabric/components/inputaccessory (= 0.74.5-0)
-    - React-Fabric/components/legacyviewmanagerinterop (= 0.74.5-0)
-    - React-Fabric/components/modal (= 0.74.5-0)
-    - React-Fabric/components/rncore (= 0.74.5-0)
-    - React-Fabric/components/root (= 0.74.5-0)
-    - React-Fabric/components/safeareaview (= 0.74.5-0)
-    - React-Fabric/components/scrollview (= 0.74.5-0)
-    - React-Fabric/components/text (= 0.74.5-0)
-    - React-Fabric/components/textinput (= 0.74.5-0)
-    - React-Fabric/components/unimplementedview (= 0.74.5-0)
-    - React-Fabric/components/view (= 0.74.5-0)
-    - React-graphics
-    - React-jsi
-    - React-jsiexecutor
-    - React-logger
-    - React-rendererdebug
-    - React-runtimescheduler
-    - React-utils
-    - ReactCommon/turbomodule/core
-  - React-Fabric/components/inputaccessory (0.74.5-0):
+  - React-Fabric/componentregistrynative (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -530,7 +481,37 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/legacyviewmanagerinterop (0.74.5-0):
+  - React-Fabric/components (0.74.3-0):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-Fabric/components/inputaccessory (= 0.74.3-0)
+    - React-Fabric/components/legacyviewmanagerinterop (= 0.74.3-0)
+    - React-Fabric/components/modal (= 0.74.3-0)
+    - React-Fabric/components/rncore (= 0.74.3-0)
+    - React-Fabric/components/root (= 0.74.3-0)
+    - React-Fabric/components/safeareaview (= 0.74.3-0)
+    - React-Fabric/components/scrollview (= 0.74.3-0)
+    - React-Fabric/components/text (= 0.74.3-0)
+    - React-Fabric/components/textinput (= 0.74.3-0)
+    - React-Fabric/components/unimplementedview (= 0.74.3-0)
+    - React-Fabric/components/view (= 0.74.3-0)
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/inputaccessory (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -549,7 +530,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/modal (0.74.5-0):
+  - React-Fabric/components/legacyviewmanagerinterop (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -568,7 +549,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/rncore (0.74.5-0):
+  - React-Fabric/components/modal (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -587,7 +568,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/root (0.74.5-0):
+  - React-Fabric/components/rncore (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -606,7 +587,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/safeareaview (0.74.5-0):
+  - React-Fabric/components/root (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -625,7 +606,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/scrollview (0.74.5-0):
+  - React-Fabric/components/safeareaview (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -644,7 +625,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/text (0.74.5-0):
+  - React-Fabric/components/scrollview (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -663,7 +644,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/textinput (0.74.5-0):
+  - React-Fabric/components/text (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -682,7 +663,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/unimplementedview (0.74.5-0):
+  - React-Fabric/components/textinput (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -701,7 +682,26 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/components/view (0.74.5-0):
+  - React-Fabric/components/unimplementedview (0.74.3-0):
+    - DoubleConversion
+    - fmt (= 9.1.0)
+    - glog
+    - hermes-engine
+    - RCT-Folly/Fabric (= 2024.01.01.00)
+    - RCTRequired
+    - RCTTypeSafety
+    - React-Core
+    - React-cxxreact
+    - React-debug
+    - React-graphics
+    - React-jsi
+    - React-jsiexecutor
+    - React-logger
+    - React-rendererdebug
+    - React-runtimescheduler
+    - React-utils
+    - ReactCommon/turbomodule/core
+  - React-Fabric/components/view (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -721,7 +721,7 @@ PODS:
     - React-utils
     - ReactCommon/turbomodule/core
     - Yoga
-  - React-Fabric/core (0.74.5-0):
+  - React-Fabric/core (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -740,7 +740,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/imagemanager (0.74.5-0):
+  - React-Fabric/imagemanager (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -759,7 +759,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/leakchecker (0.74.5-0):
+  - React-Fabric/leakchecker (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -778,7 +778,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/mounting (0.74.5-0):
+  - React-Fabric/mounting (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -797,7 +797,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/scheduler (0.74.5-0):
+  - React-Fabric/scheduler (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -816,7 +816,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/telemetry (0.74.5-0):
+  - React-Fabric/telemetry (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -835,7 +835,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/templateprocessor (0.74.5-0):
+  - React-Fabric/templateprocessor (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -854,7 +854,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/textlayoutmanager (0.74.5-0):
+  - React-Fabric/textlayoutmanager (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -874,7 +874,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-Fabric/uimanager (0.74.5-0):
+  - React-Fabric/uimanager (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
@@ -893,45 +893,45 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon/turbomodule/core
-  - React-FabricImage (0.74.5-0):
+  - React-FabricImage (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - RCTRequired (= 0.74.5-0)
-    - RCTTypeSafety (= 0.74.5-0)
+    - RCTRequired (= 0.74.3-0)
+    - RCTTypeSafety (= 0.74.3-0)
     - React-Fabric
     - React-graphics
     - React-ImageManager
     - React-jsi
-    - React-jsiexecutor (= 0.74.5-0)
+    - React-jsiexecutor (= 0.74.3-0)
     - React-logger
     - React-rendererdebug
     - React-utils
     - ReactCommon
     - Yoga
-  - React-featureflags (0.74.5-0)
-  - React-graphics (0.74.5-0):
+  - React-featureflags (0.74.3-0)
+  - React-graphics (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - RCT-Folly/Fabric (= 2024.01.01.00)
-    - React-Core/Default (= 0.74.5-0)
+    - React-Core/Default (= 0.74.3-0)
     - React-utils
-  - React-hermes (0.74.5-0):
+  - React-hermes (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.74.5-0)
+    - React-cxxreact (= 0.74.3-0)
     - React-jsi
-    - React-jsiexecutor (= 0.74.5-0)
+    - React-jsiexecutor (= 0.74.3-0)
     - React-jsinspector
-    - React-perflogger (= 0.74.5-0)
+    - React-perflogger (= 0.74.3-0)
     - React-runtimeexecutor
-  - React-ImageManager (0.74.5-0):
+  - React-ImageManager (0.74.3-0):
     - glog
     - RCT-Folly/Fabric
     - React-Core/Default
@@ -940,45 +940,45 @@ PODS:
     - React-graphics
     - React-rendererdebug
     - React-utils
-  - React-jserrorhandler (0.74.5-0):
+  - React-jserrorhandler (0.74.3-0):
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-debug
     - React-jsi
     - React-Mapbuffer
-  - React-jsi (0.74.5-0):
+  - React-jsi (0.74.3-0):
     - boost (= 1.83.0)
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-  - React-jsiexecutor (0.74.5-0):
+  - React-jsiexecutor (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-cxxreact (= 0.74.5-0)
-    - React-jsi (= 0.74.5-0)
+    - React-cxxreact (= 0.74.3-0)
+    - React-jsi (= 0.74.3-0)
     - React-jsinspector
-    - React-perflogger (= 0.74.5-0)
-  - React-jsinspector (0.74.5-0):
+    - React-perflogger (= 0.74.3-0)
+  - React-jsinspector (0.74.3-0):
     - DoubleConversion
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-featureflags
     - React-jsi
-    - React-runtimeexecutor (= 0.74.5-0)
-  - React-jsitracing (0.74.5-0):
+    - React-runtimeexecutor (= 0.74.3-0)
+  - React-jsitracing (0.74.3-0):
     - React-jsi
-  - React-logger (0.74.5-0):
+  - React-logger (0.74.3-0):
     - glog
-  - React-Mapbuffer (0.74.5-0):
+  - React-Mapbuffer (0.74.3-0):
     - glog
     - React-debug
-  - React-nativeconfig (0.74.5-0)
-  - React-NativeModulesApple (0.74.5-0):
+  - React-nativeconfig (0.74.3-0)
+  - React-NativeModulesApple (0.74.3-0):
     - glog
     - hermes-engine
     - React-callinvoker
@@ -989,10 +989,10 @@ PODS:
     - React-runtimeexecutor
     - ReactCommon/turbomodule/bridging
     - ReactCommon/turbomodule/core
-  - React-perflogger (0.74.5-0)
-  - React-RCTActionSheet (0.74.5-0):
-    - React-Core/RCTActionSheetHeaders (= 0.74.5-0)
-  - React-RCTAnimation (0.74.5-0):
+  - React-perflogger (0.74.3-0)
+  - React-RCTActionSheet (0.74.3-0):
+    - React-Core/RCTActionSheetHeaders (= 0.74.3-0)
+  - React-RCTAnimation (0.74.3-0):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1000,7 +1000,7 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTAppDelegate (0.74.5-0):
+  - React-RCTAppDelegate (0.74.3-0):
     - RCT-Folly (= 2024.01.01.00)
     - RCTRequired
     - RCTTypeSafety
@@ -1024,7 +1024,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - ReactCommon
-  - React-RCTBlob (0.74.5-0):
+  - React-RCTBlob (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - hermes-engine
@@ -1037,7 +1037,7 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTFabric (0.74.5-0):
+  - React-RCTFabric (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1057,7 +1057,7 @@ PODS:
     - React-runtimescheduler
     - React-utils
     - Yoga
-  - React-RCTImage (0.74.5-0):
+  - React-RCTImage (0.74.3-0):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1066,14 +1066,14 @@ PODS:
     - React-NativeModulesApple
     - React-RCTNetwork
     - ReactCommon
-  - React-RCTLinking (0.74.5-0):
+  - React-RCTLinking (0.74.3-0):
     - React-Codegen
-    - React-Core/RCTLinkingHeaders (= 0.74.5-0)
-    - React-jsi (= 0.74.5-0)
+    - React-Core/RCTLinkingHeaders (= 0.74.3-0)
+    - React-jsi (= 0.74.3-0)
     - React-NativeModulesApple
     - ReactCommon
-    - ReactCommon/turbomodule/core (= 0.74.5-0)
-  - React-RCTNetwork (0.74.5-0):
+    - ReactCommon/turbomodule/core (= 0.74.3-0)
+  - React-RCTNetwork (0.74.3-0):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1081,14 +1081,14 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTPushNotification (0.74.5-0):
+  - React-RCTPushNotification (0.74.3-0):
     - RCTTypeSafety
     - React-Codegen
     - React-Core/RCTPushNotificationHeaders
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTSettings (0.74.5-0):
+  - React-RCTSettings (0.74.3-0):
     - RCT-Folly (= 2024.01.01.00)
     - RCTTypeSafety
     - React-Codegen
@@ -1096,22 +1096,22 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - React-RCTTest (0.74.5-0):
+  - React-RCTTest (0.74.3-0):
     - RCT-Folly (= 2024.01.01.00)
-    - React-Core (= 0.74.5-0)
-    - React-CoreModules (= 0.74.5-0)
-    - React-jsi (= 0.74.5-0)
-    - ReactCommon/turbomodule/core (= 0.74.5-0)
-  - React-RCTText (0.74.5-0):
-    - React-Core/RCTTextHeaders (= 0.74.5-0)
+    - React-Core (= 0.74.3-0)
+    - React-CoreModules (= 0.74.3-0)
+    - React-jsi (= 0.74.3-0)
+    - ReactCommon/turbomodule/core (= 0.74.3-0)
+  - React-RCTText (0.74.3-0):
+    - React-Core/RCTTextHeaders (= 0.74.3-0)
     - Yoga
-  - React-rendererdebug (0.74.5-0):
+  - React-rendererdebug (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-  - React-rncore (0.74.5-0)
-  - React-RuntimeApple (0.74.5-0):
+  - React-rncore (0.74.3-0)
+  - React-RuntimeApple (0.74.3-0):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-callinvoker
@@ -1129,7 +1129,7 @@ PODS:
     - React-runtimeexecutor
     - React-RuntimeHermes
     - React-utils
-  - React-RuntimeCore (0.74.5-0):
+  - React-RuntimeCore (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
@@ -1142,9 +1142,9 @@ PODS:
     - React-runtimeexecutor
     - React-runtimescheduler
     - React-utils
-  - React-runtimeexecutor (0.74.5-0):
-    - React-jsi (= 0.74.5-0)
-  - React-RuntimeHermes (0.74.5-0):
+  - React-runtimeexecutor (0.74.3-0):
+    - React-jsi (= 0.74.3-0)
+  - React-RuntimeHermes (0.74.3-0):
     - hermes-engine
     - RCT-Folly/Fabric (= 2024.01.01.00)
     - React-featureflags
@@ -1155,7 +1155,7 @@ PODS:
     - React-nativeconfig
     - React-RuntimeCore
     - React-utils
-  - React-runtimescheduler (0.74.5-0):
+  - React-runtimescheduler (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
@@ -1167,15 +1167,15 @@ PODS:
     - React-rendererdebug
     - React-runtimeexecutor
     - React-utils
-  - React-utils (0.74.5-0):
+  - React-utils (0.74.3-0):
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
     - React-debug
-    - React-jsi (= 0.74.5-0)
-  - ReactCommon (0.74.5-0):
-    - ReactCommon/turbomodule (= 0.74.5-0)
-  - ReactCommon-Samples (0.74.5-0):
+    - React-jsi (= 0.74.3-0)
+  - ReactCommon (0.74.3-0):
+    - ReactCommon/turbomodule (= 0.74.3-0)
+  - ReactCommon-Samples (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - hermes-engine
@@ -1186,44 +1186,44 @@ PODS:
     - React-jsi
     - React-NativeModulesApple
     - ReactCommon
-  - ReactCommon/turbomodule (0.74.5-0):
+  - ReactCommon/turbomodule (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.5-0)
-    - React-cxxreact (= 0.74.5-0)
-    - React-jsi (= 0.74.5-0)
-    - React-logger (= 0.74.5-0)
-    - React-perflogger (= 0.74.5-0)
-    - ReactCommon/turbomodule/bridging (= 0.74.5-0)
-    - ReactCommon/turbomodule/core (= 0.74.5-0)
-  - ReactCommon/turbomodule/bridging (0.74.5-0):
+    - React-callinvoker (= 0.74.3-0)
+    - React-cxxreact (= 0.74.3-0)
+    - React-jsi (= 0.74.3-0)
+    - React-logger (= 0.74.3-0)
+    - React-perflogger (= 0.74.3-0)
+    - ReactCommon/turbomodule/bridging (= 0.74.3-0)
+    - ReactCommon/turbomodule/core (= 0.74.3-0)
+  - ReactCommon/turbomodule/bridging (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.5-0)
-    - React-cxxreact (= 0.74.5-0)
-    - React-jsi (= 0.74.5-0)
-    - React-logger (= 0.74.5-0)
-    - React-perflogger (= 0.74.5-0)
-  - ReactCommon/turbomodule/core (0.74.5-0):
+    - React-callinvoker (= 0.74.3-0)
+    - React-cxxreact (= 0.74.3-0)
+    - React-jsi (= 0.74.3-0)
+    - React-logger (= 0.74.3-0)
+    - React-perflogger (= 0.74.3-0)
+  - ReactCommon/turbomodule/core (0.74.3-0):
     - DoubleConversion
     - fmt (= 9.1.0)
     - glog
     - hermes-engine
     - RCT-Folly (= 2024.01.01.00)
-    - React-callinvoker (= 0.74.5-0)
-    - React-cxxreact (= 0.74.5-0)
-    - React-debug (= 0.74.5-0)
-    - React-jsi (= 0.74.5-0)
-    - React-logger (= 0.74.5-0)
-    - React-perflogger (= 0.74.5-0)
-    - React-utils (= 0.74.5-0)
-  - ScreenshotManager (0.74.87):
+    - React-callinvoker (= 0.74.3-0)
+    - React-cxxreact (= 0.74.3-0)
+    - React-debug (= 0.74.3-0)
+    - React-jsi (= 0.74.3-0)
+    - React-logger (= 0.74.3-0)
+    - React-perflogger (= 0.74.3-0)
+    - React-utils (= 0.74.3-0)
+  - ScreenshotManager (0.74.85):
     - DoubleConversion
     - glog
     - hermes-engine
@@ -1440,65 +1440,65 @@ EXTERNAL SOURCES:
 SPEC CHECKSUMS:
   boost: 88202336c3ba1e7a264a83c0c888784b0f360c28
   DoubleConversion: 00143ab27d470b28035933623e1a3ea37e68889c
-  FBLazyVector: a3df5e0e93ad03f65526deee8647cbfd9eea095f
+  FBLazyVector: efebcbe4c5aee297390c37084326b8b06b1648a7
   fmt: 1568fa7b2f242362c45c42d4a15e9dd4b2e621b3
   glog: 5941fa5836fea300e249178dd5a75c96e0207bb9
-  hermes-engine: f344cfa62a1c446c55649bd734e7dd3be23d18bc
-  MyNativeView: 1cd60c7b928ff04620cb1330580d148202a7901e
-  NativeCxxModuleExample: f940a878ca982eb48676c0dd0888b158c6a7d954
+  hermes-engine: fdb92d647326e1a9f1a9ffedb340bfec04a21475
+  MyNativeView: 8398cfa69a5aa33a3e8a1b110b6db5bc445748a7
+  NativeCxxModuleExample: 9f704759a218b5beb2ed19f764ab6d233459996e
   OCMock: 300b1b1b9155cb6378660b981c2557448830bdc6
   RCT-Folly: b54b39c7532acfa0216d988bdeb706883e71416e
-  RCTDeprecation: 83e9728446042462a2c6ae65acd436a8fa1e509d
-  RCTRequired: 33588674977a47c3605698ecf2880504aa439097
-  RCTTypeSafety: 3943c78fc40e684a8ad635565ac116a59a3118b7
-  React: fae3784df668d10c62fefe37fe1da4b5acb01739
-  React-callinvoker: 2d3ca4381b6c6018ed6cf727f52c376a4c48b392
-  React-Codegen: 0fa35e7d12e3d48ae4e5f4397cbaed7b13a5bf8b
-  React-Core: ee5e87b028fec71d4aed7302e762f440018e2a94
-  React-CoreModules: 86f34311827188b1fa8e9e70ba3674daefaed82b
-  React-cxxreact: 60793d385cb9f340cdf599aacbba2dd132f795d0
-  React-debug: a1ddbe1f74eb8ef9846cd3f1ff547edf8d56f039
-  React-Fabric: 8bc427f0061846caf0fd2b6cd771d14262df70f9
-  React-FabricImage: cbe812e9bfd5869dd28cb60ec361f84ab5123779
-  React-featureflags: 9ec0386f9a87b398a3211195f7f65e6b4129e883
-  React-graphics: 662c9c7b7f11686d229d25f343e7bb9f50d6ddd3
-  React-hermes: 9f77384c4ca8782c27ef1d9befdee9ed43895d74
-  React-ImageManager: 116b4848ed7718b619ebed65f913df5dea9da46f
-  React-jserrorhandler: f171c4f84cdb758d6ef6b5ecb388f5f4feeedb42
-  React-jsi: 1654a8d64b08c81b0601e7a25cfdc1962ac2f4dd
-  React-jsiexecutor: 95ca4d9069db3f2d99f5089e38c99aed726c83f6
-  React-jsinspector: fd86201bfff8493aac7368b87ff1e054f8d95ba7
-  React-jsitracing: e85fa8f607d38c6a3e169f5785777812289beba4
-  React-logger: c0654977aab00b4a39279fa4f9514ac9f7f5fa66
-  React-Mapbuffer: 25578953b1a52c45a875fe1a3a4dbd6ad3cbfc37
-  React-nativeconfig: 5d3d749a2fefcdb71a9d2d839078aaeb73a9ed57
-  React-NativeModulesApple: 9f6e0609c724b374263553607d5d90fdc177f875
-  React-perflogger: dc7aac6511117fb94a24d337114f165fd0df5602
-  React-RCTActionSheet: 7ed0b9a4b92a0949810f7bbbc3db2138321098e2
-  React-RCTAnimation: d7ec6371b1e08de51432c13fcdee5a1e16e8eeac
-  React-RCTAppDelegate: dac87ff9d1022871a2d7d2fc600cf4ed638a6262
-  React-RCTBlob: 89f4409d954ceb839d8ecc34c99c0a954e9d1ce4
-  React-RCTFabric: 7a470ca597759e14c885dc04a27a1951cad61367
-  React-RCTImage: 27f100e1a6a9f5b601fb1982617b8274f5cb921d
-  React-RCTLinking: 5bac4f926af49c605a2f0931f49c9fcdf8021d93
-  React-RCTNetwork: 16a1ec6208e36ae0166224c30f610522d96cfdde
-  React-RCTPushNotification: 2e26dea1514dd59f7338127e9275b3de033819cd
-  React-RCTSettings: 318c37f264ce65d6031d32a846b190c61cf9c81d
-  React-RCTTest: 0272fa9118baa257a46ec00c19f91dc1ba927d50
-  React-RCTText: 977ea327b3bf2be6599a516e76c538045a14cbb9
-  React-rendererdebug: 716efb6d02f34316f1bd2458f4aaf2646656ed39
-  React-rncore: 20ab18903a607eb08612ee72b663f8fbfbde2fbb
-  React-RuntimeApple: 691c8edde215c064e2f5924e80eb55e5b2159164
-  React-RuntimeCore: 2542d0c05e577cb571b150b6e653653d87ac3e68
-  React-runtimeexecutor: 50d003e35f94a6a8556d13f11c160bf4cd287ac4
-  React-RuntimeHermes: fe6cbfb3e26028b822c1f4499407c72ab85d96e1
-  React-runtimescheduler: 8b6df7507ef57e43698e07c17f2f640a551c7744
-  React-utils: 0722628556f07211936d98debee53d0df33227c1
-  ReactCommon: 1a11abd52b3c972770d105a523cbbbcc2ca678f9
-  ReactCommon-Samples: d4bf326f2b52f2e9227261ef2b4bb2cfcfd76b27
-  ScreenshotManager: 702c67f5583d7e29a1c0434904ccd620bc7c55ae
+  RCTDeprecation: f7b846bce4154b856ab90894ad4c16bcf663f0de
+  RCTRequired: 8a5f633665b5cbd4db30d96f9e65ab5d5efa08b6
+  RCTTypeSafety: 3125b2fcf10730b0901159e146a193ab4d655fd4
+  React: b6699168a1afd324c9ad59c99512a846d02ce2c9
+  React-callinvoker: 6a7b3db9bd97524d1a260c3764889154643f28ee
+  React-Codegen: 2d33e67eae0de6bca61002791c6aea98029384c2
+  React-Core: feed612e1c16bbb39f50223bc31329d3c783f6ac
+  React-CoreModules: ec7bfac20d3ba81783018f8f082b9e3662585363
+  React-cxxreact: 183e1c5d081bbdd8beda65ca610463fb0b23ffc7
+  React-debug: d349089d7d26fcb0ea5a2bdfbfc30b6f86868905
+  React-Fabric: 1090f7bea5445fa46bb081a66a42d9acdce8d733
+  React-FabricImage: 99f116b0e3f6dc491d5cbbc1817b68a026611bd1
+  React-featureflags: 411d48be9dff9ca265c8e34f243fa8830832e42d
+  React-graphics: c7c501a3de2906856a1e0af2231d092ba0b50b0f
+  React-hermes: f196cb018f03a2325a59092fc6fee278af567d1f
+  React-ImageManager: 1b132f98fab1ad9da129c6f3cb812ca25c979d41
+  React-jserrorhandler: 697a876182f33777ed41096d1b69c239cecb57be
+  React-jsi: 0003db80d35cf084cb0014dc5850efb5dd8ad979
+  React-jsiexecutor: eae10252ff1592632054629d62a9554bd164fbe5
+  React-jsinspector: 43ea35a80ce22c4cec7bfc818dca2a555000fe4a
+  React-jsitracing: 574a2fab47b3fe3d031b3676cfde464628d40984
+  React-logger: 19894e59913bfbd7b2f2f5fc2d9d6cc19790c211
+  React-Mapbuffer: 231bc59e70c8a09acdd1c61791b2e4fd2c482abc
+  React-nativeconfig: 16f4b40e276f81eab5fd09a71d3fe94d63dd94c7
+  React-NativeModulesApple: 94835bd3120c1e57e2ce9bd3d903d311468bb767
+  React-perflogger: 29778d3d7b87e51b517834b2e836a4d8fbae4ece
+  React-RCTActionSheet: 1f27f6e1f6c429c3ef17c991b89f6b8a45916e00
+  React-RCTAnimation: 7419aac16be2064d66b08bf6df10e73970c7fa97
+  React-RCTAppDelegate: 12d632d558f835e441145bceb652e4314d9454fc
+  React-RCTBlob: 378fd8abb657cf8797f2fe85aec85ef2d9e13b51
+  React-RCTFabric: 8f225e29abe7334641aaa657d77d260151640c12
+  React-RCTImage: c1a14d8366a617de9dce9a71baa0cbb9832ed3b0
+  React-RCTLinking: 3bc59251b9012c69817656a0f951f48f0fdc9fa4
+  React-RCTNetwork: e2e86c8c2afa1a1990aa5de8f74958e1e27c177d
+  React-RCTPushNotification: 13e8d5f9e32285560b44946cb21e9ff12208e3cf
+  React-RCTSettings: ff964d2e79583710f4b0de39771f3651bb19c693
+  React-RCTTest: 72bfea58494c62984a99a8e4b060131287570b32
+  React-RCTText: a77677e03ff6dc32ba7cba3b52205ca8e6f45553
+  React-rendererdebug: 6e5ef9313a3f9652a134d0ace6334d97aabcaf29
+  React-rncore: fb844f5276144e40f3863d3c752b9651d93e64c4
+  React-RuntimeApple: 2213c97fbb84ae6c880cbcd1f368d16b307477ce
+  React-RuntimeCore: f9587350021c1e3acea14d88397331f41f714de8
+  React-runtimeexecutor: 98a1483bf4dbc57e2bc4197cbda6be7c7182d5b9
+  React-RuntimeHermes: 9270e94bcbba051e8f5b22a9f409bddea1a8ae12
+  React-runtimescheduler: 57136aa718e5851ad3a8a7c85fd3b560928eeb13
+  React-utils: c81447161a12c311f08d31607889180371231a55
+  ReactCommon: 55ec5949191f314403e61ced6d5bb0798d493585
+  ReactCommon-Samples: 0cd7c41f1d3f42c640be3ba2608ada3c3a08e249
+  ScreenshotManager: 76aaf7b872963e4bcf6595d28de46f2d7e9f483c
   SocketRocket: abac6f5de4d4d62d24e11868d7a2f427e0ef940d
-  Yoga: 69701a97cb6d539d522352f92334fa2b383f559c
+  Yoga: 67339ae9c4da2254f6ac2b73ac266332c5962ce0
 
 PODFILE CHECKSUM: 13ecd40d4b3f8802df1b52487c2663a1677f35d5
 

--- a/packages/rn-tester/RNTester/Info.plist
+++ b/packages/rn-tester/RNTester/Info.plist
@@ -61,5 +61,7 @@
 	</array>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
 </dict>
 </plist>

--- a/packages/rn-tester/js/components/RNTTitleBar.js
+++ b/packages/rn-tester/js/components/RNTTitleBar.js
@@ -43,7 +43,7 @@ const HeaderIOS = ({
             <RNTesterDocumentationURL documentationURL={documentationURL} />
           )}
         </View>
-        {onBack != null && (
+        {!Platform.isTV && onBack != null && (
           <View>
             <Button
               title="Back"


### PR DESCRIPTION
## Summary:

Minor fixes have been made to the RNTester app for tvOS. These changes do not affect Android TV.

## Changelog:

[FIXED] - Missing LaunchScreen on RNTester for tvOS
[FIXED] - Mobile back button should not be shown in tvOS Navigation Bar.
[FIXED] - Wrong Hermes version reference from Podfile.lock file
