### PR TITLE
Fix broken Android RootViewTest

### DIFF
--- a/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
+++ b/packages/react-native/ReactAndroid/src/test/java/com/facebook/react/RootViewTest.kt
@@ -25,13 +25,13 @@ import com.facebook.react.bridge.WritableArray
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.common.SystemClock
 import com.facebook.react.internal.featureflags.ReactNativeFeatureFlagsForTests
+import com.facebook.react.modules.core.DeviceEventManagerModule
 import com.facebook.react.uimanager.DisplayMetricsHolder
 import com.facebook.react.uimanager.UIManagerModule
 import com.facebook.react.uimanager.events.Event
 import com.facebook.react.uimanager.events.EventDispatcher
 import com.facebook.react.uimanager.events.RCTEventEmitter
-import java.util.Date
-import org.assertj.core.api.Assertions.*
+import org.assertj.core.api.Assertions.assertThat
 import org.junit.After
 import org.junit.Before
 import org.junit.Test
@@ -40,11 +40,17 @@ import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers
 import org.mockito.MockedStatic
 import org.mockito.Mockito
-import org.mockito.Mockito.*
-import org.mockito.Mockito.`when` as whenever
+import org.mockito.Mockito.mock
+import org.mockito.Mockito.reset
+import org.mockito.Mockito.spy
+import org.mockito.Mockito.times
+import org.mockito.Mockito.verify
+import org.mockito.Mockito.verifyNoMoreInteractions
 import org.robolectric.Robolectric
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.RuntimeEnvironment
+import java.util.Date
+import org.mockito.Mockito.`when` as whenever
 
 @RunWith(RobolectricTestRunner::class)
 class RootViewTest {
@@ -198,6 +204,11 @@ class RootViewTest {
     val instanceManager = mock(ReactInstanceManager::class.java)
     val activity = Robolectric.buildActivity(Activity::class.java).create().get()
     whenever(instanceManager.currentReactContext).thenReturn(reactContext)
+
+    val deviceEventEmitterMock = mock(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+    whenever(reactContext.getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter::class.java))
+      .thenReturn(deviceEventEmitterMock)
+
     val rootView: ReactRootView =
         object : ReactRootView(activity) {
           override fun getWindowVisibleDisplayFrame(outRect: Rect) {
@@ -232,6 +243,6 @@ class RootViewTest {
     endCoordinates.putDouble("screenY", keyboardHeight)
     params.putMap("endCoordinates", endCoordinates)
     params.putString("easing", "keyboard")
-    verify(reactContext, times(1)).emitDeviceEvent("keyboardDidShow", params)
+    verify(deviceEventEmitterMock, times(1)).emit("keyboardDidShow", params)
   }
 }


### PR DESCRIPTION
## Problem  
The `testCheckForKeyboardEvents` unit test is failing with a `NullPointerException` in `ReactAndroidHWInputDeviceHelper.java`.  

```shell
RootViewTest > testCheckForKeyboardEvents FAILED  
    java.lang.NullPointerException at ReactAndroidHWInputDeviceHelper.java:233  

> Task :packages:react-native:ReactAndroid:testDebugUnitTest FAILED  

311 tests completed, 1 failed, 7 skipped  

FAILURE: Build failed with an exception.  
```

## Root Cause  
The failure occurs because the `ReactContext` is not properly mocked during the test execution, causing the `getJSModule` method to return `null`. This leads to a `NullPointerException` when attempting to emit events.  

## Solution  
The test has been updated to properly mock the `ReactContext` and the `RCTDeviceEventEmitter` module, ensuring that event emissions are handled correctly during test execution.  

## Testing  
To verify the fix:  

1. Clone the repository:  
   ```shell
   gh repo clone cgoldsby/react-native-tvos
   ```  

2. Check out the branch with the fix:  
   ```shell
   git checkout FixAndroidRootViewTest
   ```  

3. Install dependencies:  
   ```shell
   yarn
   ```  

4. Run the tests:  
   ```shell
   ./gradlew test
   ```  

**Expected Result:**  
All tests should pass without any `NullPointerException`:  

- **Tests completed:** 311  
- **Tests failed:** 0  
- **Tests skipped:** 7  

---

**Note:** While implementing the fix, my IDE automatically organized imports. If this is an issue, let me know, and I can revert those changes.

Let me know if further adjustments are needed!