### PR TITLE
[Release 0.77.0-0rc5] Set RNTester modal background color

### DIFF
--- a/packages/rn-tester/js/examples/Modal/ModalOnShow.js
+++ b/packages/rn-tester/js/examples/Modal/ModalOnShow.js
@@ -145,6 +145,7 @@ const styles = StyleSheet.create({
   },
   modalView: {
     margin: 20,
+    backgroundColor: 'white',
     borderRadius: 20,
     padding: 35,
     alignItems: 'center',


### PR DESCRIPTION
This PR addresses an issue where the Modal background color was not rendering correctly in the 0.77.0-rc5 release candidate of react-native-tvos.

Details

- The issue was reported in [this discussion](https://github.com/react-native-tvos/react-native-tvos/discussions/851#discussioncomment-11733423).

| Before | After |
| - | - |
|![400142328-18adfcd1-beb2-4200-ad8e-d4d29d4995f6](https://github.com/user-attachments/assets/017b619b-b879-4f62-9559-b21bdf4de82c)|![Screenshot_1736187184](https://github.com/user-attachments/assets/680e89d3-cc23-42a2-ac07-88ec9011dd0c)|

