### PR TITLE
fix(#786): 0.73 - Stack overflow fix for Fire TV/ AndroidTV Touch Enabled de…

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -472,4 +472,5 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
     public void trapFocusRight(ReactViewGroup view, boolean enabled) {
     view.setTrapFocusRight(enabled);
   }
+
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.java
@@ -81,6 +81,14 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
   @ReactProp(name = "accessible")
   public void setAccessible(ReactViewGroup view, boolean accessible) {
     view.setFocusable(accessible);
+    // This is required to handle Android TV/ Fire TV Devices that are Touch Enabled as well as LeanBack
+    // https://developer.android.com/reference/android/view/View#requestFocus(int,%20android.graphics.Rect)
+    // ** A view will not actually take focus if it is not focusable (isFocusable() returns false), **
+    // ** or if it is focusable and it is not focusable in touch mode (isFocusableInTouchMode()) **
+    // ** while the device is in touch mode.  **
+    if (hasTouchScreen(view.getContext())) {
+      view.setFocusableInTouchMode(accessible);
+    }
   }
 
   @ReactProp(name = "hasTVPreferredFocus")
@@ -432,6 +440,14 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
     root.setFocusDestinations(fd);
   }
 
+  /**
+   * Utility function to help capture Android TV/ Fire TV Devices with Touch Support
+   */
+  private boolean hasTouchScreen(Context context) {
+    PackageManager pm = context.getPackageManager();
+    return pm.hasSystemFeature(PackageManager.FEATURE_TOUCHSCREEN);
+  }
+
   @ReactProp(name = "autoFocus")
   public void setAutoFocusTV(ReactViewGroup view, boolean autoFocus) {
     view.setAutoFocusTV(autoFocus);
@@ -456,5 +472,4 @@ public class ReactViewManager extends ReactClippingViewManager<ReactViewGroup> {
     public void trapFocusRight(ReactViewGroup view, boolean enabled) {
     view.setTrapFocusRight(enabled);
   }
-
 }


### PR DESCRIPTION
Provided fix that ensures when a touch enabled TV device requests focus on a touchable component we ensure both isFocusable and isFocusableInTouchMode are both set to the value of accessible. This ensures we dont enter an infinite loop if trying to request focus on something that focusable.