### PR TITLE
fix: make hasTVPreferredFocus work properly on the new arch

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -110,6 +110,7 @@ public class ReactViewGroup extends ViewGroup
   private boolean trapFocusDown = false;
   private boolean trapFocusLeft = false;
   private boolean trapFocusRight = false;
+  public boolean hasTVPreferredFocus = false;
 
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -82,6 +82,7 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
     return view
   }
 
+
   @ReactProp(name = "accessible")
   public open fun setAccessible(view: ReactViewGroup, accessible: Boolean) {
     view.isFocusable = accessible
@@ -109,6 +110,17 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
 
   @ReactProp(name = "hasTVPreferredFocus")
   public open fun setTVPreferredFocus(view: ReactViewGroup, hasTVPreferredFocus: Boolean) {
+    /*
+     * React prop functions like this one gets called repeatedly on the New Architecture
+     * no matter the prop has changed or not. Contrary to others, `hasTVPreferredFocus` has
+     * a side effect, calling `requestFocus` function on the view which disrupts the user flow
+     * and should only called once when the property changes to `true.
+     * We keep a special state in the View class and run a comparison here to mitigate
+     * that problem.
+     */
+    if (view.hasTVPreferredFocus == hasTVPreferredFocus) return;
+    view.hasTVPreferredFocus = hasTVPreferredFocus;
+
     if (hasTVPreferredFocus) {
       view.isFocusable = true
       view.isFocusableInTouchMode = true


### PR DESCRIPTION
This PR fixes #759.

## Summary
Apparently, prop setter functions can (and do) get called whether their value actually changed or not. The weird thing is, this property only applies if a given property changes **at least once** after the initial creation of a component. If it never changes after the initial render, it's all good. So, if you set your `hasTVPreferredFocus` to true on a component and never change it on runtime, it's cool, you don't experience the issue. This whole thing feels like a bug and I'd like dive deeper (if I had time) on this one but it seems like the way things really work at the moment.

I applied more of a band-aid to mitigate this issue. I basically keep a "current value" state for `hasTVPreferredFocus` and run a basic conditional on it to understand whether the value actually changed or not.

It seems that, folks at Meta working on a diffing logic for the props on Android. Means that this problem will go away if their work goes past the "experimental" phase. I'm leaving some of the related PRs/code snippets:

https://github.com/facebook/react-native/pull/45397
https://github.com/facebook/react-native/commit/92d79461e9ae93151b3a10256e2ba099f163d74f
https://github.com/facebook/react-native/pull/48303
https://github.com/facebook/react-native/pull/48852
https://github.com/facebook/react-native/blob/main/packages/react-native/ReactAndroid/src/main/jni/react/fabric/FabricMountingManager.cpp#L216