### PR TITLE
fix: [Regression] invert disabled condition in Pressability event handlers and add tests (#856)

### DIFF
--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -439,7 +439,7 @@ export default class Pressability {
   _createEventHandlers(): EventHandlers {
     const tvPressEventHandlers = {
       onPressIn: (evt: any): void => {
-        if (this._config.disabled === false) {
+        if (this._config.disabled === true) {
           return;
         }
 
@@ -460,7 +460,7 @@ export default class Pressability {
         }, delayLongPress + delayPressIn);
       },
       onPressOut: (evt: any): void => {
-        if (this._config.disabled === false) {
+        if (this._config.disabled === true) {
           return;
         }
         this._cancelLongPressDelayTimeout();

--- a/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
+++ b/packages/react-native/Libraries/Pressability/__tests__/Pressability-test.js
@@ -241,6 +241,34 @@ describe('Pressability', () => {
     jest.spyOn(HoverState, 'isHoverEnabled');
   });
 
+  describe('disabled', () => {
+    beforeEach(() => {
+      jest.clearAllMocks();
+    });
+
+    it('returns false from onStartShouldSetResponder if disabled is true', () => {
+      const {handlers} = createMockPressability({
+        disabled: true,
+      });
+
+      expect(handlers.onStartShouldSetResponder()).toBe(false);
+    });
+
+    it('prevents press callbacks from being called when disabled is true', () => {
+      const {config, handlers} = createMockPressability({
+        disabled: true,
+      });
+
+      const shouldSetResponder = handlers.onStartShouldSetResponder();
+      expect(shouldSetResponder).toBe(false);
+
+      expect(config.onPressIn).not.toBeCalled();
+      expect(config.onPress).not.toBeCalled();
+      expect(config.onLongPress).not.toBeCalled();
+      expect(config.onPressOut).not.toBeCalled();
+    });
+  });
+
   describe('onBlur', () => {
     it('is called if provided in config', () => {
       const {config, handlers} = createMockPressability();


### PR DESCRIPTION
#856 is part of the release [0.76.6 release](https://github.com/react-native-tvos/react-native-tvos/releases/tag/v0.76.6-0) but did not make it into 0.77.0. cc: @psysize

```
git cherry-pick 5eb839d958995e0c7a2b48ec07e3ca994af4c09c
```