### PR TITLE
fix: coordinate tvOS press animations with native events

### DIFF
--- a/packages/react-native/Libraries/Components/Pressable/Pressable.d.ts
+++ b/packages/react-native/Libraries/Components/Pressable/Pressable.d.ts
@@ -20,6 +20,7 @@ import {
 import {View} from '../View/View';
 import {AccessibilityProps} from '../View/ViewAccessibility';
 import {ViewProps} from '../View/ViewPropTypes';
+import {TVParallaxProperties} from '../../../types/public/ReactNativeTVTypes';
 
 export interface PressableStateCallbackType {
   readonly pressed: boolean;
@@ -159,6 +160,13 @@ export interface PressableProps
    * Duration (in milliseconds) to wait after press down before calling onPressIn.
    */
   unstable_pressDelay?: number | undefined;
+
+  /**
+   * *(Apple TV only)* Object with properties to control Apple TV parallax effects.
+   *
+   * @platform ios
+   */
+  tvParallaxProperties?: TVParallaxProperties;
 }
 
 // TODO use React.AbstractComponent when available

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -277,33 +277,35 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
     [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:recognizer.eventKeyAction tag:@(self.tag) target:@(self.tag)];
 }
 
-- (void)animatePress
+- (void)animatePressIn
 {
   if (_tvParallaxProperties.enabled == YES) {
-    float magnification = _tvParallaxProperties.magnification;
     float pressMagnification = _tvParallaxProperties.pressMagnification;
 
     // Duration of press animation
     float pressDuration = _tvParallaxProperties.pressDuration;
 
-    // Delay of press animation
-    float pressDelay = _tvParallaxProperties.pressDelay;
-
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:pressDelay]];
-
     [UIView animateWithDuration:(pressDuration/2)
                      animations:^{
       self.transform = CGAffineTransformMakeScale(pressMagnification, pressMagnification);
     }
-                     completion:^(__unused BOOL finished1){
-      [UIView animateWithDuration:(pressDuration/2)
-                       animations:^{
-        self.transform = CGAffineTransformMakeScale(magnification, magnification);
-      }
-                       completion:^(__unused BOOL finished2) {
-      }];
-    }];
+                     completion:^(__unused BOOL finished){}];
+  }
+}
 
+- (void) animatePressOut
+{
+  if (_tvParallaxProperties.enabled == YES) {
+    float magnification = _tvParallaxProperties.magnification;
+
+    // Duration of press animation
+    float pressDuration = _tvParallaxProperties.pressDuration;
+
+    [UIView animateWithDuration:(pressDuration/2)
+                     animations:^{
+      self.transform = CGAffineTransformMakeScale(magnification, magnification);
+    }
+                     completion:^(__unused BOOL finished){}];
   }
 }
 
@@ -312,10 +314,11 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   switch (r.state) {
       case UIGestureRecognizerStateBegan:
       _eventEmitter->onPressIn();
+      [self animatePressIn];
           break;
       case UIGestureRecognizerStateEnded:
       case UIGestureRecognizerStateCancelled:
-      [self animatePress];
+      [self animatePressOut];
       _eventEmitter->onPressOut();
           break;
       default:

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -90,32 +90,30 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   }
 }
 
-- (void)animatePress
+- (void)animatePressIn
 {
   if ([self.tvParallaxProperties[@"enabled"] boolValue] == YES) {
-    float magnification = [self.tvParallaxProperties[@"magnification"] floatValue];
     float pressMagnification = [self.tvParallaxProperties[@"pressMagnification"] floatValue];
-    
-    // Duration of press animation
     float pressDuration = [self.tvParallaxProperties[@"pressDuration"] floatValue];
-    
-    // Delay of press animation
-    float pressDelay = [self.tvParallaxProperties[@"pressDelay"] floatValue];
-    
-    [[NSRunLoop currentRunLoop] runUntilDate:[NSDate dateWithTimeIntervalSinceNow:pressDelay]];
-    
     [UIView animateWithDuration:(pressDuration/2)
                      animations:^{
       self.transform = CGAffineTransformMakeScale(pressMagnification, pressMagnification);
     }
-                     completion:^(__unused BOOL finished1){
-      [UIView animateWithDuration:(pressDuration/2)
-                       animations:^{
-        self.transform = CGAffineTransformMakeScale(magnification, magnification);
-      }
-                       completion:^(__unused BOOL finished2) {
-      }];
-    }];
+                     completion:^(__unused BOOL finished){}];
+  }
+}
+
+- (void) animatePressOut
+{
+  if ([self.tvParallaxProperties[@"enabled"] boolValue] == YES) {
+    float magnification = [self.tvParallaxProperties[@"magnification"] floatValue];
+    float pressDuration = [self.tvParallaxProperties[@"pressDuration"] floatValue];
+
+    [UIView animateWithDuration:(pressDuration/2)
+                     animations:^{
+      self.transform = CGAffineTransformMakeScale(magnification, magnification);
+    }
+                     completion:^(__unused BOOL finished){}];
   }
 }
 
@@ -124,10 +122,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   switch (r.state) {
       case UIGestureRecognizerStateBegan:
       if (self.onPressIn) self.onPressIn(nil);
+      [self animatePressIn];
           break;
       case UIGestureRecognizerStateEnded:
       case UIGestureRecognizerStateCancelled:
-      [self animatePress];
+      [self animatePressOut];
       if (self.onPressOut) self.onPressOut(nil);
           break;
       default:

--- a/packages/react-native/types/public/ReactNativeTVTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTVTypes.d.ts
@@ -100,7 +100,7 @@ declare module 'react-native' {
     pressDuration?: number | undefined,
 
     /**
-     * Defaults to 0.3
+     * @deprecated No longer used
      */
     pressDelay?: number | undefined,
   };


### PR DESCRIPTION
Now that we are generating `pressIn` and `pressOut` events natively, the press magnification animation in Apple TV parallax properties needs to be coordinated with these events, and not use its own delay and occur after the native events are emitted.

After this fix, the animation is smooth and coordinated with the style changes initiated by the press events.

Also fixed up the Typescript type for the parallax properties and made sure they are included in `Pressable` prop types.

Before:

https://github.com/user-attachments/assets/9a0c25d2-6d7e-47d3-9ec9-fc3ef8264c81

After:

https://github.com/user-attachments/assets/a98de4f6-c26f-4af4-ac9f-f7d5d30f7103

