### PR TITLE
fix: TextInput regression with new native events and old arch

### DIFF
--- a/packages/react-native/React/Views/RCTTVView.h
+++ b/packages/react-native/React/Views/RCTTVView.h
@@ -57,18 +57,13 @@
 @property (nonatomic, assign) BOOL trapFocusLeft;
 @property (nonatomic, assign) BOOL trapFocusRight;
 
-
-/**
- * Focus
- */
+// These handlers are defined in RCTView
+/*
 @property (nonatomic, copy) RCTBubblingEventBlock onFocus;
 @property (nonatomic, copy) RCTBubblingEventBlock onBlur;
-
-/**
- * TV Press Handlers
- */
 @property (nonatomic, copy) RCTDirectEventBlock onPressIn;
 @property (nonatomic, copy) RCTDirectEventBlock onPressOut;
+ */
 
 - (instancetype)initWithBridge:(RCTBridge *)bridge;
 

--- a/packages/react-native/React/Views/RCTView.h
+++ b/packages/react-native/React/Views/RCTView.h
@@ -123,6 +123,25 @@ extern const UIAccessibilityTraits SwitchAccessibilityTrait;
 
 @property (nonatomic, assign) RCTCursor cursor;
 
+#if TARGET_OS_TV
+// For Paper, all views on TV might have focus, blur, pressIn, pressOut handlers,
+// so we need to add these properties here and not in RCTTVView,
+// since some views do not inherit from RCTTVView.
+
+/**
+ * Focus
+ */
+@property (nonatomic, copy) RCTBubblingEventBlock onFocus;
+@property (nonatomic, copy) RCTBubblingEventBlock onBlur;
+
+/**
+ * TV Press Handlers
+ */
+@property (nonatomic, copy) RCTDirectEventBlock onPressIn;
+@property (nonatomic, copy) RCTDirectEventBlock onPressOut;
+
+#endif // TARGET_OS_TV
+
 /**
  * (Experimental and unused for Paper) Pointer event handlers.
  */


### PR DESCRIPTION
Fixes #833 .

This problem is specific to apps running in old non-Fabric architecture. It occurs because in the old architecture implementation, some views (TextInput, ScrollView) do not inherit from the TV-specific RCTTVVIew class.

For correct behavior and to avoid other regressions, I've moved the handler properties to RCTView. 