### PR TITLE
fix: issue with onPressIn and Android ripple

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
+++ b/packages/react-native/Libraries/Components/Pressable/useAndroidRippleForView.js
@@ -80,8 +80,8 @@ export default function useAndroidRippleForView(
           if (view != null) {
             Commands.hotspotUpdate(
               view,
-              event.nativeEvent.locationX ?? 0,
-              event.nativeEvent.locationY ?? 0,
+              event.nativeEvent?.locationX ?? 0,
+              event.nativeEvent?.locationY ?? 0,
             );
             Commands.setPressed(view, true);
           }
@@ -91,8 +91,8 @@ export default function useAndroidRippleForView(
           if (view != null) {
             Commands.hotspotUpdate(
               view,
-              event.nativeEvent.locationX ?? 0,
-              event.nativeEvent.locationY ?? 0,
+              event.nativeEvent?.locationX ?? 0,
+              event.nativeEvent?.locationY ?? 0,
             );
           }
         },


### PR DESCRIPTION
Fixes an issue where `onPressIn` and `onPressOut` may not have `nativeEvent` properties.