### PR TITLE
[Release 0.77.0-0rc5] Fix Key Events Propagation Issue on Android TV's Modals #829

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -144,6 +144,14 @@ public abstract class ReactActivity extends AppCompatActivity
     mDelegate.onConfigurationChanged(newConfig);
   }
 
+  public boolean onDialogKeyUp(int keyCode, KeyEvent event) {
+    return mDelegate != null && mDelegate.onDialogKeyUp(keyCode, event);
+  }
+
+  public boolean onDialogKeyDown(int keyCode, KeyEvent event) {
+    return mDelegate != null && mDelegate.onDialogKeyDown(keyCode, event);
+  }
+
   protected final ReactNativeHost getReactNativeHost() {
     return mDelegate.getReactNativeHost();
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -199,6 +199,14 @@ public class ReactActivityDelegate {
     return mReactDelegate.onBackPressed();
   }
 
+  public boolean onDialogKeyUp(int keyCode, KeyEvent event) {
+    return mReactDelegate != null && mReactDelegate.onDialogKeyUp(keyCode, event);
+  }
+
+  public boolean onDialogKeyDown(int keyCode, KeyEvent event) {
+    return mReactDelegate != null && mReactDelegate.onDialogKeyDown(keyCode, event);
+  }
+
   public boolean onNewIntent(Intent intent) {
     return mReactDelegate.onNewIntent(intent);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -247,6 +247,43 @@ public class ReactDelegate {
     return false;
   }
 
+  /**
+   * Handles key up events for a dialog.
+   * <p>
+   * This method currently does not perform any action and always returns {@code false}. Subclasses
+   * can override this method to provide custom behavior.
+   * </p>
+   *
+   * @param keyCode the code of the key that was released
+   * @param event the {@link KeyEvent} object containing full information about the event
+   * @return {@code true} if the event was handled, {@code false} otherwise
+   *
+   * @see KeyEvent
+   * @see <a href="https://github.com/react-native-tvos/react-native-tvos/issues/829">GitHub Issue #829</a>
+   */
+  public boolean onDialogKeyUp(int keyCode, KeyEvent event) {
+    return false;
+  }
+
+  /**
+   * Handles key down events for a dialog.
+   * <p>
+   * This method currently does not perform any action and always returns {@code false}. Subclasses
+   * can override this method to provide custom behavior.
+   * </p>
+   *
+   * @param keyCode the code of the key that was pressed
+   * @param event the {@link KeyEvent} object containing full information about the event
+   * @return {@code false} indicating the event was not handled
+   *
+   * @see KeyEvent
+   * @see <a href="https://github.com/react-native-tvos/react-native-tvos/issues/829">GitHub Issue #829</a>
+   */
+  public boolean onDialogKeyDown(int keyCode, KeyEvent event) {
+    return false;
+  }
+
+
   public void reload() {
     DevSupportManager devSupportManager = getDevSupportManager();
     if (devSupportManager == null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -278,7 +278,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
                 val innerCurrentActivity =
                     (this@ReactModalHostView.context as ReactContext).currentActivity as? ReactActivity
                 if (innerCurrentActivity != null) {
-                  return innerCurrentActivity.onKeyUp(keyCode, event)
+                  return innerCurrentActivity.onDialogKeyUp(keyCode, event)
                 }
               }
             }
@@ -297,7 +297,7 @@ public class ReactModalHostView(context: ThemedReactContext) :
               val innerCurrentActivity =
                 (this@ReactModalHostView.context as ReactContext).currentActivity as? ReactActivity
               if (innerCurrentActivity != null) {
-                return innerCurrentActivity.onKeyDown(keyCode, event)
+                return innerCurrentActivity.onDialogKeyDown(keyCode, event)
               }
             }
 

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
@@ -10,12 +10,14 @@ package com.facebook.react.uiapp
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.View
 import android.widget.FrameLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.FBRNTesterEndToEndHelper
 import com.facebook.react.ReactActivity
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 import java.io.FileDescriptor
@@ -77,5 +79,27 @@ internal class RNTesterActivity : ReactActivity() {
       args: Array<String>?
   ) {
     FBRNTesterEndToEndHelper.maybeDump(prefix, writer, args)
+  }
+
+  override fun onDialogKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+    val data = Arguments.createMap()
+    data.putString("keyCode", KeyEvent.keyCodeToString(keyCode))
+
+    reactActivityDelegate.currentReactContext
+      ?.getJSModule(com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+      ?.emit(::onDialogKeyUp.name + "Event", data)
+
+    return super.onDialogKeyUp(keyCode, event)
+  }
+
+  override fun onDialogKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+    val data = Arguments.createMap()
+    data.putString("keyCode", KeyEvent.keyCodeToString(keyCode))
+
+    reactActivityDelegate.currentReactContext
+      ?.getJSModule(com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+      ?.emit(::onDialogKeyDown.name + "Event", data)
+
+    return super.onDialogKeyDown(keyCode, event)
   }
 }


### PR DESCRIPTION
### Description
---
This pull request addresses the key events propagation issue reported in #829 in the `react-native-tvos` repository. The fix incorporates feedback from the original issue discussion and resolves the problem where `ACTION_DOWN` key events were not properly propagated to the Android app's main activity modals.

### Changes
---
- Added a condition to delegate `ACTION_DOWN` key events to `onDialogKeyDown` when a modal is open.
- Updated handling of `ACTION_UP` key events to be delegated to `onDialogKeyUp`.
- Tries to incorporate feedback from the original issue discussion.

### Testing Instructions
---
1. Clone the repository:
   ```bash
   gh repo clone cgoldsby/react-native-tvos
   ```
2. Checkout the branch `modalFix-test`:
   ```bash
   git checkout modalFix-test
   ```
3. Install dependencies:
   ```bash
   yarn
   ```
4. Build and run the project on Android:
   ```bash
   yarn android
   ```

5. Navigate to the "Modal" page in the RNTester app. While a modal is open, pressing up or down on any key (other than back or escape) should log a message in Android Studio's Logcat, confirming that the key events are now correctly propagated to the app's main activity.

---
### Breaking Change

The current implementation handles `ACTION_UP` by delegating to the app's activity `onKeyUp` function. This behavior has been modified. `ACTION_UP` is now delegated to `onDialogKeyUp` instead.

To retain the previous behavior, you can override `onDialogKeyUp` as follows:

```kotlin
override fun onDialogKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
    return this.onKeyUp(keyCode, event)
}
```

This will ensure that `onKeyUp` is still called when the `ACTION_UP` event occurs.

---
### Thank you
Thanks for checking out this PR! 🙌 Any feedback you have would be awesome to make this change even more 🌟. Appreciate your time! 😊
