### PR TITLE
fix(iOS): Fix focus guide autofocus for Apple TV in Fabric

### DIFF
--- a/packages/react-native/Libraries/Components/TV/TVViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/TV/TVViewPropTypes.js
@@ -83,6 +83,6 @@ export type TVViewProps = $ReadOnly<{|
    */
   destinations?: ?(Object[]),
   enabled?: boolean,
-  autofocus?: boolean,
+  autoFocus?: boolean,
   safePadding?: string | null,
 |}>;

--- a/packages/react-native/Libraries/NativeComponent/TVViewConfig.js
+++ b/packages/react-native/Libraries/NativeComponent/TVViewConfig.js
@@ -5,7 +5,7 @@ export const validAttributesForTVProps = {
   tvParallaxProperties: true,
   destinations: true,
   enabled: true,
-  autofocus: true,
+  autoFocus: true,
   safePadding: true,
   focusable: true,
   nextFocusDown: true,

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -62,13 +62,13 @@ BaseViewProps::BaseViewProps(
           rawProps,
           "isTVSelectable",
           sourceProps.isTVSelectable,
-          (Boolean) false)),
+          false)),
       hasTVPreferredFocus(CoreFeatures::enablePropIteratorSetter ? sourceProps.hasTVPreferredFocus : convertRawProp(
           context,
           rawProps,
           "hasTVPreferredFocus",
           sourceProps.hasTVPreferredFocus,
-          (Boolean) false)),
+          false)),
       tvParallaxProperties(CoreFeatures::enablePropIteratorSetter ? sourceProps.tvParallaxProperties : convertRawProp(
           context,
           rawProps,
@@ -104,7 +104,7 @@ BaseViewProps::BaseViewProps(
           rawProps,
           "autoFocus",
           sourceProps.autoFocus,
-          (Boolean) false)),
+          false)),
       trapFocusUp(CoreFeatures::enablePropIteratorSetter ? sourceProps.trapFocusUp : convertRawProp(
           context,
           rawProps,


### PR DESCRIPTION
## Summary:

Fix typos in prop types that were breaking autofocus on Apple TV when Fabric (bridgeless) was enabled.

Fixes #718

## Changelog:

[iOS][Fixed] Enable TVFocusGuideView autoFocus in Fabric for Apple TV

## Test Plan:

RNTester TVFocusGuideView autoFocus test should work.