### PR TITLE
feat: Add NativeWind support to Pressable

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.js
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.js
@@ -408,12 +408,17 @@ function Pressable(
       // $FlowFixMe[prop-missing]
       if (evt.eventType === 'select') {
         // $FlowFixMe[incompatible-exact]
+        onPressIn(evt);
         onPress && onPress(evt);
+        setTimeout(() => {
+          onPressOut(evt)
+        }, unstable_pressDelay ?? 100);
       }
       // $FlowFixMe[prop-missing]
       if (evt.eventType === 'longSelect') {
         // $FlowFixMe[incompatible-exact]
-        onLongPress && onLongPress(evt);
+        evt.eventKeyAction === 0 ? onPressIn(evt) : onPressOut(evt);
+        // onLongPress && onLongPress(evt);
       }
     },
     [


### PR DESCRIPTION
TV controls such as `Touchable*` and `Pressable` already support the `focus:` NativeWind style modifier. This change allows `Pressable` to support the `active:` NativeWind style modifier on TV.

See https://www.nativewind.dev/v4/core-concepts/states#hover-focus-and-active-

(This does not add `active:` support for the `Touchable*` components.)