### PR TITLE
[docs] Update README for 0.75

### DIFF
--- a/README-core.md
+++ b/README-core.md
@@ -50,7 +50,7 @@ React Native brings [**React**'s][r] declarative UI framework to iOS and Android
 
 React Native is developed and supported by many companies and individual core contributors. Find out more in our [ecosystem overview][e].
 
-[r]: https://reactjs.org/
+[r]: https://react.dev/
 [p]: https://reactnative.dev/docs/out-of-tree-platforms
 [e]: https://github.com/facebook/react-native/blob/HEAD/ECOSYSTEM.md
 
@@ -67,7 +67,7 @@ React Native is developed and supported by many companies and individual core co
 
 ## 📋 Requirements
 
-React Native apps may target iOS 12.4 and Android 5.0 (API 21) or newer. You may use Windows, macOS, or Linux as your development operating system, though building and running iOS apps is limited to macOS. Tools like [Expo](https://expo.dev) can be used to work around this.
+React Native apps may target iOS 13.4 and Android 6.0 (API 23) or newer. You may use Windows, macOS, or Linux as your development operating system, though building and running iOS apps is limited to macOS. Tools like [Expo](https://expo.dev) can be used to work around this.
 
 ## 🎉 Building your first React Native app
 
@@ -90,7 +90,7 @@ The React Native documentation discusses components, APIs, and topics that are s
 The source for the React Native documentation and website is hosted on a separate repo, [**@facebook/react-native-website**][repo-website].
 
 [docs]: https://reactnative.dev/docs/getting-started
-[r-docs]: https://reactjs.org/docs/getting-started.html
+[r-docs]: https://react.dev/learn
 [repo-website]: https://github.com/facebook/react-native-website
 
 ## 🚀 Upgrading
@@ -143,5 +143,5 @@ React Native is MIT licensed, as found in the [LICENSE][l] file.
 
 React Native documentation is Creative Commons licensed, as found in the [LICENSE-docs][ld] file.
 
-[l]: https://github.com/facebook/react-native/blob/HEAD/LICENSE
-[ld]: https://github.com/facebook/react-native/blob/HEAD/LICENSE-docs
+[l]: https://github.com/facebook/react-native/blob/main/LICENSE
+[ld]: https://github.com/facebook/react-native/blob/main/LICENSE-docs

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Apple TV and Android TV support for React Native are maintained here and in the corresponding `react-native-tvos` NPM package, and not in the [core repo](https://github.com/facebook/react-native/).  This is a full fork of the main repository, with only the changes needed to support Apple TV and Android TV.
 
-Releases of `react-native-tvos` will be based on a public release of `react-native`; e.g. the 0.74.0-0 release of this package will be derived from the 0.74.0 release of `react-native`. All releases of this repo will follow the 0.xx.x-y format, where x digits are from a specific RN core release, and y represents the additional versioning from this repo.
+Releases of `react-native-tvos` will be based on a public release of `react-native`; e.g. the 0.75.2-0 release of this package will be derived from the 0.75.0 release of `react-native`. All releases of this repo will follow the 0.xx.x-y format, where x digits are from a specific RN core release, and y represents the additional versioning from this repo.
 
 Releases will be published on npmjs.org and you may find the latest release version here: https://www.npmjs.com/package/react-native-tvos?activeTab=versions or use the tag `@latest`
 
@@ -27,12 +27,10 @@ As of the 0.71 release, Hermes is fully working on both Apple TV and Android TV,
 
 ### React Native new architecture (Fabric) support
 
-- _Apple TV_: Modify your app's Podfile to set the `:fabric_enabled` value to `true` in both iOS and tvOS targets. After that, run `pod install` to pick up the additional pods needed for the new architecture. Some components (TVTextScrollView, TabBarIOS) have not been reimplemented in the new architecture so they will show up as an "unimplemented component".
+- _Apple TV_: Modify your app's Podfile to set the `:fabric_enabled` value to `true` in both iOS and tvOS targets. After that, run `pod install` to pick up the additional pods needed for the new architecture. Components that have not been reimplemented in the new architecture will show up as an "unimplemented component".
 - _Android TV_: To enable Fabric, modify `android/gradle.properties` in your app and set `newArchEnabled=true`, then rebuild your app.
 
-As of the 0.74 release, bridgeless is the default when Fabric is enabled.
-
-Known issue: The `TVFocusGuide` `autofocus` API has problems on Apple TV when bridgeless is enabled. If you need to use Fabric without bridgeless on Apple TV, you can override the default by adding the method below in `AppDelegate.mm`:
+As of the 0.74 release, bridgeless is the default when Fabric is enabled. If you need to use Fabric without bridgeless on Apple TV, you can override the default by adding the method below in `AppDelegate.mm`:
 
 ```objc
 - (BOOL)bridgelessEnabled
@@ -63,32 +61,78 @@ Minimum operating system versions:
 - _Native layer for Apple TV_: React Native Xcode projects all now have Apple TV build targets, with names ending in the string '-tvOS'.  Changes in the React Native podspecs in 0.73 now require that your application `Podfile` only have one target. This repo supports either an iOS target or a tvOS target, but both targets should not be active at the same time. The new app template now has the iOS target commented out.
 - _Maven artifacts for Android TV_: In 0.71 and later releases, the React Native Android prebuilt archives are published to Maven instead of being included in the NPM. We are following the same model, except that the Maven artifacts will be in group `io.github.react-native-tvos` instead of `com.facebook.react`. The `@react-native/gradle-plugin` module has been upgraded so that the Android dependencies will be detected correctly during build.
 
-## _(New)_ Project creation using the Expo CLI
+## _(New)_ TV project creation in React Native 0.75 and later
 
-> _Pitfall:_ Make sure you do not globally install `react-native` or `react-native-tvos`. If you have done this the wrong way, you may get error messages like `ld: library not found for -lPods-TestApp-tvOS`.
+> _Warning:_ Make sure you do not globally install `react-native` or `react-native-tvos`. If you have done this the wrong way, you may get error messages like `ld: library not found for -lPods-TestApp-tvOS`.
 
 We strongly recommend [Yarn](https://classic.yarnpkg.com/en/docs/install) as the package manager.
-You should install `yarn` globally, as it should be used instead of `npm` for working in React Native projects.
 
-To create a new project, use `yarn create react-native-app` as shown below. (This will install the Expo tool `create-react-native-app` for you if it is not already present.)
+### Using the Expo SDK with TV apps
 
-New projects created this way will automatically have properly configured iPhone and Apple TV targets created in their XCode projects, and will have the Android manifest correctly configured for both Android phone and Android TV.  New projects are set up to use the Expo CLI; the Expo dependency and `react-native.config.js` are included in the new app template.
+As of React Native version 0.75.x, the core team [recommends Expo for new projects](https://reactnative.dev/docs/environment-setup).
+
+See the [Building Expo apps for TV](https://docs.expo.dev/guides/building-for-tv/) guide from Expo for details on how to set up a new Expo project, including supported Expo modules and limitations.
+
+Using Expo's [continuous native generation (CNG)](https://docs.expo.dev/workflow/continuous-native-generation/) model, projects created this way can be used to build either mobile or TV apps, taking advantage of the full support for both mobile and TV platforms in this repo.
+
+## Project creation using the React Native Community CLI
+
+As of React Native 0.75.x, the template that used to reside in the `react-native` core package has been moved to a [new community repo](https://github.com/react-native-community/template) and will be maintained there. To support developers that wish to continue using the community CLI, we have created a [new TV template repository](https://github.com/react-native-tvos/template-tv) and will maintain a TV port of this template.
+
+> _Note:_ The new TV template will only build apps for Apple TV and Android TV. Multiple platform targets are no longer supported in React Native app Podfiles.
+
+To create a new project:
 
 ```sh
-# Init an app called 'TestApp', note that you must not be in a node module (directory with node_modules sub-directory) for this to work
-yarn create react-native-app TestApp --template https://github.com/react-native-tvos/react-native-template-typescript-tv/tree/tv-release-0.73.0 --template-path template
-cd TestApp
+# 
+# Init an app called 'TVTest', note that you must not be in a node module (directory with node_modules sub-directory) for this to work
+$ npx @react-native-community/cli@latest init TVTest --template @react-native-tvos/template-tv
+                                                          
+               ######                ######               
+             ###     ####        ####     ###             
+            ##          ###    ###          ##            
+            ##             ####             ##            
+            ##             ####             ##            
+            ##           ##    ##           ##            
+            ##         ###      ###         ##            
+             ##  ########################  ##             
+          ######    ###            ###    ######          
+      ###     ##    ##              ##    ##     ###      
+   ###         ## ###      ####      ### ##         ###   
+  ##           ####      ########      ####           ##  
+ ##             ###     ##########     ###             ## 
+  ##           ####      ########      ####           ##  
+   ###         ## ###      ####      ### ##         ###   
+      ###     ##    ##              ##    ##     ###      
+          ######    ###            ###    ######          
+             ##  ########################  ##             
+            ##         ###      ###         ##            
+            ##           ##    ##           ##            
+            ##             ####             ##            
+            ##             ####             ##            
+            ##          ###    ###          ##            
+             ###     ####        ####     ###             
+               ######                ######               
+                                                          
+
+              Welcome to React Native 0.75.2!                
+                 Learn once, write anywhere               
+
+✔ Downloading template
+✔ Copying template
+✔ Processing template
+✔ Installing dependencies
+✔ Do you want to install CocoaPods now? Only needed if you run your project in Xcode directly … yes
+✔ Installing Ruby Gems
+✔ Installing CocoaPods dependencies  (this may take a few minutes)
+.
+.
+.
+$ cd TVTest
 # Now build and start the app in the tvOS Simulator - this will only work on a macOS machine.
-# This command can also be run via "yarn tvos".
-npx expo run:ios --scheme MyApp-tvOS --device "Apple TV"
-# You can also build and start the app on an iOS phone simulator.
-# This command can also be run via "yarn ios".
-npx expo run:ios
-# or specify a simulator:
-npx expo run:ios --scheme MyApp --device "iPhone 15"
-# This command builds and starts the app in an Android TV emulator or a phone emulator (needs to be created in advance).
-# This command can also be run via "yarn android".
-npx expo run:android --device tv_api_31
+npx react-native run-ios --simulator "Apple TV"
+# This command builds and starts the app in an Android TV emulator (needs to be created in advance).
+npx react-native run:android --device tv_api_31
 ```
 
 See [this document](https://docs.expo.dev/bare/using-expo-cli/) for more details on Expo CLI functionality. (Note that many of these features require that Expo SDK modules be built into your app. Expo SDK support requires a different project configuration as described below.)
@@ -172,11 +216,10 @@ const TVEventHandlerView: () => React.Node = () => {
 // Class based component
 
 class Game2048 extends React.Component {
-  _tvEventHandler: any;
+  _tvEventHandlerSubscription: any;
 
   _enableTVEventHandler() {
-    this._tvEventHandler = new TVEventHandler();
-    this._tvEventHandler.enable(this, function(cmp, evt) {
+    this._tvEventHandlerSubscription = TVEventHandler.addListener(function(evt) {
       if (evt && evt.eventType === 'right') {
         cmp.setState({board: cmp.state.board.move(2)});
       } else if(evt && evt.eventType === 'up') {
@@ -192,9 +235,9 @@ class Game2048 extends React.Component {
   }
 
   _disableTVEventHandler() {
-    if (this._tvEventHandler) {
-      this._tvEventHandler.disable();
-      delete this._tvEventHandler;
+    if (this._tvEventHandlerSubscription) {
+      this._tvEventHandlerSubscription.remove();
+      delete this._tvEventHandlerSubscription;
     }
   }
 
@@ -239,11 +282,9 @@ class Game2048 extends React.Component {
   
   - _TVTextScrollView_: On Apple TV, a ScrollView will not scroll unless there are focusable items inside it or above/below it.  This component wraps ScrollView and uses tvOS-specific native code to allow scrolling using swipe gestures from the remote control.
 
-- VirtualizedList: We extend `VirtualizedList` to make virtualization work well with focus management in mind. All of the improvements that we made are automatically available to all the VirtualizedList based components such as `FlatList`.
-  - Defaults
-    - VirtualizeList contents are automatically wrapped with a `TVFocusGuideView` with `trapFocus*` properties enabled depending on the orientation of the list. This default makes sure that focus doesn't leave the list accidentally due to a virtualization issue etc. until reaching the beginning or the end of the list.
-
-  New Props:
+  - _VirtualizedList_: We extend `VirtualizedList` to make virtualization work well with focus management in mind. All of the improvements that we made are automatically available to all the VirtualizedList based components such as `FlatList`.
+    - Defaults: VirtualizeList contents are automatically wrapped with a `TVFocusGuideView` with `trapFocus*` properties enabled depending on the orientation of the list. This default makes sure that focus doesn't leave the list accidentally due to a virtualization issue etc. until reaching the beginning or the end of the list.
+    - New Props:
 
   | Prop | Value | Description | 
   |---|---|---|

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ const TVEventHandlerView: () => React.Node = () => {
 // Class based component
 
 class Game2048 extends React.Component {
-  _tvEventHandlerSubscription: any;
+  _tvEventHandlerSubscription: EventSubscription || undefined;
 
   _enableTVEventHandler() {
     this._tvEventHandlerSubscription = TVEventHandler.addListener(function(evt) {


### PR DESCRIPTION
- Merge 0.75 changes from the core repo into `README-core.md`
- Changes to the TV `README.md`:
  - Recommend Expo for new projects
  - `create-react-native-app` section removed (no longer supported)
  - New section on creating a new project with the new TV template (derived from the [community template](https://github.com/react-native-community/template))
  - Remove outdated text
  - Update example on using `TVEventHandler` directly in a class-based component