### PR TITLE
fix: `disabled` prop - invert condition in Pressability.js event handlers

### DIFF
--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -440,7 +440,7 @@ export default class Pressability {
   _createEventHandlers(): EventHandlers {
     const tvPressEventHandlers = {
       onPressIn: (evt: any): void => {
-        if (this._config.disabled === false) {
+        if (this._config.disabled === true) {
           return;
         }
 
@@ -461,7 +461,7 @@ export default class Pressability {
         }, delayLongPress + delayPressIn);
       },
       onPressOut: (evt: any): void => {
-        if (this._config.disabled === false) {
+        if (this._config.disabled === true) {
           return;
         }
         this._cancelLongPressDelayTimeout();

--- a/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
+++ b/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
@@ -241,6 +241,34 @@ describe('Pressability', () => {
     jest.spyOn(HoverState, 'isHoverEnabled');
   });
 
+  describe('disabled', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns false from onStartShouldSetResponder if disabled is true', () => {
+      const {handlers} = createMockPressability({
+        disabled: true,
+      });
+
+      expect(handlers.onStartShouldSetResponder()).toBe(false);
+    });
+
+    it('prevents press callbacks from being called when disabled is true', () => {
+      const {config, handlers} = createMockPressability({
+        disabled: true,
+      });
+
+      const shouldSetResponder = handlers.onStartShouldSetResponder();
+      expect(shouldSetResponder).toBe(false);
+
+      expect(config.onPressIn).not.toBeCalled();
+      expect(config.onPress).not.toBeCalled();
+      expect(config.onLongPress).not.toBeCalled();
+      expect(config.onPressOut).not.toBeCalled();
+    });
+  });
+
   describe('onBlur', () => {
     it('is called if provided in config', () => {
       const {config, handlers} = createMockPressability();


### PR DESCRIPTION
This PR fixes incorrect handling of the `disabled` prop in the `Pressability` class. The `onPressIn` and `onPressOut` handlers now correctly exit early when `disabled` is set to `true`, ensuring that no unintended interactions occur.

I think this mistake slipped in during the #813 refactor.
