### PR TITLE
fix: auto focus on RTL to go to first right aligned item

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -519,11 +519,6 @@ public class ReactViewGroup extends ViewGroup
     boolean elementsHorizontallyAligned = isHorizontallyLaidOut(focusables);
     boolean shouldSwapIndexing = isRtl && elementsHorizontallyAligned;
 
-    // Determine start and end indices based on layout direction
-    int startIndex = shouldSwapIndexing ? focusables.size() - 1 : 0;
-    int endIndex = shouldSwapIndexing ? -1 : focusables.size();
-    int step = shouldSwapIndexing ? -1 : 1;
-
     View firstFocusableElement = null;
     Integer index = 0;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -532,7 +532,6 @@ public class ReactViewGroup extends ViewGroup
           }
           index--;
       }
-      if (firstFocusableElement != null) return firstFocusableElement.requestFocus();
     } else {
       while (firstFocusableElement == null && index < focusables.size()) {
         View elem = focusables.get(index);
@@ -542,8 +541,8 @@ public class ReactViewGroup extends ViewGroup
         }
         index++;
       }
-      if (firstFocusableElement != null) return firstFocusableElement.requestFocus();
     }
+    if (firstFocusableElement != null) return firstFocusableElement.requestFocus();
     return false;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -514,35 +514,26 @@ public class ReactViewGroup extends ViewGroup
      */
     if (focusables.size() <= 0) return false;
 
-    // Check layout direction
+    /**
+     * We want to swap the while loop if RTL is enabled and the items
+     * are horizontally aligned. This means autoFocus will focus the element
+     * on the right hand side of the screen rather than left, creating a better
+     * UX on RTL applications.
+     */ 
     boolean isRtl = I18nUtil.getInstance().isRTL(getContext());
     boolean elementsHorizontallyAligned = isHorizontallyLaidOut(focusables);
-    boolean shouldSwapIndexing = isRtl && elementsHorizontallyAligned;
+    boolean shouldReverse = isRtl && elementsHorizontallyAligned;
 
-    View firstFocusableElement = null;
-    Integer index = 0;
+    Integer index = shouldReverse ? focusables.size() - 1 : 0;
 
-    if (shouldSwapIndexing) {
-      index = focusables.size() - 1;  // Start from the last element
-      while (firstFocusableElement == null && index >= 0) {  // Ensure we don’t go out of bounds
-          View elem = focusables.get(index);
-          if (elem != viewGroup) {
-              firstFocusableElement = elem;
-              break;
-          }
-          index--;
-      }
-    } else {
-      while (firstFocusableElement == null && index < focusables.size()) {
+    while (shouldReverse ? index >= 0 : index < focusables.size()) {
         View elem = focusables.get(index);
         if (elem != viewGroup) {
-          firstFocusableElement = elem;
-          break;
+            return elem.requestFocus();
         }
-        index++;
-      }
+        index += shouldReverse ? -1 : 1;
     }
-    if (firstFocusableElement != null) return firstFocusableElement.requestFocus();
+
     return false;
   }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -514,20 +514,57 @@ public class ReactViewGroup extends ViewGroup
      */
     if (focusables.size() <= 0) return false;
 
+    // Check layout direction
+    boolean isRtl = I18nUtil.getInstance().isRTL(getContext());
+    boolean elementsHorizontallyAligned = isHorizontallyLaidOut(focusables);
+    boolean shouldSwapIndexing = isRtl && elementsHorizontallyAligned;
+
+    // Determine start and end indices based on layout direction
+    int startIndex = shouldSwapIndexing ? focusables.size() - 1 : 0;
+    int endIndex = shouldSwapIndexing ? -1 : focusables.size();
+    int step = shouldSwapIndexing ? -1 : 1;
+
     View firstFocusableElement = null;
     Integer index = 0;
-    while (firstFocusableElement == null && index < focusables.size()) {
-      View elem = focusables.get(index);
-      if (elem != viewGroup) {
-        firstFocusableElement = elem;
-        break;
+
+    if (shouldSwapIndexing) {
+      index = focusables.size() - 1;  // Start from the last element
+      while (firstFocusableElement == null && index >= 0) {  // Ensure we don’t go out of bounds
+          View elem = focusables.get(index);
+          if (elem != viewGroup) {
+              firstFocusableElement = elem;
+              break;
+          }
+          index--;
       }
-      index++;
+      if (firstFocusableElement != null) return firstFocusableElement.requestFocus();
+    } else {
+      while (firstFocusableElement == null && index < focusables.size()) {
+        View elem = focusables.get(index);
+        if (elem != viewGroup) {
+          firstFocusableElement = elem;
+          break;
+        }
+        index++;
+      }
+      if (firstFocusableElement != null) return firstFocusableElement.requestFocus();
     }
-
-    if (firstFocusableElement != null) return firstFocusableElement.requestFocus();
-
     return false;
+  }
+
+  private boolean isHorizontallyLaidOut(ArrayList<View> focusables) {
+    if (focusables.size() <= 1) return false;
+
+    // Use the y-coordinate of the first focusable as a reference
+    int referenceY = focusables.get(0).getTop();
+
+    // Check if all focusables share the same y-coordinate
+    for (View view : focusables) {
+        if (view.getTop() != referenceY) {
+            return false; // Not horizontally laid out
+        }
+    }
+    return true; // All on the same horizontal axis
   }
 
   void recoverFocus(View view) {


### PR DESCRIPTION
## What
Auto focus logic for RTL should select the right most available item rather than left most

## Why
A better UX for RTL apps, stopping "jumping" in flatlists

## Additional
Also includes a slight refactoring in the initial logic by removing the `firstFocusableElement` variable and early returning instead

All videos were taken with bridgeless and fabric set to false in `packages/react-native/ReactAndroid/src/main/java/com/facebook/react/defaults/DefaultNewArchitectureEntryPoint.kt` - I'm not sure where I'd make these changes for fabric tbh

## Original Behaviour - RTL
https://github.com/user-attachments/assets/b45ea448-f8d6-4253-855a-2da1d5c72ee7

## Fixed Behaviour - RTL
https://github.com/user-attachments/assets/581eeddd-5f51-45dc-a683-d674e680941b

The below are videos for LTR, in which the behaviour has stayed the same

## Original Behaviour - LTR
https://github.com/user-attachments/assets/e664a15f-de00-495a-a741-3571f51ac52a

## Fix Behaviour - LTR
https://github.com/user-attachments/assets/74abdb2b-22d3-4c42-bbb5-b979f6c5fb84




