### PR TITLE
fix: unset nextFocus guides when prop set to undefined

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -966,6 +966,9 @@ using namespace facebook::react;
       _nextFocusUp = [rootView viewWithTag:newViewProps.nextFocusUp.value()];
       [self enableDirectionalFocusGuides];
     } else {
+      if (self.focusGuideUp != nil) {
+        [[self containingRootView] removeLayoutGuide:self.focusGuideUp];
+      }
       _nextFocusUp = nil;
     }
   }
@@ -976,6 +979,9 @@ using namespace facebook::react;
       _nextFocusDown = [rootView viewWithTag:newViewProps.nextFocusDown.value()];
       [self enableDirectionalFocusGuides];
     } else {
+      if (self.focusGuideDown != nil) {
+        [[self containingRootView] removeLayoutGuide:self.focusGuideDown];
+      }
       _nextFocusDown = nil;
     }
   }
@@ -986,6 +992,9 @@ using namespace facebook::react;
       _nextFocusLeft = [rootView viewWithTag:newViewProps.nextFocusLeft.value()];
       [self enableDirectionalFocusGuides];
     } else {
+      if (self.focusGuideLeft != nil) {
+        [[self containingRootView] removeLayoutGuide:self.focusGuideLeft];
+      }
       _nextFocusLeft = nil;
     }
   }
@@ -996,6 +1005,9 @@ using namespace facebook::react;
       _nextFocusRight = [rootView viewWithTag:newViewProps.nextFocusRight.value()];
       [self enableDirectionalFocusGuides];
     } else {
+      if (self.focusGuideRight != nil) {
+        [[self containingRootView] removeLayoutGuide:self.focusGuideRight];
+      }
       _nextFocusRight = nil;
     }
   }

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -458,23 +458,43 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 }
 
 - (void)setNextFocusUp:(NSNumber *)nextFocusUp {
-  self->_nextFocusUp = [self getViewById: nextFocusUp];
-  [self enableDirectionalFocusGuides];
+  if (self.focusGuideUp != nil && nextFocusUp == nil) {
+    [[self rootView] removeLayoutGuide:self.focusGuideUp];
+    self.focusGuideUp = nil;
+  } else {
+    self->_nextFocusUp = [self getViewById: nextFocusUp];
+    [self enableDirectionalFocusGuides];
+  }
 }
 
 - (void)setNextFocusDown:(NSNumber *)nextFocusDown {
-  self->_nextFocusDown = [self getViewById: nextFocusDown];
-  [self enableDirectionalFocusGuides];
+  if (self.focusGuideDown != nil && nextFocusDown) {
+    [[self rootView] removeLayoutGuide:self.focusGuideDown];
+    self.focusGuideDown = nil;
+  } else {
+    self->_nextFocusDown = [self getViewById: nextFocusDown];
+    [self enableDirectionalFocusGuides];
+  }
 }
 
 - (void)setNextFocusLeft:(NSNumber *)nextFocusLeft {
-  self->_nextFocusLeft = [self getViewById: nextFocusLeft];
-  [self enableDirectionalFocusGuides];
+  if (self.focusGuideLeft != nil && nextFocusLeft == nil) {
+    [[self rootView] removeLayoutGuide:self.focusGuideLeft];
+    self.focusGuideLeft = nil;
+  } else {
+    self->_nextFocusLeft = [self getViewById: nextFocusLeft];
+    [self enableDirectionalFocusGuides];
+  }
 }
 
 - (void)setNextFocusRight:(NSNumber *)nextFocusRight {
-  self->_nextFocusRight = [self getViewById: nextFocusRight];
-  [self enableDirectionalFocusGuides];
+  if (self.focusGuideRight != nil && nextFocusRight) {
+    [[self rootView] removeLayoutGuide:self.focusGuideRight];
+    self.focusGuideRight = nil;
+  } else {
+    self->_nextFocusRight = [self getViewById: nextFocusRight];
+    [self enableDirectionalFocusGuides];
+  }
 }
 
 - (void)setPreferredFocus:(BOOL)hasTVPreferredFocus


### PR DESCRIPTION
Unset focus guides when changing the nextFocus prop back to undefined