### PR TITLE
fix: minor typescript fixes

### DIFF
--- a/packages/react-native/Libraries/Components/TV/TVFocusGuideView.js
+++ b/packages/react-native/Libraries/Components/TV/TVFocusGuideView.js
@@ -8,7 +8,6 @@
  * @format
  */
 
-import type {HostComponent} from '../../Renderer/shims/ReactNativeTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
 import type {ComponentOrHandleType} from './tagForComponentOrHandle';
 

--- a/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
+++ b/packages/react-native/Libraries/Components/View/ViewPropTypes.d.ts
@@ -17,6 +17,8 @@ import {
   PointerEvents,
   FocusEvents,
   PressEvents,
+  NativeFocusEvent,
+  NativeBlurEvent,
 } from '../../Types/CoreEventTypes';
 import {Touchable} from '../Touchable/Touchable';
 import {AccessibilityProps} from './ViewAccessibility';
@@ -227,6 +229,6 @@ export interface ViewProps
    */
   experimental_layoutConformance?: 'strict' | 'classic' | undefined;
 
-  readonly onFocus?: BubblingEventHandler<Event> | undefined;
-  readonly onBlur?: BubblingEventHandler<Event> | undefined;
+  readonly onFocus?: BubblingEventHandler<NativeFocusEvent> | undefined;
+  readonly onBlur?: BubblingEventHandler<NativeBlurEvent> | undefined;
 }


### PR DESCRIPTION
## Warning 1
After running the lint task:

```
yarn ; yarn lint

$ eslint .

../react-native-tvos/packages/react-native/Libraries/Components/TV/TVFocusGuideView.js
  11:14  warning  'HostComponent' is defined but never used  no-unused-vars

✖ 1 problem (0 errors, 1 warning)

✨  Done in 9.77s.
````

## Warning 2
This warning is displayed in my private project when I ran `npx tsc`. I've updated the `onBlur` and `onFocus` props to use the native events.
```
node_modules/react-native/Libraries/Components/View/ViewPropTypes.d.ts:130:18 - error TS2430: Interface 'ViewProps' incorrectly extends interface 'FocusEvents'.
  Types of property 'onFocus' are incompatible.
    Type 'BubblingEventHandler<Event>' is not assignable to type '(event: FocusEvent) => void'.
      Types of parameters 'event' and 'event' are incompatible.
        Type 'FocusEvent' is not assignable to type 'NativeSyntheticEvent<Event>'.
          Type 'NativeFocusEvent' is missing the following properties from type 'Event': bubbles, cancelBubble, cancelable, composed, and 17 more.

130 export interface ViewProps
```