### PR TITLE
fix: allow UIModalPresentationOverFullScreen on transparent Modal

### DIFF
--- a/packages/react-native/React/Base/RCTConvert.mm
+++ b/packages/react-native/React/Base/RCTConvert.mm
@@ -528,17 +528,19 @@ RCT_ENUM_CONVERTER(
     }),
     NSNotFound,
     unsignedIntegerValue)
+#endif
 RCT_ENUM_CONVERTER(
     UIModalPresentationStyle,
     (@{
       @"fullScreen" : @(UIModalPresentationFullScreen),
+#if !TARGET_OS_TV
       @"pageSheet" : @(UIModalPresentationPageSheet),
       @"formSheet" : @(UIModalPresentationFormSheet),
+#endif
       @"overFullScreen" : @(UIModalPresentationOverFullScreen),
     }),
     UIModalPresentationFullScreen,
     integerValue)
-#endif
 
 RCT_ENUM_CONVERTER(
     UIViewContentMode,


### PR DESCRIPTION
Running into the issue that the Modal isn't transparent, like described #831 also.
This fixes that. Android already works like expected.

Without the fix it shows the background:

https://github.com/user-attachments/assets/39c7abe9-b11c-4bbf-9c2e-f32542626486


With the fix the background is transparent, like expected:

https://github.com/user-attachments/assets/9b8a0b60-8bfe-4768-b92a-32f3196d84e5

Code snippet to test:
```tsx
const [showModal, setShowModal] = useState(false);

    return (
      <View style={{ flex: 1 }}>
        <View
          style={{
            flex: 1,
            backgroundColor: 'gray',
            alignItems: 'center',
            justifyContent: 'center',
          }}
        >
          <TouchableHighlight
            style={{
              padding: 10,
            }}
            underlayColor="red"
            onPress={() => setShowModal(true)}
          >
            <Text>Show Modal</Text>
          </TouchableHighlight>
        </View>
        <Modal
          transparent={true}
          visible={showModal}
          onRequestClose={() => {
            setShowModal(false);
          }}
        >
          <View
            style={{
              backgroundColor: 'green',
              width: 200,
              height: 200,
              left: 20,
              top: 20,
              padding: 20,
            }}
          >
            <Text>I'm in a modal</Text>
            <TouchableHighlight
              style={{
                padding: 10,
              }}
              underlayColor="pink"
              onPress={() => setShowModal(true)}
            >
              <Text>Hide Modal</Text>
            </TouchableHighlight>
          </View>
        </Modal>
      </View>
    );
```