### PR TITLE
fix: restore TV event handler select/longSelect for tvOS

### DIFF
--- a/packages/react-native/React/Base/RCTTVRemoteHandler.m
+++ b/packages/react-native/React/Base/RCTTVRemoteHandler.m
@@ -119,11 +119,6 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
                                   pressType:UIPressTypePlayPause
                                        name:RCTTVRemoteEventPlayPause];
 
-  // Select
-  [self addTapGestureRecognizerWithSelector:@selector(selectPressed:)
-                                  pressType:UIPressTypeSelect
-                                       name:RCTTVRemoteEventSelect];
-    
   // Page Up/Down
   if (@available(tvOS 14.3, *)) {
       [self addTapGestureRecognizerWithSelector:@selector(tappedPageUp:)
@@ -161,10 +156,6 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
   [self addLongPressGestureRecognizerWithSelector:@selector(longPlayPausePressed:)
                                         pressType:UIPressTypePlayPause
                                              name:RCTTVRemoteEventLongPlayPause];
-
-  [self addLongPressGestureRecognizerWithSelector:@selector(longSelectPressed:)
-                                        pressType:UIPressTypeSelect
-                                             name:RCTTVRemoteEventLongSelect];
 
   [self addLongPressGestureRecognizerWithSelector:@selector(longUpPressed:)
                                         pressType:UIPressTypeUpArrow
@@ -355,11 +346,6 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
     [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventMenu keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
-- (void)selectPressed:(UIGestureRecognizer *)r
-{
-    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventSelect keyAction:r.eventKeyAction tag:nil target:nil];
-}
-
 - (void)longPlayPausePressed:(UIGestureRecognizer *)r
 {
     [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongPlayPause keyAction:r.eventKeyAction tag:nil target:nil];
@@ -368,11 +354,6 @@ static __volatile BOOL __gestureHandlersCancelTouches = YES;
     // If shake to show is enabled on device, use long play/pause event to show dev menu
     [[NSNotificationCenter defaultCenter] postNotificationName:@"RCTShowDevMenuNotification" object:nil];
 #endif
-}
-
-- (void)longSelectPressed:(UIGestureRecognizer *)r
-{
-    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:r.eventKeyAction tag:nil target:nil];
 }
 
 - (void)longUpPressed:(UIGestureRecognizer *)r

--- a/packages/react-native/React/Base/RCTTVRemoteSelectHandler.h
+++ b/packages/react-native/React/Base/RCTTVRemoteSelectHandler.h
@@ -5,11 +5,15 @@ NS_ASSUME_NONNULL_BEGIN
 
 @protocol RCTTVRemoteSelectHandlerDelegate <NSObject>
 
-- (void)selectGestureBegan;
-- (void)selectGestureEnded;
+- (void)animatePressIn;
+- (void)animatePressOut;
 
-- (void)longSelectGestureBegan;
-- (void)longSelectGestureEnded;
+- (void)emitPressInEvent;
+- (void)emitPressOutEvent;
+
+- (void)sendSelectNotification;
+- (void)sendLongSelectBeganNotification;
+- (void)sendLongSelectEndedNotification;
 
 @end
 

--- a/packages/react-native/React/Base/RCTTVRemoteSelectHandler.h
+++ b/packages/react-native/React/Base/RCTTVRemoteSelectHandler.h
@@ -1,0 +1,23 @@
+#import <UIKit/UIKit.h>
+#import <Foundation/Foundation.h>
+
+NS_ASSUME_NONNULL_BEGIN
+
+@protocol RCTTVRemoteSelectHandlerDelegate <NSObject>
+
+- (void)selectGestureBegan;
+- (void)selectGestureEnded;
+
+- (void)longSelectGestureBegan;
+- (void)longSelectGestureEnded;
+
+@end
+
+@interface RCTTVRemoteSelectHandler : NSObject <UIGestureRecognizerDelegate>
+
+- (instancetype _Nonnull )initWithView:(UIView<RCTTVRemoteSelectHandlerDelegate> * _Nonnull)view;
+- (instancetype _Nonnull )init __attribute__((unavailable("init not available, use initWithView:")));
+
+@end
+
+NS_ASSUME_NONNULL_END

--- a/packages/react-native/React/Base/RCTTVRemoteSelectHandler.m
+++ b/packages/react-native/React/Base/RCTTVRemoteSelectHandler.m
@@ -1,0 +1,111 @@
+#import "RCTTVRemoteSelectHandler.h"
+
+@interface RCTTVRemoteSelectHandler()
+
+@property (nonatomic, strong) UILongPressGestureRecognizer * pressRecognizer;
+@property (nonatomic, strong) UILongPressGestureRecognizer * longPressRecognizer;
+
+@property (nonatomic, weak) UIView<RCTTVRemoteSelectHandlerDelegate> *view;
+
+@end
+
+@implementation RCTTVRemoteSelectHandler {
+  NSMutableDictionary<NSString *, UIGestureRecognizer *> *_tvRemoteGestureRecognizers;
+}
+
+#pragma mark -
+#pragma mark Public methods
+
+- (instancetype)initWithView:(UIView <RCTTVRemoteSelectHandlerDelegate> *)view
+{
+  if ((self = [super init])) {
+      _view = view;
+      [self attachToView];
+  }
+  return self;
+}
+
+- (void)dealloc
+{
+  [self detachFromView];
+  _view = nil;
+}
+
+#pragma mark -
+#pragma UIGestureRecognizerDelegate method
+
+// Press recognizer should allow long press recognizer to work (but not the reverse)
+- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
+  return gestureRecognizer == _pressRecognizer;
+}
+
+#pragma mark -
+#pragma mark Private methods
+
+- (void)attachToView {
+  UILongPressGestureRecognizer *pressRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handlePress:)];
+  pressRecognizer.allowedPressTypes = @[ @(UIPressTypeSelect) ];
+  pressRecognizer.minimumPressDuration = 0.0;
+  pressRecognizer.delegate = self; // Press recognizer allows other recognizers to run
+
+  [self.view addGestureRecognizer:pressRecognizer];
+  self.pressRecognizer = pressRecognizer;
+
+  UILongPressGestureRecognizer *longPressRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
+  longPressRecognizer.allowedPressTypes = @[ @(UIPressTypeSelect) ];
+  longPressRecognizer.minimumPressDuration = 0.5;
+
+  [self.view addGestureRecognizer:longPressRecognizer];
+  self.longPressRecognizer = longPressRecognizer;
+}
+
+- (void)detachFromView {
+  if (_pressRecognizer) {
+    [self.view removeGestureRecognizer:_pressRecognizer];
+    self.pressRecognizer = nil;
+  }
+  if (_longPressRecognizer) {
+    [self.view removeGestureRecognizer:_longPressRecognizer];
+    self.longPressRecognizer = nil;
+  }
+}
+
+- (void)handlePress:(UIGestureRecognizer *)r
+{
+  switch (r.state) {
+    case UIGestureRecognizerStateBegan:
+      NSLog(@"selectGestureBegan");
+      [self.view selectGestureBegan];
+      break;
+    case UIGestureRecognizerStateCancelled:
+    case UIGestureRecognizerStateEnded:
+      if (r.enabled) {
+        NSLog(@"selectGestureEnded");
+        [self.view selectGestureEnded];
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+- (void)handleLongPress:(UIGestureRecognizer *)r
+{
+  switch (r.state) {
+    case UIGestureRecognizerStateBegan:
+      self.pressRecognizer.enabled = NO;
+      NSLog(@"longSelectGestureBegan");
+      [self.view longSelectGestureBegan];
+      break;
+    case UIGestureRecognizerStateEnded:
+    case UIGestureRecognizerStateCancelled:
+      NSLog(@"longSelectGestureEnded");
+      [self.view longSelectGestureEnded];
+      self.pressRecognizer.enabled = YES;
+      break;
+    default:
+      break;
+  }
+}
+
+@end

--- a/packages/react-native/React/Base/RCTTVRemoteSelectHandler.m
+++ b/packages/react-native/React/Base/RCTTVRemoteSelectHandler.m
@@ -74,12 +74,15 @@
 {
   switch (r.state) {
     case UIGestureRecognizerStateBegan:
-      [self.view selectGestureBegan];
+      [self.view emitPressInEvent];
+      [self.view animatePressIn];
       break;
     case UIGestureRecognizerStateCancelled:
     case UIGestureRecognizerStateEnded:
       if (r.enabled) {
-        [self.view selectGestureEnded];
+        [self.view animatePressOut];
+        [self.view emitPressOutEvent];
+        [self.view sendSelectNotification];
       }
       break;
     default:
@@ -87,16 +90,26 @@
   }
 }
 
+/*
+ When a long press starts, the press recognizer has already started
+ and called selectGestureBegan(). We disable the press recognizer
+ when the long press starts. At the end of the gesture, we execute the
+ code for pressOut (since the press recognizer cannot), and then reenable
+ the press recgonizer. This guarantees
+ only one pressIn and one pressOut, and only longSelect notifications.
+ */
 - (void)handleLongPress:(UIGestureRecognizer *)r
 {
   switch (r.state) {
     case UIGestureRecognizerStateBegan:
       self.pressRecognizer.enabled = NO;
-      [self.view longSelectGestureBegan];
+      [self.view sendLongSelectBeganNotification];
       break;
     case UIGestureRecognizerStateEnded:
     case UIGestureRecognizerStateCancelled:
-      [self.view longSelectGestureEnded];
+      [self.view animatePressOut];
+      [self.view emitPressOutEvent];
+      [self.view sendLongSelectEndedNotification];
       self.pressRecognizer.enabled = YES;
       break;
     default:

--- a/packages/react-native/React/Base/RCTTVRemoteSelectHandler.m
+++ b/packages/react-native/React/Base/RCTTVRemoteSelectHandler.m
@@ -74,13 +74,11 @@
 {
   switch (r.state) {
     case UIGestureRecognizerStateBegan:
-      NSLog(@"selectGestureBegan");
       [self.view selectGestureBegan];
       break;
     case UIGestureRecognizerStateCancelled:
     case UIGestureRecognizerStateEnded:
       if (r.enabled) {
-        NSLog(@"selectGestureEnded");
         [self.view selectGestureEnded];
       }
       break;
@@ -94,12 +92,10 @@
   switch (r.state) {
     case UIGestureRecognizerStateBegan:
       self.pressRecognizer.enabled = NO;
-      NSLog(@"longSelectGestureBegan");
       [self.view longSelectGestureBegan];
       break;
     case UIGestureRecognizerStateEnded:
     case UIGestureRecognizerStateCancelled:
-      NSLog(@"longSelectGestureEnded");
       [self.view longSelectGestureEnded];
       self.pressRecognizer.enabled = YES;
       break;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -11,6 +11,7 @@
 #import <React/RCTConstants.h>
 #import <React/RCTTouchableComponentViewProtocol.h>
 #import <React/UIView+ComponentViewProtocol.h>
+#import <React/RCTTVRemoteSelectHandler.h>
 #import <react/renderer/components/view/ViewEventEmitter.h>
 #import <react/renderer/components/view/ViewProps.h>
 #import <react/renderer/core/EventEmitter.h>
@@ -25,7 +26,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * UIView class for <View> component.
  */
-@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol, UIGestureRecognizerDelegate> {
+@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol, RCTTVRemoteSelectHandlerDelegate, UIGestureRecognizerDelegate> {
  @protected
   facebook::react::LayoutMetrics _layoutMetrics;
   facebook::react::SharedViewProps _props;
@@ -72,6 +73,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property(nonatomic, nullable) UIFocusGuide *focusGuideDown;
 @property(nonatomic, nullable) UIFocusGuide *focusGuideLeft;
 @property(nonatomic, nullable) UIFocusGuide *focusGuideRight;
+@property(nonatomic, nullable, strong) RCTTVRemoteSelectHandler *tvRemoteSelectHandler;
 #endif
 
 /**

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -25,7 +25,7 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * UIView class for <View> component.
  */
-@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol> {
+@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol, UIGestureRecognizerDelegate> {
  @protected
   facebook::react::LayoutMetrics _layoutMetrics;
   facebook::react::SharedViewProps _props;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.h
@@ -11,7 +11,9 @@
 #import <React/RCTConstants.h>
 #import <React/RCTTouchableComponentViewProtocol.h>
 #import <React/UIView+ComponentViewProtocol.h>
+#if TARGET_OS_TV
 #import <React/RCTTVRemoteSelectHandler.h>
+#endif
 #import <react/renderer/components/view/ViewEventEmitter.h>
 #import <react/renderer/components/view/ViewProps.h>
 #import <react/renderer/core/EventEmitter.h>
@@ -26,7 +28,11 @@ NS_ASSUME_NONNULL_BEGIN
 /**
  * UIView class for <View> component.
  */
-@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol, RCTTVRemoteSelectHandlerDelegate, UIGestureRecognizerDelegate> {
+#if TARGET_OS_TV
+@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol, RCTTVRemoteSelectHandlerDelegate> {
+#else
+@interface RCTViewComponentView : UIView <RCTComponentViewProtocol, RCTTouchableComponentViewProtocol> {
+#endif
  @protected
   facebook::react::LayoutMetrics _layoutMetrics;
   facebook::react::SharedViewProps _props;

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -271,12 +271,12 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventSelect keyAction:RCTTVRemoteEventKeyActionUp tag:@(self.tag) target:@(self.tag)];
 }
 
-- (void)sendLongSelectStartNotification
+- (void)sendLongSelectBeganNotification
 {
     [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:RCTTVRemoteEventKeyActionDown tag:@(self.tag) target:@(self.tag)];
 }
 
-- (void)sendLongSelectEndNotification
+- (void)sendLongSelectEndedNotification
 {
     [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:RCTTVRemoteEventKeyActionUp tag:@(self.tag) target:@(self.tag)];
 }
@@ -313,29 +313,14 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   }
 }
 
-- (void)selectGestureBegan
+- (void)emitPressInEvent
 {
   _eventEmitter->onPressIn();
-  [self animatePressIn];
 }
 
-- (void)selectGestureEnded
+- (void)emitPressOutEvent
 {
-  [self animatePressOut];
   _eventEmitter->onPressOut();
-  [self sendSelectNotification];
-}
-
-- (void)longSelectGestureBegan
-{
-  [self sendLongSelectStartNotification];
-}
-
-- (void)longSelectGestureEnded
-{
-  [self animatePressOut];
-  _eventEmitter->onPressOut();
-  [self sendLongSelectEndNotification];
 }
 
 - (void)addParallaxMotionEffects

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -63,8 +63,6 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   BOOL _removeClippedSubviews;
   NSMutableArray<UIView *> *_reactSubviews;
   BOOL _motionEffectsAdded;
-  UILongPressGestureRecognizer * _pressRecognizer;
-  UILongPressGestureRecognizer * _longPressRecognizer;
   NSSet<NSString *> *_Nullable _propKeysManagedByAnimated_DO_NOT_USE_THIS_IS_BROKEN;
   UIView *_containerView;
   BOOL _useCustomContainerView;
@@ -157,11 +155,6 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   if ([self.traitCollection hasDifferentColorAppearanceComparedToTraitCollection:previousTraitCollection]) {
     [self invalidateLayer];
   }
-}
-
-// Press recognizer should allow long press recognizer to work (but not the reverse)
-- (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-  return gestureRecognizer == _pressRecognizer;
 }
 
 #if TARGET_OS_TV

--- a/packages/react-native/React/Views/RCTTVView.h
+++ b/packages/react-native/React/Views/RCTTVView.h
@@ -12,7 +12,7 @@
 #import <React/RCTBridge.h>
 
 //  A RCTView with additional properties and methods for user interaction using the Apple TV focus engine.
-@interface RCTTVView : RCTView
+@interface RCTTVView : RCTView <UIGestureRecognizerDelegate>
 
 /**
  * TV event handlers
@@ -76,11 +76,6 @@
  * Send Blur Notifications to listeners
  */
 - (void)sendBlurNotification:(UIFocusUpdateContext *)context;
-
-/**
- * Send Select Notification to listeners
- */
-- (void)sendSelectNotification:(UIGestureRecognizer *)recognizer;
 
 /**
  * Adds Parallax Motion Effects if tvParallaxProperty is enabled

--- a/packages/react-native/React/Views/RCTTVView.h
+++ b/packages/react-native/React/Views/RCTTVView.h
@@ -10,9 +10,10 @@
 
 #import <React/RCTView.h>
 #import <React/RCTBridge.h>
+#import <React/RCTTVRemoteSelectHandler.h>
 
 //  A RCTView with additional properties and methods for user interaction using the Apple TV focus engine.
-@interface RCTTVView : RCTView <UIGestureRecognizerDelegate>
+@interface RCTTVView : RCTView <RCTTVRemoteSelectHandlerDelegate>
 
 /**
  * TV event handlers
@@ -29,6 +30,10 @@
  */
 @property (nonatomic, assign) BOOL hasTVPreferredFocus;
 
+/**
+  * Select and longSelect event handler
+ */
+@property (nonatomic, strong) RCTTVRemoteSelectHandler *tvRemoteSelectHandler;
 /**
  * Focus direction tags
  */

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -508,7 +508,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 }
 
 - (void)setNextFocusDown:(NSNumber *)nextFocusDown {
-  if (self.focusGuideDown != nil && nextFocusDown) {
+  if (self.focusGuideDown != nil && nextFocusDown == nil) {
     [[self rootView] removeLayoutGuide:self.focusGuideDown];
     self.focusGuideDown = nil;
   } else {
@@ -528,7 +528,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
 }
 
 - (void)setNextFocusRight:(NSNumber *)nextFocusRight {
-  if (self.focusGuideRight != nil && nextFocusRight) {
+  if (self.focusGuideRight != nil && nextFocusRight == nil) {
     [[self rootView] removeLayoutGuide:self.focusGuideRight];
     self.focusGuideRight = nil;
   } else {

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -22,8 +22,6 @@
 
 @implementation RCTTVView {
   __weak RCTBridge *_bridge;
-  UILongPressGestureRecognizer * _pressRecognizer;
-  UILongPressGestureRecognizer * _longPressRecognizer;
   BOOL motionEffectsAdded;
   NSArray* focusDestinations;
   id<UIFocusItem> previouslyFocusedItem;

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -108,29 +108,14 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   }
 }
 
-- (void)selectGestureBegan
+- (void)emitPressInEvent
 {
   if (self.onPressIn) self.onPressIn(nil);
-  [self animatePressIn];
 }
 
-- (void)selectGestureEnded
+- (void)emitPressOutEvent
 {
-  [self animatePressOut];
   if (self.onPressOut) self.onPressOut(nil);
-  [self sendSelectNotification];
-}
-
-- (void)longSelectGestureBegan
-{
-  [self sendLongSelectStartNotification];
-}
-
-- (void)longSelectGestureEnded
-{
-  [self animatePressOut];
-  if (self.onPressOut) self.onPressOut(nil);
-  [self sendLongSelectEndNotification];
 }
 
 - (BOOL)isTVFocusGuide
@@ -444,12 +429,12 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventSelect keyAction:RCTTVRemoteEventKeyActionUp tag:self.reactTag target:self.reactTag];
 }
 
-- (void)sendLongSelectStartNotification
+- (void)sendLongSelectBeganNotification
 {
     [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:RCTTVRemoteEventKeyActionDown tag:self.reactTag target:self.reactTag];
 }
 
-- (void)sendLongSelectEndNotification
+- (void)sendLongSelectEndedNotification
 {
     [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:RCTTVRemoteEventKeyActionUp tag:self.reactTag target:self.reactTag];
 }

--- a/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
+++ b/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
@@ -10,11 +10,6 @@
 
 'use strict';
 
-import type {
-  FocusEvent,
-  BlurEvent,
-} from '../../../../react-native/Libraries/Types/CoreEventTypes';
-
 import * as React from 'react';
 import ReactNative from 'react-native';
 
@@ -32,7 +27,7 @@ const {
   TVEventControl,
 } = ReactNative;
 
-const focusHandler = (event: FocusEvent & {name?: string}, props: any) => {
+const focusHandler = (event: $FlowFixMe, props: any) => {
   if (props.noBubbledEvents) {
     event.name = undefined;
     event.stopPropagation();
@@ -42,7 +37,7 @@ const focusHandler = (event: FocusEvent & {name?: string}, props: any) => {
   props.log(`Focus on ${props.title} at ${event.nativeEvent?.target}`);
 };
 
-const blurHandler = (event: BlurEvent & {name: string}, props: any) => {
+const blurHandler = (event: $FlowFixMe, props: any) => {
   if (props.noBubbledEvents) {
     event.stopPropagation();
   } else {
@@ -60,20 +55,22 @@ const PressableButton = (props: {
   log: (entry: string) => void,
   functional?: boolean,
   noBubbledEvents?: boolean,
+  tvParallaxProperties?: $FlowFixMe,
 }) => {
   // Set functional=false to have no functional style or children
   // and test the fix for #744
+  const {functional, log, noBubbledEvents, title, ...pressableProps} = props;
   const [userFocused, setUserFocused] = React.useState(false);
-  const functional = props?.functional ?? true;
-  return functional ? (
+  return functional !== false ? (
     <Pressable
-      {...props}
-      onFocus={(event: FocusEvent) => focusHandler(event, props)}
-      onBlur={(event: BlurEvent) => blurHandler(event, props)}
+      {...pressableProps}
+      onFocus={(event: $FlowFixMe) => focusHandler(event, props)}
+      onBlur={(event: $FlowFixMe) => blurHandler(event, props)}
       onPress={() => pressEventHandler('onPress', props)}
       onLongPress={() => pressEventHandler('onLongPress', props)}
       onPressIn={() => pressEventHandler('onPressIn', props)}
       onPressOut={() => pressEventHandler('onPressOut', props)}
+      tvParallaxProperties={props.tvParallaxProperties}
       android_ripple={{
         color: '#cccccc',
         radius: 50,
@@ -95,15 +92,16 @@ const PressableButton = (props: {
     </Pressable>
   ) : (
     <Pressable
-      {...props}
-      onFocus={(event: FocusEvent) => {
+      {...pressableProps}
+      onFocus={(event: $FlowFixMe) => {
         focusHandler(event, props);
         setUserFocused(true);
       }}
-      onBlur={(event: BlurEvent) => {
+      onBlur={(event: $FlowFixMe) => {
         blurHandler(event, props);
         setUserFocused(false);
       }}
+      tvParallaxProperties={props.tvParallaxProperties}
       onPress={() => pressEventHandler('onPress', props)}
       onLongPress={() => pressEventHandler('onLongPress', props)}
       onPressIn={() => pressEventHandler('onPressIn', props)}
@@ -283,6 +281,15 @@ const TVEventHandlerView: () => React.Node = () => {
             log={updatePressableLog}
             functional={false}
           />
+          <PressableButton
+            title="Pressable tvOS expand"
+            log={updatePressableLog}
+            tvParallaxProperties={{
+              enabled: true,
+              magnification: 1.05,
+              pressMagnification: 1.1,
+            }}
+          />
           <TouchableOpacityButton
             title="TouchableOpacity"
             log={updatePressableLog}
@@ -335,12 +342,12 @@ const TVEventHandlerView: () => React.Node = () => {
         </View>
         <View
           style={styles.containerView}
-          onFocus={(event: FocusEvent) => {
+          onFocus={(event: $FlowFixMe) => {
             updatePressableLog(
               `Focus bubbled from ${event.nativeEvent.target}`,
             );
           }}
-          onBlur={(event: BlurEvent) => {
+          onBlur={(event: $FlowFixMe) => {
             updatePressableLog(`Blur bubbled from ${event.nativeEvent.target}`);
           }}>
           <Text style={{fontSize: 12 * scale}}>
@@ -358,12 +365,12 @@ const TVEventHandlerView: () => React.Node = () => {
             <View>
               <TextInput
                 ref={textInputRef}
-                onFocus={(event: FocusEvent) =>
+                onFocus={(event: $FlowFixMe) =>
                   updatePressableLog(
                     `TextInput ${event.nativeEvent.target} is focused`,
                   )
                 }
-                onBlur={(event: BlurEvent) =>
+                onBlur={(event: $FlowFixMe) =>
                   updatePressableLog(
                     `TextInput ${event.nativeEvent.target} is blurred`,
                   )


### PR DESCRIPTION
The introduction of fully native focus/blur/pressIn/pressOut in #813 led to an inconsistency in the behavior of the TV event handler. On Android TV, the `select` and `longSelect` events are still sent to the handler. On Apple TV, they are missing.

Root cause was interference between the select gesture recognizer in the views, and the one in `RCTTVRemoteHandler`.

Solution:

- Remove handling of select and longSelect from `RCTTVRemoteHandler`
- Create a new class, `RCTTVRemoteSelectHandler`, that has the select and longSelect gesture recognizers, and calls delegate methods in the views when these gestures start and finish
- The new class is used by both Fabric and non-Fabric views, to avoid code duplication.

Before:

![Simulator Screenshot - Apple TV - 2024-11-15 at 00 06 35](https://github.com/user-attachments/assets/155eebcb-f917-4361-87ec-5ab77f275443)

After:

![Simulator Screenshot - Apple TV - 2024-11-15 at 00 10 12](https://github.com/user-attachments/assets/5c25b056-8c69-408a-a9be-b5b5a1509d56)
