### PR TITLE
chore: Refactor Touchables to use Pressability for TV

### DIFF
--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -209,7 +209,7 @@ class TouchableHighlight extends React.Component<Props, State> {
         if (this._hideTimeout != null) {
           clearTimeout(this._hideTimeout);
         }
-        if (!Platform.isTV) {
+        if (event.nativeEvent) {
           this._showUnderlay();
           this._hideTimeout = setTimeout(() => {
             this._hideUnderlay();
@@ -220,7 +220,7 @@ class TouchableHighlight extends React.Component<Props, State> {
         }
       },
       onPressIn: event => {
-        if (!Platform.isTV) {
+        if (event.nativeEvent) {
           if (this._hideTimeout != null) {
             clearTimeout(this._hideTimeout);
             this._hideTimeout = null;
@@ -232,7 +232,7 @@ class TouchableHighlight extends React.Component<Props, State> {
         }
       },
       onPressOut: event => {
-        if (!Platform.isTV) {
+        if (event.nativeEvent) {
           if (this._hideTimeout == null) {
             this._hideUnderlay();
           }

--- a/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableHighlight.js
@@ -220,18 +220,22 @@ class TouchableHighlight extends React.Component<Props, State> {
         }
       },
       onPressIn: event => {
-        if (this._hideTimeout != null) {
-          clearTimeout(this._hideTimeout);
-          this._hideTimeout = null;
+        if (!Platform.isTV) {
+          if (this._hideTimeout != null) {
+            clearTimeout(this._hideTimeout);
+            this._hideTimeout = null;
+          }
+          this._showUnderlay();
         }
-        this._showUnderlay();
         if (this.props.onPressIn != null) {
           this.props.onPressIn(event);
         }
       },
       onPressOut: event => {
-        if (this._hideTimeout == null) {
-          this._hideUnderlay();
+        if (!Platform.isTV) {
+          if (this._hideTimeout == null) {
+            this._hideUnderlay();
+          }
         }
         if (this.props.onPressOut != null) {
           this.props.onPressOut(event);
@@ -381,35 +385,7 @@ class TouchableHighlight extends React.Component<Props, State> {
   componentDidMount(): void {
     this._isMounted = true;
     if (Platform.isTV) {
-      this._tvTouchable = new TVTouchable(this, {
-        getDisabled: () => this.props.disabled === true,
-        onBlur: event => {
-          if (Platform.isTV) {
-            this._hideUnderlay();
-          }
-          if (this.props.onBlur != null) {
-            this.props.onBlur(event);
-          }
-        },
-        onFocus: event => {
-          if (Platform.isTV) {
-            this._showUnderlay();
-          }
-          if (this.props.onFocus != null) {
-            this.props.onFocus(event);
-          }
-        },
-        onPress: event => {
-          if (this.props.onPress != null) {
-            this.props.onPress(event);
-          }
-        },
-        onLongPress: event => {
-          if (this.props.onLongPress != null) {
-            this.props.onLongPress(event);
-          }
-        },
-      });
+      this._tvTouchable = new TVTouchable(this, this.state.pressability);
     }
     this.state.pressability.configure(this._createPressabilityConfig());
   }

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -341,32 +341,10 @@ class TouchableNativeFeedback extends React.Component<Props, State> {
   }
 
   componentDidMount(): void {
-    this.state.pressability.configure(this._createPressabilityConfig());
     if (Platform.isTV) {
-      this._tvTouchable = new TVTouchable(this, {
-        getDisabled: () => this.props.disabled === true,
-        onBlur: event => {
-          if (this.props.onBlur != null) {
-            this.props.onBlur(event);
-          }
-        },
-        onFocus: event => {
-          if (this.props.onFocus != null) {
-            this.props.onFocus(event);
-          }
-        },
-        onPress: event => {
-          if (this.props.onPress != null) {
-            this.props.onPress(event);
-          }
-        },
-        onLongPress: event => {
-          if (this.props.onLongPress != null) {
-            this.props.onLongPress(event);
-          }
-        },
-      });
+      this._tvTouchable = new TVTouchable(this, this.state.pressability);
     }
+    this.state.pressability.configure(this._createPressabilityConfig());
   }
 
   componentDidUpdate(prevProps: Props, prevState: State) {

--- a/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableNativeFeedback.js
@@ -185,6 +185,8 @@ class TouchableNativeFeedback extends React.Component<Props, State> {
       android_disableSound: this.props.touchSoundDisabled,
       onLongPress: this.props.onLongPress,
       onPress: this.props.onPress,
+      onFocus: this.props.onFocus,
+      onBlur: this.props.onBlur,
       onPressIn: event => {
         if (Platform.OS === 'android') {
           this._dispatchHotspotUpdate(event);
@@ -226,7 +228,8 @@ class TouchableNativeFeedback extends React.Component<Props, State> {
 
   _dispatchHotspotUpdate(event: PressEvent): void {
     if (Platform.OS === 'android') {
-      const {locationX, locationY} = event.nativeEvent;
+      const locationX = event.nativeEvent?.locationX ?? 0;
+      const locationY = event.nativeEvent?.locationY ?? 0;
       const hostComponentRef = findHostInstance_DEPRECATED(this);
       if (hostComponentRef == null) {
         console.warn(
@@ -234,11 +237,7 @@ class TouchableNativeFeedback extends React.Component<Props, State> {
             'Has your Touchable component been unmounted?',
         );
       } else {
-        Commands.hotspotUpdate(
-          hostComponentRef,
-          locationX ?? 0,
-          locationY ?? 0,
-        );
+        Commands.hotspotUpdate(hostComponentRef, locationX, locationY);
       }
     }
   }

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -175,17 +175,21 @@ class TouchableOpacity extends React.Component<Props, State> {
       onLongPress: this.props.onLongPress,
       onPress: this.props.onPress,
       onPressIn: event => {
-        this._opacityActive(
-          event.dispatchConfig.registrationName === 'onResponderGrant'
-            ? 0
-            : 150,
-        );
+        if (!Platform.isTV) {
+          this._opacityActive(
+            event.dispatchConfig?.registrationName === 'onResponderGrant'
+              ? 0
+              : 150,
+          );
+        }
         if (this.props.onPressIn != null) {
           this.props.onPressIn(event);
         }
       },
       onPressOut: event => {
-        this._opacityInactive(250);
+        if (!Platform.isTV) {
+          this._opacityInactive(250);
+        }
         if (this.props.onPressOut != null) {
           this.props.onPressOut(event);
         }
@@ -315,31 +319,7 @@ class TouchableOpacity extends React.Component<Props, State> {
 
   componentDidMount(): void {
     if (Platform.isTV) {
-      this._tvTouchable = new TVTouchable(this, {
-        getDisabled: () => this.props.disabled === true,
-        onBlur: event => {
-          this._opacityInactive(250);
-          if (this.props.onBlur != null) {
-            this.props.onBlur(event);
-          }
-        },
-        onFocus: event => {
-          this._opacityActive(150);
-          if (this.props.onFocus != null) {
-            this.props.onFocus(event);
-          }
-        },
-        onPress: event => {
-          if (this.props.onPress != null) {
-            this.props.onPress(event);
-          }
-        },
-        onLongPress: event => {
-          if (this.props.onLongPress != null) {
-            this.props.onLongPress(event);
-          }
-        },
-      });
+      this._tvTouchable = new TVTouchable(this, this.state.pressability);
     }
     this.state.pressability.configure(this._createPressabilityConfig());
   }

--- a/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableOpacity.js
@@ -175,7 +175,7 @@ class TouchableOpacity extends React.Component<Props, State> {
       onLongPress: this.props.onLongPress,
       onPress: this.props.onPress,
       onPressIn: event => {
-        if (!Platform.isTV) {
+        if (event.nativeEvent) {
           this._opacityActive(
             event.dispatchConfig?.registrationName === 'onResponderGrant'
               ? 0
@@ -187,7 +187,7 @@ class TouchableOpacity extends React.Component<Props, State> {
         }
       },
       onPressOut: event => {
-        if (!Platform.isTV) {
+        if (event.nativeEvent) {
           this._opacityInactive(250);
         }
         if (this.props.onPressOut != null) {

--- a/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
+++ b/packages/react-native/Libraries/Components/Touchable/TouchableWithoutFeedback.js
@@ -27,7 +27,6 @@ import type {TVParallaxPropertiesType} from '../TV/TVViewPropTypes';
 import View from '../../Components/View/View';
 import {PressabilityDebugView} from '../../Pressability/PressabilityDebug';
 import usePressability from '../../Pressability/usePressability';
-import useTVEventHandler from '../TV/useTVEventHandler';
 import * as React from 'react';
 import {useMemo} from 'react';
 
@@ -201,24 +200,6 @@ module.exports = function TouchableWithoutFeedback(props: Props): React.Node {
   // adopting `Pressability`, so preserve that behavior.
   const {onBlur, onFocus, ...eventHandlersWithoutBlurAndFocus} =
     eventHandlers || {};
-
-  useTVEventHandler(evt => {
-    if (props.disabled === true || props['aria-disabled'] === true) {
-      return;
-    }
-    if (evt.eventType === 'focus') {
-      props.onFocus && props.onFocus(evt);
-    }
-    if (evt.eventType === 'blur') {
-      props.onBlur && props.onBlur(evt);
-    }
-    if (evt.eventType === 'select') {
-      props.onPress && props.onPress(evt);
-    }
-    if (evt.eventType === 'longSelect') {
-      props.onLongPress && props.onLongPress(evt);
-    }
-  });
 
   const elementProps: {[string]: mixed, ...} = {
     ...eventHandlersWithoutBlurAndFocus,

--- a/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
+++ b/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
@@ -103,6 +103,8 @@ const TouchableOpacityButton = (props: {
       style={styles.pressable}
       onFocus={(event: any) => props.log(`${props.title} focus`)}
       onBlur={(event: any) => props.log(`${props.title} blur`)}
+      onPressIn={() => props.log(`${props.title} onPressIn`)}
+      onPressOut={() => props.log(`${props.title} onPressOut`)}
       onPress={(event: any) =>
         props.log(`${props.title} pressed action=${event.eventKeyAction}`)
       }
@@ -123,6 +125,8 @@ const TouchableHighlightButton = (props: {
       style={styles.pressable}
       onFocus={event => props.log(`${props.title} focus`)}
       onBlur={event => props.log(`${props.title} blur`)}
+      onPressIn={() => props.log(`${props.title} onPressIn`)}
+      onPressOut={() => props.log(`${props.title} onPressOut`)}
       onPress={(event: any) =>
         props.log(`${props.title} pressed action=${event.eventKeyAction}`)
       }


### PR DESCRIPTION
Simplify `Touchable` components so that TV event handling all happens in the `Pressability` event handlers.

- `TouchableBounce` is omitted, since it is no longer exported in RN
- `TouchableWithoutFeedback` is omitted, and the TV event handler there is removed since it does not support focus/blur

Added logging for `onPressIn` and `onPressOut` events in the TVEventHandler RNTester example.

For now, we use the presence of the `nativeEvent` property to distinguish between touch events and TV events in the Pressability configs.