### PR TITLE
fix: TVFocusGuide extra onBlur trigger on focus

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -585,7 +585,7 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
       [self handleFocusGuide];
     }
 
-    if (context.nextFocusedView == self && self.isUserInteractionEnabled && ![self isTVFocusGuide]) {
+    if (context.nextFocusedView == self) {
       if(_eventEmitter) _eventEmitter->onFocus();
 
       [self becomeFirstResponder];
@@ -594,7 +594,10 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
           [self addParallaxMotionEffects];
           [self sendFocusNotification:context];
       } completion:^(void){}];
-    } else {
+      // Without this check, onBlur would also trigger when `TVFocusGuideView` transfers focus to its children.
+      // [self isTVFocusGuide] is false when autofocus and destinations are not used, so we cannot use that.
+      // Generally speaking, it would happen for any non-collapsable `View`.
+    } else if (context.previouslyFocusedView == self) {
       if (_eventEmitter) _eventEmitter->onBlur();
 
       [self disableDirectionalFocusGuides];

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -303,7 +303,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     [self handleFocusGuide];
   }
     
-  if (context.nextFocusedView == self && ![self isTVFocusGuide] && self.isTVSelectable ) {
+  if (context.nextFocusedView == self) {
     if (self.onFocus) self.onFocus(nil);
     [self becomeFirstResponder];
     [self enableDirectionalFocusGuides];
@@ -311,7 +311,10 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
       [self addParallaxMotionEffects];
       [self sendFocusNotification:context];
     } completion:^(void){}];
-  } else {
+    // Without this check, onBlur would also trigger when `TVFocusGuideView` transfers focus to its children.
+    // [self isTVFocusGuide] is false when autofocus and destinations are not used, so we cannot use that.
+    // Generally speaking, it would happen for any non-collapsable `View`.
+  } else if (context.previouslyFocusedView == self ) {
     if (self.onBlur) self.onBlur(nil);
     [self disableDirectionalFocusGuides];
     [coordinator addCoordinatedAnimations:^(void){

--- a/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
+++ b/packages/rn-tester/js/examples/TVEventHandler/TVEventHandlerExample.js
@@ -25,6 +25,7 @@ const {
   TouchableNativeFeedback,
   TouchableOpacity,
   TVEventControl,
+  TVFocusGuideView,
 } = ReactNative;
 
 const focusHandler = (event: $FlowFixMe, props: any) => {
@@ -228,6 +229,8 @@ const TVEventHandlerView: () => React.Node = () => {
   const [pressableEventLog, setPressableEventLog] = React.useState<string[]>(
     [],
   );
+  const [isContainerFocused, setIsContainerFocused] =
+    React.useState<boolean>(false);
 
   const textInputRef = React.useRef<any>(undefined);
   const [textInputValue, setTextInputValue] = React.useState<string>('');
@@ -305,8 +308,11 @@ const TVEventHandlerView: () => React.Node = () => {
             />
           ) : null}
         </View>
-        <View
-          style={styles.containerView}
+        <TVFocusGuideView
+          style={[
+            styles.containerView,
+            isContainerFocused ? {backgroundColor: '#cccccc'} : {},
+          ]}
           onBlurCapture={(event: any) => {
             updatePressableLog(
               `Container captured blur event for ${event.nativeEvent.target}`,
@@ -317,16 +323,18 @@ const TVEventHandlerView: () => React.Node = () => {
               `Container captured focus event for ${event.nativeEvent.target}`,
             );
           }}
-          onBlur={(event: any) =>
+          onBlur={(event: any) => {
             updatePressableLog(
               `Container received bubbled blur event from ${event.name} at ${event.nativeEvent.target}`,
-            )
-          }
-          onFocus={(event: any) =>
+            );
+            setIsContainerFocused(false);
+          }}
+          onFocus={(event: any) => {
             updatePressableLog(
               `Container received bubbled focus event from ${event.name} at ${event.nativeEvent?.target}`,
-            )
-          }>
+            );
+            setIsContainerFocused(true);
+          }}>
           <Text style={{fontSize: 12 * scale}}>
             Container receives bubbled events
           </Text>
@@ -339,7 +347,7 @@ const TVEventHandlerView: () => React.Node = () => {
             log={updatePressableLog}
             noBubbledEvents
           />
-        </View>
+        </TVFocusGuideView>
         <View
           style={styles.containerView}
           onFocus={(event: $FlowFixMe) => {


### PR DESCRIPTION
This PR adresses issue #867 after the investigation detailed in the comments. It should probably be backported to 0.76 since the bubbling focus event feature was introduced in this version

## Android TV

<img width="1269" alt="Capture d’écran 2025-02-06 à 18 17 51" src="https://github.com/user-attachments/assets/ebdfb2b3-55b9-474f-aaa8-cfcf3bc7bb73" />

## Apple TV (before fix)

<img width="1174" alt="Capture d’écran 2025-02-06 à 18 12 29" src="https://github.com/user-attachments/assets/14b5ecbb-d7bb-41dc-855f-72a9ce071da8" />

## Apple TV (after fix)

<img width="1174" alt="Capture d’écran 2025-02-06 à 18 08 23" src="https://github.com/user-attachments/assets/2b789581-17ed-4278-b68f-2f3bd54b50e8" />
