### PR TITLE
Optimize androidHWInputDeviceHelper to use lazy initialization

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -401,8 +401,9 @@ public class ReactModalHostView(context: ThemedReactContext) :
     private var viewHeight = 0
     private val jSTouchDispatcher: JSTouchDispatcher = JSTouchDispatcher(this)
     private var jSPointerDispatcher: JSPointerDispatcher? = null
-    internal val androidHWInputDeviceHelper: ReactAndroidHWInputDeviceHelper
-      get() = ReactAndroidHWInputDeviceHelper()
+    internal val androidHWInputDeviceHelper: ReactAndroidHWInputDeviceHelper by lazy {
+      ReactAndroidHWInputDeviceHelper()
+    }
 
     internal val reactContext: ThemedReactContext
       get() = context as ThemedReactContext


### PR DESCRIPTION
The computed property `androidHWInputDeviceHelper` previously used a custom getter that created a new instance of `ReactAndroidHWInputDeviceHelper` each time it was accessed. This behavior led to a new instance being created with every key press, causing issues with maintaining state, such as tracking the last focused button.

By switching to a `by lazy` initialization approach, `androidHWInputDeviceHelper` is now instantiated only once upon its first access, preserving its state across key presses. This ensures that the "select" key functions correctly by retaining focus information across button interactions.