### PR TITLE
Add Android API 22 support to version 0.77

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
+++ b/packages/react-native/ReactAndroid/src/main/AndroidManifest.xml
@@ -8,7 +8,7 @@
    up from the file to lint until it find an AndroidManifest with a minSdkVersion. This is then used
    as the min SDK to lint the file.-->
   <uses-sdk
-      android:minSdkVersion="24"
+      android:minSdkVersion="22"
       android:targetSdkVersion="35"
       />
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -222,7 +222,10 @@ public class ReactActivityDelegate {
   public void requestPermissions(
       String[] permissions, int requestCode, PermissionListener listener) {
     mPermissionListener = listener;
-    getPlainActivity().requestPermissions(permissions, requestCode);
+    // For Android API < 23, permissions are granted at install time.
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      getPlainActivity().requestPermissions(permissions, requestCode);
+    }
   }
 
   public void onRequestPermissionsResult(

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactFragment.java
@@ -9,6 +9,7 @@ package com.facebook.react;
 
 import android.app.Activity;
 import android.content.Intent;
+import android.os.Build;
 import android.os.Bundle;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -213,7 +214,11 @@ public class ReactFragment extends Fragment implements PermissionAwareActivity {
 
   @Override
   public int checkSelfPermission(String permission) {
-    return getActivity().checkSelfPermission(permission);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return getActivity().checkSelfPermission(permission);
+    }
+
+    return getContext().checkPermission(permission, android.os.Process.myPid(), android.os.Process.myUid());
   }
 
   @Override

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/devsupport/DebugOverlayController.java
@@ -13,6 +13,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.graphics.PixelFormat;
 import android.net.Uri;
+import android.os.Build;
 import android.provider.Settings;
 import android.view.WindowManager;
 import android.widget.FrameLayout;
@@ -30,7 +31,7 @@ import com.facebook.react.common.ReactConstants;
 
   public static void requestPermission(Context context) {
     // Get permission to show debug overlay in dev builds.
-    if (!Settings.canDrawOverlays(context)) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && !Settings.canDrawOverlays(context)) {
       Intent intent =
           new Intent(
               Settings.ACTION_MANAGE_OVERLAY_PERMISSION,
@@ -49,7 +50,11 @@ import com.facebook.react.common.ReactConstants;
   private static boolean permissionCheck(Context context) {
     // Get permission to show debug overlay in dev builds.
     // overlay permission not yet granted
-    return Settings.canDrawOverlays(context);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return Settings.canDrawOverlays(context);
+    }
+
+    return true;
   }
 
   private static boolean hasPermission(Context context, String permission) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
@@ -7,7 +7,6 @@
 
 package com.facebook.react.modules.i18nmanager
 
-import android.annotation.TargetApi
 import android.os.Build
 import com.facebook.fbreact.specs.NativeI18nManagerSpec
 import com.facebook.react.bridge.ReactApplicationContext

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/i18nmanager/I18nManagerModule.kt
@@ -7,6 +7,8 @@
 
 package com.facebook.react.modules.i18nmanager
 
+import android.annotation.TargetApi
+import android.os.Build
 import com.facebook.fbreact.specs.NativeI18nManagerSpec
 import com.facebook.react.bridge.ReactApplicationContext
 import com.facebook.react.module.annotations.ReactModule
@@ -16,7 +18,11 @@ import com.facebook.react.module.annotations.ReactModule
 public class I18nManagerModule(context: ReactApplicationContext?) : NativeI18nManagerSpec(context) {
   override public fun getTypedExportedConstants(): Map<String, Any> {
     val context = getReactApplicationContext()
-    val locale = context.resources.configuration.locales[0]
+    val locale = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+      context.resources.configuration.locales[0]
+    } else {
+      context.resources.configuration.locale
+    }
 
     return mapOf(
         "isRTL" to I18nUtil.instance.isRTL(context),

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/BackgroundStyleApplicator.kt
@@ -53,7 +53,7 @@ public object BackgroundStyleApplicator {
   public fun setBackgroundColor(view: View, @ColorInt color: Int?): Unit {
     // No color to set, and no color already set
     if ((color == null || color == Color.TRANSPARENT) &&
-      view.background !is CompositeBackgroundDrawable) {
+        view.background !is CompositeBackgroundDrawable) {
       return
     }
 
@@ -66,8 +66,8 @@ public object BackgroundStyleApplicator {
 
   @JvmStatic
   public fun setBackgroundImage(
-    view: View,
-    backgroundImageLayers: List<BackgroundImageLayer>?
+      view: View,
+      backgroundImageLayers: List<BackgroundImageLayer>?
   ): Unit {
     if (ReactNativeFeatureFlags.enableNewBackgroundAndBorderDrawables()) {
       ensureBackgroundDrawable(view).backgroundImageLayers = backgroundImageLayers
@@ -145,13 +145,13 @@ public object BackgroundStyleApplicator {
 
   @JvmStatic
   public fun setBorderRadius(
-    view: View,
-    corner: BorderRadiusProp,
-    radius: LengthPercentage?
+      view: View,
+      corner: BorderRadiusProp,
+      radius: LengthPercentage?
   ): Unit {
     val compositeBackgroundDrawable = ensureCompositeBackgroundDrawable(view)
     compositeBackgroundDrawable.borderRadius =
-      compositeBackgroundDrawable.borderRadius ?: BorderRadiusStyle()
+        compositeBackgroundDrawable.borderRadius ?: BorderRadiusStyle()
     compositeBackgroundDrawable.borderRadius?.set(corner, radius)
 
     if (ReactNativeFeatureFlags.enableNewBackgroundAndBorderDrawables()) {
@@ -159,7 +159,7 @@ public object BackgroundStyleApplicator {
         ensureBackgroundDrawable(view)
       }
       compositeBackgroundDrawable.background?.borderRadius =
-        compositeBackgroundDrawable.borderRadius
+          compositeBackgroundDrawable.borderRadius
       compositeBackgroundDrawable.border?.borderRadius = compositeBackgroundDrawable.borderRadius
 
       compositeBackgroundDrawable.background?.invalidateSelf()
@@ -170,14 +170,14 @@ public object BackgroundStyleApplicator {
 
     if (Build.VERSION.SDK_INT >= MIN_OUTSET_BOX_SHADOW_SDK_VERSION) {
       for (shadow in
-      compositeBackgroundDrawable.outerShadows.filterIsInstance<OutsetBoxShadowDrawable>()) {
+          compositeBackgroundDrawable.outerShadows.filterIsInstance<OutsetBoxShadowDrawable>()) {
         shadow.borderRadius = compositeBackgroundDrawable.borderRadius
       }
     }
 
     if (Build.VERSION.SDK_INT >= MIN_INSET_BOX_SHADOW_SDK_VERSION) {
       for (shadow in
-      compositeBackgroundDrawable.innerShadows.filterIsInstance<InsetBoxShadowDrawable>()) {
+          compositeBackgroundDrawable.innerShadows.filterIsInstance<InsetBoxShadowDrawable>()) {
         shadow.borderRadius = compositeBackgroundDrawable.borderRadius
       }
     }
@@ -293,31 +293,31 @@ public object BackgroundStyleApplicator {
 
       if (inset && Build.VERSION.SDK_INT >= MIN_INSET_BOX_SHADOW_SDK_VERSION) {
         innerShadows.add(
-          InsetBoxShadowDrawable(
-            context = view.context,
-            borderRadius = borderRadius,
-            borderInsets = borderInsets,
-            shadowColor = color,
-            offsetX = offsetX,
-            offsetY = offsetY,
-            blurRadius = blurRadius,
-            spread = spreadDistance))
+            InsetBoxShadowDrawable(
+                context = view.context,
+                borderRadius = borderRadius,
+                borderInsets = borderInsets,
+                shadowColor = color,
+                offsetX = offsetX,
+                offsetY = offsetY,
+                blurRadius = blurRadius,
+                spread = spreadDistance))
       } else if (!inset && Build.VERSION.SDK_INT >= MIN_OUTSET_BOX_SHADOW_SDK_VERSION) {
         outerShadows.add(
-          OutsetBoxShadowDrawable(
-            context = view.context,
-            borderRadius = borderRadius,
-            shadowColor = color,
-            offsetX = offsetX,
-            offsetY = offsetY,
-            blurRadius = blurRadius,
-            spread = spreadDistance))
+            OutsetBoxShadowDrawable(
+                context = view.context,
+                borderRadius = borderRadius,
+                shadowColor = color,
+                offsetX = offsetX,
+                offsetY = offsetY,
+                blurRadius = blurRadius,
+                spread = spreadDistance))
       }
     }
 
     view.background =
-      ensureCompositeBackgroundDrawable(view)
-        .withNewShadows(outerShadows = outerShadows, innerShadows = innerShadows)
+        ensureCompositeBackgroundDrawable(view)
+            .withNewShadows(outerShadows = outerShadows, innerShadows = innerShadows)
   }
 
   @JvmStatic
@@ -354,22 +354,22 @@ public object BackgroundStyleApplicator {
       val paddingBoxRect = RectF()
 
       val computedBorderInsets =
-        composite.borderInsets?.resolve(composite.layoutDirection, view.context)
+          composite.borderInsets?.resolve(composite.layoutDirection, view.context)
 
       paddingBoxRect.left = composite.bounds.left + (computedBorderInsets?.left?.dpToPx() ?: 0f)
       paddingBoxRect.top = composite.bounds.top + (computedBorderInsets?.top?.dpToPx() ?: 0f)
       paddingBoxRect.right = composite.bounds.right - (computedBorderInsets?.right?.dpToPx() ?: 0f)
       paddingBoxRect.bottom =
-        composite.bounds.bottom - (computedBorderInsets?.bottom?.dpToPx() ?: 0f)
+          composite.bounds.bottom - (computedBorderInsets?.bottom?.dpToPx() ?: 0f)
 
       if (composite.borderRadius?.hasRoundedBorders() == true) {
         val paddingBoxPath =
-          createPaddingBoxPath(
-            view,
-            composite,
-            paddingBoxRect,
-            computedBorderInsets,
-          )
+            createPaddingBoxPath(
+                view,
+                composite,
+                paddingBoxRect,
+                computedBorderInsets,
+            )
 
         paddingBoxPath.offset(drawingRect.left.toFloat(), drawingRect.top.toFloat())
         canvas.clipPath(paddingBoxPath)
@@ -412,13 +412,13 @@ public object BackgroundStyleApplicator {
     }
 
     val compositeDrawable =
-      CompositeBackgroundDrawable(context = view.context, originalBackground = view.background)
+        CompositeBackgroundDrawable(context = view.context, originalBackground = view.background)
     view.background = compositeDrawable
     return compositeDrawable
   }
 
   private fun getCompositeBackgroundDrawable(view: View): CompositeBackgroundDrawable? =
-    view.background as? CompositeBackgroundDrawable
+      view.background as? CompositeBackgroundDrawable
 
   private fun ensureCSSBackground(view: View): CSSBackgroundDrawable {
     val compositeBackgroundDrawable = ensureCompositeBackgroundDrawable(view)
@@ -441,20 +441,20 @@ public object BackgroundStyleApplicator {
       background
     } else {
       background =
-        BackgroundDrawable(
-          view.context,
-          compositeBackgroundDrawable.borderRadius,
-          compositeBackgroundDrawable.borderInsets)
+          BackgroundDrawable(
+              view.context,
+              compositeBackgroundDrawable.borderRadius,
+              compositeBackgroundDrawable.borderInsets)
       view.background = compositeBackgroundDrawable.withNewBackground(background)
       background
     }
   }
 
   private fun getCSSBackground(view: View): CSSBackgroundDrawable? =
-    getCompositeBackgroundDrawable(view)?.cssBackground
+      getCompositeBackgroundDrawable(view)?.cssBackground
 
   private fun getBackground(view: View): BackgroundDrawable? =
-    getCompositeBackgroundDrawable(view)?.background
+      getCompositeBackgroundDrawable(view)?.background
 
   private fun getBorder(view: View): BorderDrawable? = getCompositeBackgroundDrawable(view)?.border
 
@@ -463,13 +463,13 @@ public object BackgroundStyleApplicator {
     var border = compositeBackgroundDrawable.border
     if (border == null) {
       border =
-        BorderDrawable(
-          context = view.context,
-          borderRadius = compositeBackgroundDrawable.borderRadius,
-          borderWidth = Spacing(0f),
-          borderStyle = BorderStyle.SOLID,
-          borderInsets = compositeBackgroundDrawable.borderInsets,
-        )
+          BorderDrawable(
+              context = view.context,
+              borderRadius = compositeBackgroundDrawable.borderRadius,
+              borderWidth = Spacing(0f),
+              borderStyle = BorderStyle.SOLID,
+              borderInsets = compositeBackgroundDrawable.borderInsets,
+          )
       view.background = compositeBackgroundDrawable.withNewBorder(border)
     }
 
@@ -481,21 +481,21 @@ public object BackgroundStyleApplicator {
     var outline = compositeBackgroundDrawable.outline
     if (outline == null) {
       val borderRadius =
-        if (ReactNativeFeatureFlags.enableNewBackgroundAndBorderDrawables()) {
-          compositeBackgroundDrawable.borderRadius
-        } else {
-          ensureCSSBackground(view).borderRadius
-        }
+          if (ReactNativeFeatureFlags.enableNewBackgroundAndBorderDrawables()) {
+            compositeBackgroundDrawable.borderRadius
+          } else {
+            ensureCSSBackground(view).borderRadius
+          }
 
       outline =
-        OutlineDrawable(
-          context = view.context,
-          borderRadius = borderRadius,
-          outlineColor = Color.BLACK,
-          outlineOffset = 0f,
-          outlineStyle = OutlineStyle.SOLID,
-          outlineWidth = 0f,
-        )
+          OutlineDrawable(
+              context = view.context,
+              borderRadius = borderRadius,
+              outlineColor = Color.BLACK,
+              outlineOffset = 0f,
+              outlineStyle = OutlineStyle.SOLID,
+              outlineWidth = 0f,
+          )
 
       view.background = compositeBackgroundDrawable.withNewOutline(outline)
     }
@@ -504,7 +504,7 @@ public object BackgroundStyleApplicator {
   }
 
   private fun getOutlineDrawable(view: View): OutlineDrawable? =
-    getCompositeBackgroundDrawable(view)?.outline
+      getCompositeBackgroundDrawable(view)?.outline
 
   /**
    * Here, "inner" refers to the border radius on the inside of the border. So it ends up being the
@@ -515,65 +515,65 @@ public object BackgroundStyleApplicator {
   }
 
   private fun createPaddingBoxPath(
-    view: View,
-    composite: CompositeBackgroundDrawable,
-    paddingBoxRect: RectF,
-    computedBorderInsets: RectF?
+      view: View,
+      composite: CompositeBackgroundDrawable,
+      paddingBoxRect: RectF,
+      computedBorderInsets: RectF?
   ): Path {
     val computedBorderRadius =
-      composite.borderRadius?.resolve(
-        composite.layoutDirection,
-        view.context,
-        PixelUtil.toDIPFromPixel(composite.bounds.width().toFloat()),
-        PixelUtil.toDIPFromPixel(composite.bounds.height().toFloat()),
-      )
+        composite.borderRadius?.resolve(
+            composite.layoutDirection,
+            view.context,
+            PixelUtil.toDIPFromPixel(composite.bounds.width().toFloat()),
+            PixelUtil.toDIPFromPixel(composite.bounds.height().toFloat()),
+        )
 
     val paddingBoxPath = Path()
 
     val innerTopLeftRadiusX =
-      getInnerBorderRadius(
-        computedBorderRadius?.topLeft?.horizontal?.dpToPx(),
-        computedBorderInsets?.left?.dpToPx())
+        getInnerBorderRadius(
+            computedBorderRadius?.topLeft?.horizontal?.dpToPx(),
+            computedBorderInsets?.left?.dpToPx())
     val innerTopLeftRadiusY =
-      getInnerBorderRadius(
-        computedBorderRadius?.topLeft?.vertical?.dpToPx(), computedBorderInsets?.top?.dpToPx())
+        getInnerBorderRadius(
+            computedBorderRadius?.topLeft?.vertical?.dpToPx(), computedBorderInsets?.top?.dpToPx())
     val innerTopRightRadiusX =
-      getInnerBorderRadius(
-        computedBorderRadius?.topRight?.horizontal?.dpToPx(),
-        computedBorderInsets?.right?.dpToPx())
+        getInnerBorderRadius(
+            computedBorderRadius?.topRight?.horizontal?.dpToPx(),
+            computedBorderInsets?.right?.dpToPx())
     val innerTopRightRadiusY =
-      getInnerBorderRadius(
-        computedBorderRadius?.topRight?.vertical?.dpToPx(), computedBorderInsets?.top?.dpToPx())
+        getInnerBorderRadius(
+            computedBorderRadius?.topRight?.vertical?.dpToPx(), computedBorderInsets?.top?.dpToPx())
     val innerBottomRightRadiusX =
-      getInnerBorderRadius(
-        computedBorderRadius?.bottomRight?.horizontal?.dpToPx(),
-        computedBorderInsets?.right?.dpToPx())
+        getInnerBorderRadius(
+            computedBorderRadius?.bottomRight?.horizontal?.dpToPx(),
+            computedBorderInsets?.right?.dpToPx())
     val innerBottomRightRadiusY =
-      getInnerBorderRadius(
-        computedBorderRadius?.bottomRight?.vertical?.dpToPx(),
-        computedBorderInsets?.bottom?.dpToPx())
+        getInnerBorderRadius(
+            computedBorderRadius?.bottomRight?.vertical?.dpToPx(),
+            computedBorderInsets?.bottom?.dpToPx())
     val innerBottomLeftRadiusX =
-      getInnerBorderRadius(
-        computedBorderRadius?.bottomLeft?.horizontal?.dpToPx(),
-        computedBorderInsets?.left?.dpToPx())
+        getInnerBorderRadius(
+            computedBorderRadius?.bottomLeft?.horizontal?.dpToPx(),
+            computedBorderInsets?.left?.dpToPx())
     val innerBottomLeftRadiusY =
-      getInnerBorderRadius(
-        computedBorderRadius?.bottomLeft?.vertical?.dpToPx(),
-        computedBorderInsets?.bottom?.dpToPx())
+        getInnerBorderRadius(
+            computedBorderRadius?.bottomLeft?.vertical?.dpToPx(),
+            computedBorderInsets?.bottom?.dpToPx())
 
     paddingBoxPath.addRoundRect(
-      paddingBoxRect,
-      floatArrayOf(
-        innerTopLeftRadiusX,
-        innerTopLeftRadiusY,
-        innerTopRightRadiusX,
-        innerTopRightRadiusY,
-        innerBottomRightRadiusX,
-        innerBottomRightRadiusY,
-        innerBottomLeftRadiusX,
-        innerBottomLeftRadiusY,
-      ),
-      Path.Direction.CW)
+        paddingBoxRect,
+        floatArrayOf(
+            innerTopLeftRadiusX,
+            innerTopLeftRadiusY,
+            innerTopRightRadiusX,
+            innerTopRightRadiusY,
+            innerBottomRightRadiusX,
+            innerBottomRightRadiusY,
+            innerBottomLeftRadiusX,
+            innerBottomLeftRadiusY,
+        ),
+        Path.Direction.CW)
     return paddingBoxPath
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -229,7 +229,7 @@ public class UIManagerModuleConstantsHelper {
         // Since event maps are client based Map interface, it could be immutable
         if (!(destValue instanceof HashMap)) {
           destValue = new HashMap((Map) destValue);
-          dest.replace(key, (Map) destValue);
+          dest.put(key, (Map) destValue);
         }
         recursiveMerge((Map) destValue, (Map) sourceValue);
       } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/UIManagerModuleConstantsHelper.java
@@ -229,7 +229,7 @@ public class UIManagerModuleConstantsHelper {
         // Since event maps are client based Map interface, it could be immutable
         if (!(destValue instanceof HashMap)) {
           destValue = new HashMap((Map) destValue);
-          dest.put(key, (Map) destValue);
+          dest.replace(key, (Map) destValue);
         }
         recursiveMerge((Map) destValue, (Map) sourceValue);
       } else {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BackgroundDrawable.kt
@@ -19,7 +19,6 @@ import android.graphics.PorterDuff
 import android.graphics.Rect
 import android.graphics.RectF
 import android.graphics.Shader
-import android.graphics.drawable.Drawable
 import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.style.BackgroundImageLayer

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/BorderDrawable.kt
@@ -20,7 +20,6 @@ import android.graphics.PointF
 import android.graphics.Rect
 import android.graphics.RectF
 import android.graphics.Region
-import android.graphics.drawable.Drawable
 import android.os.Build
 import com.facebook.react.uimanager.FloatUtil.floatsEqual
 import com.facebook.react.uimanager.LengthPercentage

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CSSBackgroundDrawable.java
@@ -25,7 +25,6 @@ import android.graphics.Rect;
 import android.graphics.RectF;
 import android.graphics.Region;
 import android.graphics.Shader;
-import android.graphics.drawable.Drawable;
 import android.view.View;
 import androidx.annotation.Nullable;
 import androidx.core.graphics.ColorUtils;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
@@ -25,55 +25,55 @@ import com.facebook.react.uimanager.style.BorderRadiusStyle
  */
 @OptIn(UnstableReactNativeAPI::class)
 internal class CompositeBackgroundDrawable(
-  private val context: Context,
-  /**
-   * Any non-react-managed background already part of the view, like one set as Android style on a
-   * TextInput
-   */
-  val originalBackground: Drawable? = null,
+    private val context: Context,
+    /**
+     * Any non-react-managed background already part of the view, like one set as Android style on a
+     * TextInput
+     */
+    val originalBackground: Drawable? = null,
 
-  /** Non-inset box shadows */
-  val outerShadows: List<Drawable> = emptyList(),
+    /** Non-inset box shadows */
+    val outerShadows: List<Drawable> = emptyList(),
 
-  /**
-   * CSS background layer and border rendering
-   *
-   * TODO: we should extract path logic from here, and fast-path to using simpler drawables like
-   *   ColorDrawable in the common cases
-   */
-  val cssBackground: CSSBackgroundDrawable? = null,
+    /**
+     * CSS background layer and border rendering
+     *
+     * TODO: we should extract path logic from here, and fast-path to using simpler drawables like
+     *   ColorDrawable in the common cases
+     */
+    val cssBackground: CSSBackgroundDrawable? = null,
 
-  /** Background rendering Layer */
-  val background: BackgroundDrawable? = null,
+    /** Background rendering Layer */
+    val background: BackgroundDrawable? = null,
 
-  /** Border rendering Layer */
-  val border: BorderDrawable? = null,
+    /** Border rendering Layer */
+    val border: BorderDrawable? = null,
 
-  /** TouchableNativeFeeback set selection background, like "SelectableBackground" */
-  val feedbackUnderlay: Drawable? = null,
+    /** TouchableNativeFeeback set selection background, like "SelectableBackground" */
+    val feedbackUnderlay: Drawable? = null,
 
-  /** Inset box-shadows */
-  val innerShadows: List<Drawable> = emptyList(),
+    /** Inset box-shadows */
+    val innerShadows: List<Drawable> = emptyList(),
 
-  /** Outline */
-  val outline: OutlineDrawable? = null,
+    /** Outline */
+    val outline: OutlineDrawable? = null,
 
-  // Holder value for currently set insets
-  var borderInsets: BorderInsets? = null,
+    // Holder value for currently set insets
+    var borderInsets: BorderInsets? = null,
 
-  // Holder value for currently set border radius
-  var borderRadius: BorderRadiusStyle? = null,
+    // Holder value for currently set border radius
+    var borderRadius: BorderRadiusStyle? = null,
 ) :
   com.facebook.react.uimanager.drawable.LayerDrawable(
-    createLayersArray(
-      originalBackground,
-      outerShadows,
-      cssBackground,
-      background,
-      border,
-      feedbackUnderlay,
-      innerShadows,
-      outline)) {
+        createLayersArray(
+            originalBackground,
+            outerShadows,
+            cssBackground,
+            background,
+            border,
+            feedbackUnderlay,
+            innerShadows,
+            outline)) {
 
   init {
     // We want to overlay drawables, instead of placing future drawables within the content area of
@@ -84,100 +84,100 @@ internal class CompositeBackgroundDrawable(
 
   fun withNewCssBackground(cssBackground: CSSBackgroundDrawable?): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
-      context,
-      originalBackground,
-      outerShadows,
-      cssBackground,
-      background,
-      border,
-      feedbackUnderlay,
-      innerShadows,
-      outline,
-      borderInsets,
-      borderRadius,
+        context,
+        originalBackground,
+        outerShadows,
+        cssBackground,
+        background,
+        border,
+        feedbackUnderlay,
+        innerShadows,
+        outline,
+        borderInsets,
+        borderRadius,
     )
   }
 
   fun withNewBackground(background: BackgroundDrawable?): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
-      context,
-      originalBackground,
-      outerShadows,
-      cssBackground,
-      background,
-      border,
-      feedbackUnderlay,
-      innerShadows,
-      outline,
-      borderInsets,
-      borderRadius,
+        context,
+        originalBackground,
+        outerShadows,
+        cssBackground,
+        background,
+        border,
+        feedbackUnderlay,
+        innerShadows,
+        outline,
+        borderInsets,
+        borderRadius,
     )
   }
 
   fun withNewShadows(
-    outerShadows: List<Drawable>,
-    innerShadows: List<Drawable>
+      outerShadows: List<Drawable>,
+      innerShadows: List<Drawable>
   ): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
-      context,
-      originalBackground,
-      outerShadows,
-      cssBackground,
-      background,
-      border,
-      feedbackUnderlay,
-      innerShadows,
-      outline,
-      borderInsets,
-      borderRadius,
+        context,
+        originalBackground,
+        outerShadows,
+        cssBackground,
+        background,
+        border,
+        feedbackUnderlay,
+        innerShadows,
+        outline,
+        borderInsets,
+        borderRadius,
     )
   }
 
   fun withNewBorder(border: BorderDrawable): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
-      context,
-      originalBackground,
-      outerShadows,
-      cssBackground,
-      background,
-      border,
-      feedbackUnderlay,
-      innerShadows,
-      outline,
-      borderInsets,
-      borderRadius,
+        context,
+        originalBackground,
+        outerShadows,
+        cssBackground,
+        background,
+        border,
+        feedbackUnderlay,
+        innerShadows,
+        outline,
+        borderInsets,
+        borderRadius,
     )
   }
 
   fun withNewOutline(outline: OutlineDrawable): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
-      context,
-      originalBackground,
-      outerShadows,
-      cssBackground,
-      background,
-      border,
-      feedbackUnderlay,
-      innerShadows,
-      outline,
-      borderInsets,
-      borderRadius,
+        context,
+        originalBackground,
+        outerShadows,
+        cssBackground,
+        background,
+        border,
+        feedbackUnderlay,
+        innerShadows,
+        outline,
+        borderInsets,
+        borderRadius,
     )
   }
 
   fun withNewFeedbackUnderlay(newUnderlay: Drawable?): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
-      context,
-      originalBackground,
-      outerShadows,
-      cssBackground,
-      background,
-      border,
-      newUnderlay,
-      innerShadows,
-      outline,
-      borderInsets,
-      borderRadius,
+        context,
+        originalBackground,
+        outerShadows,
+        cssBackground,
+        background,
+        border,
+        newUnderlay,
+        innerShadows,
+        outline,
+        borderInsets,
+        borderRadius,
     )
   }
 
@@ -188,24 +188,24 @@ internal class CompositeBackgroundDrawable(
       val pathForOutline = Path()
 
       val computedBorderRadius =
-        borderRadius?.resolve(
-          layoutDirection, context, bounds.width().toFloat(), bounds.height().toFloat())
+          borderRadius?.resolve(
+              layoutDirection, context, bounds.width().toFloat(), bounds.height().toFloat())
 
       val computedBorderInsets = borderInsets?.resolve(layoutDirection, context)
 
       computedBorderRadius?.let {
         pathForOutline.addRoundRect(
-          RectF(bounds),
-          floatArrayOf(
-            (it.topLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
-            (it.topLeft.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
-            (it.topRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
-            (it.topRight.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
-            (it.bottomRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
-            (it.bottomRight.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx(),
-            (it.bottomLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
-            (it.bottomLeft.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx()),
-          Path.Direction.CW)
+            RectF(bounds),
+            floatArrayOf(
+                (it.topLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
+                (it.topLeft.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
+                (it.topRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
+                (it.topRight.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
+                (it.bottomRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
+                (it.bottomRight.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx(),
+                (it.bottomLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
+                (it.bottomLeft.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx()),
+            Path.Direction.CW)
       }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -220,14 +220,14 @@ internal class CompositeBackgroundDrawable(
 
   companion object {
     private fun createLayersArray(
-      originalBackground: Drawable?,
-      outerShadows: List<Drawable>,
-      cssBackground: CSSBackgroundDrawable?,
-      background: BackgroundDrawable?,
-      border: BorderDrawable?,
-      feedbackUnderlay: Drawable?,
-      innerShadows: List<Drawable>,
-      outline: OutlineDrawable?
+        originalBackground: Drawable?,
+        outerShadows: List<Drawable>,
+        cssBackground: CSSBackgroundDrawable?,
+        background: BackgroundDrawable?,
+        border: BorderDrawable?,
+        feedbackUnderlay: Drawable?,
+        innerShadows: List<Drawable>,
+        outline: OutlineDrawable?
     ): Array<Drawable?> {
       val layers = mutableListOf<Drawable?>()
       originalBackground?.let { layers.add(it) }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/CompositeBackgroundDrawable.kt
@@ -15,7 +15,6 @@ import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import android.os.Build
 import com.facebook.react.common.annotations.UnstableReactNativeAPI
-import com.facebook.react.internal.featureflags.ReactNativeFeatureFlags
 import com.facebook.react.uimanager.PixelUtil.dpToPx
 import com.facebook.react.uimanager.style.BorderInsets
 import com.facebook.react.uimanager.style.BorderRadiusStyle
@@ -26,163 +25,160 @@ import com.facebook.react.uimanager.style.BorderRadiusStyle
  */
 @OptIn(UnstableReactNativeAPI::class)
 internal class CompositeBackgroundDrawable(
-    private val context: Context,
-    /**
-     * Any non-react-managed background already part of the view, like one set as Android style on a
-     * TextInput
-     */
-    public val originalBackground: Drawable? = null,
+  private val context: Context,
+  /**
+   * Any non-react-managed background already part of the view, like one set as Android style on a
+   * TextInput
+   */
+  val originalBackground: Drawable? = null,
 
-    /** Non-inset box shadows */
-    outerShadows: LayerDrawable? = null,
+  /** Non-inset box shadows */
+  val outerShadows: List<Drawable> = emptyList(),
 
-    /**
-     * CSS background layer and border rendering
-     *
-     * TODO: we should extract path logic from here, and fast-path to using simpler drawables like
-     *   ColorDrawable in the common cases
-     */
-    public val cssBackground: CSSBackgroundDrawable? = null,
+  /**
+   * CSS background layer and border rendering
+   *
+   * TODO: we should extract path logic from here, and fast-path to using simpler drawables like
+   *   ColorDrawable in the common cases
+   */
+  val cssBackground: CSSBackgroundDrawable? = null,
 
-    /** Background rendering Layer */
-    background: BackgroundDrawable? = null,
+  /** Background rendering Layer */
+  val background: BackgroundDrawable? = null,
 
-    /** Border rendering Layer */
-    border: BorderDrawable? = null,
+  /** Border rendering Layer */
+  val border: BorderDrawable? = null,
 
-    /** TouchableNativeFeeback set selection background, like "SelectableBackground" */
-    feedbackUnderlay: Drawable? = null,
+  /** TouchableNativeFeeback set selection background, like "SelectableBackground" */
+  val feedbackUnderlay: Drawable? = null,
 
-    /** Inset box-shadows */
-    innerShadows: LayerDrawable? = null,
+  /** Inset box-shadows */
+  val innerShadows: List<Drawable> = emptyList(),
 
-    /** Outline */
-    outline: OutlineDrawable? = null,
-) : LayerDrawable(emptyArray()) {
-  public var outerShadows: LayerDrawable? = outerShadows
-    private set
-
-  public var background: BackgroundDrawable? = background
-    private set
-
-  public var border: BorderDrawable? = border
-    private set
-
-  public var feedbackUnderlay: Drawable? = feedbackUnderlay
-    private set
-
-  public var innerShadows: LayerDrawable? = innerShadows
-    private set
-
-  public var outline: OutlineDrawable? = outline
-    private set
+  /** Outline */
+  val outline: OutlineDrawable? = null,
 
   // Holder value for currently set insets
-  public var borderInsets: BorderInsets? = null
+  var borderInsets: BorderInsets? = null,
 
   // Holder value for currently set border radius
-  public var borderRadius: BorderRadiusStyle? = null
+  var borderRadius: BorderRadiusStyle? = null,
+) :
+  com.facebook.react.uimanager.drawable.LayerDrawable(
+    createLayersArray(
+      originalBackground,
+      outerShadows,
+      cssBackground,
+      background,
+      border,
+      feedbackUnderlay,
+      innerShadows,
+      outline)) {
 
   init {
     // We want to overlay drawables, instead of placing future drawables within the content area of
     // previous ones. E.g. an EditText style may set padding on a TextInput, but we don't want to
     // constrain background color to the area inside of the padding.
     setPaddingMode(LayerDrawable.PADDING_MODE_STACK)
-
-    addLayer(originalBackground, ORIGINAL_BACKGROUND_ID)
-    addLayer(outerShadows, OUTER_SHADOWS_ID)
-    addLayer(cssBackground, CSS_BACKGROUND_ID)
-    addLayer(background, BACKGROUND_ID)
-    addLayer(border, BORDER_ID)
-    addLayer(feedbackUnderlay, FEEDBACK_UNDERLAY_ID)
-    addLayer(innerShadows, INNER_SHADOWS_ID)
-    addLayer(outline, OUTLINE_ID)
   }
 
-  public fun withNewCssBackground(
-      cssBackground: CSSBackgroundDrawable?
+  fun withNewCssBackground(cssBackground: CSSBackgroundDrawable?): CompositeBackgroundDrawable {
+    return CompositeBackgroundDrawable(
+      context,
+      originalBackground,
+      outerShadows,
+      cssBackground,
+      background,
+      border,
+      feedbackUnderlay,
+      innerShadows,
+      outline,
+      borderInsets,
+      borderRadius,
+    )
+  }
+
+  fun withNewBackground(background: BackgroundDrawable?): CompositeBackgroundDrawable {
+    return CompositeBackgroundDrawable(
+      context,
+      originalBackground,
+      outerShadows,
+      cssBackground,
+      background,
+      border,
+      feedbackUnderlay,
+      innerShadows,
+      outline,
+      borderInsets,
+      borderRadius,
+    )
+  }
+
+  fun withNewShadows(
+    outerShadows: List<Drawable>,
+    innerShadows: List<Drawable>
   ): CompositeBackgroundDrawable {
     return CompositeBackgroundDrawable(
-            context,
-            originalBackground,
-            outerShadows,
-            cssBackground,
-            background,
-            border,
-            feedbackUnderlay,
-            innerShadows,
-            outline)
-        .also { composite ->
-          composite.borderInsets = this.borderInsets
-          composite.borderRadius = this.borderRadius
-        }
+      context,
+      originalBackground,
+      outerShadows,
+      cssBackground,
+      background,
+      border,
+      feedbackUnderlay,
+      innerShadows,
+      outline,
+      borderInsets,
+      borderRadius,
+    )
   }
 
-  public fun withNewOuterShadow(outerShadows: LayerDrawable?): CompositeBackgroundDrawable =
-      withNewLayer(outerShadows, OUTER_SHADOWS_ID, this::outerShadows::set)
-
-  public fun withNewBackground(background: BackgroundDrawable?): CompositeBackgroundDrawable =
-      withNewLayer(background, BACKGROUND_ID, this::background::set)
-
-  public fun withNewBorder(border: BorderDrawable?): CompositeBackgroundDrawable =
-      withNewLayer(border, BORDER_ID, this::border::set)
-
-  public fun withNewFeedbackUnderlay(newUnderlay: Drawable?): CompositeBackgroundDrawable =
-      withNewLayer(newUnderlay, FEEDBACK_UNDERLAY_ID, this::feedbackUnderlay::set)
-
-  public fun withNewInnerShadow(innerShadows: LayerDrawable?): CompositeBackgroundDrawable =
-      withNewLayer(innerShadows, INNER_SHADOWS_ID, this::innerShadows::set)
-
-  public fun withNewOutline(outline: OutlineDrawable?): CompositeBackgroundDrawable =
-      withNewLayer(outline, OUTLINE_ID, this::outline::set)
-
-  /** @return true if the layer was updated, false if it was not */
-  private fun updateLayer(layer: Drawable?, id: Int): Boolean {
-    if (layer == null) {
-      return findDrawableByLayerId(id) == null
-    }
-
-    if (findDrawableByLayerId(id) == null) {
-      insertNewLayer(layer, id)
-    } else {
-      setDrawableByLayerId(id, layer)
-    }
-    invalidateSelf()
-    return true
+  fun withNewBorder(border: BorderDrawable): CompositeBackgroundDrawable {
+    return CompositeBackgroundDrawable(
+      context,
+      originalBackground,
+      outerShadows,
+      cssBackground,
+      background,
+      border,
+      feedbackUnderlay,
+      innerShadows,
+      outline,
+      borderInsets,
+      borderRadius,
+    )
   }
 
-  private fun insertNewLayer(layer: Drawable?, id: Int) {
-    layer ?: return
-
-    if (numberOfLayers == 0) {
-      addLayer(layer, id)
-      return
-    }
-
-    for (i in 0..<numberOfLayers) {
-      if (id < getId(i)) {
-        val tempDrawable: Drawable = getDrawable(i)
-        val tempId = getId(i)
-        setDrawable(i, layer)
-        setId(i, id)
-        insertNewLayer(tempDrawable, tempId)
-        return
-      } else if (i == numberOfLayers - 1) {
-        addLayer(layer, id)
-        return
-      }
-    }
+  fun withNewOutline(outline: OutlineDrawable): CompositeBackgroundDrawable {
+    return CompositeBackgroundDrawable(
+      context,
+      originalBackground,
+      outerShadows,
+      cssBackground,
+      background,
+      border,
+      feedbackUnderlay,
+      innerShadows,
+      outline,
+      borderInsets,
+      borderRadius,
+    )
   }
 
-  private fun addLayer(layer: Drawable?, id: Int) {
-    if (layer == null) {
-      return
-    }
-
-    addLayer(layer)
-    layer.callback = this
-    setId(numberOfLayers - 1, id)
-    invalidateSelf()
+  fun withNewFeedbackUnderlay(newUnderlay: Drawable?): CompositeBackgroundDrawable {
+    return CompositeBackgroundDrawable(
+      context,
+      originalBackground,
+      outerShadows,
+      cssBackground,
+      background,
+      border,
+      newUnderlay,
+      innerShadows,
+      outline,
+      borderInsets,
+      borderRadius,
+    )
   }
 
   /* Android's elevation implementation requires this to be implemented to know where to draw the
@@ -192,24 +188,24 @@ internal class CompositeBackgroundDrawable(
       val pathForOutline = Path()
 
       val computedBorderRadius =
-          borderRadius?.resolve(
-              layoutDirection, context, bounds.width().toFloat(), bounds.height().toFloat())
+        borderRadius?.resolve(
+          layoutDirection, context, bounds.width().toFloat(), bounds.height().toFloat())
 
       val computedBorderInsets = borderInsets?.resolve(layoutDirection, context)
 
       computedBorderRadius?.let {
         pathForOutline.addRoundRect(
-            RectF(bounds),
-            floatArrayOf(
-                (it.topLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
-                (it.topLeft.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
-                (it.topRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
-                (it.topRight.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
-                (it.bottomRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
-                (it.bottomRight.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx(),
-                (it.bottomLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
-                (it.bottomLeft.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx()),
-            Path.Direction.CW)
+          RectF(bounds),
+          floatArrayOf(
+            (it.topLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
+            (it.topLeft.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
+            (it.topRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
+            (it.topRight.vertical + (computedBorderInsets?.top ?: 0f)).dpToPx(),
+            (it.bottomRight.horizontal + (computedBorderInsets?.right ?: 0f)).dpToPx(),
+            (it.bottomRight.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx(),
+            (it.bottomLeft.horizontal + (computedBorderInsets?.left ?: 0f)).dpToPx(),
+            (it.bottomLeft.vertical + (computedBorderInsets?.bottom ?: 0f)).dpToPx()),
+          Path.Direction.CW)
       }
 
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -222,41 +218,27 @@ internal class CompositeBackgroundDrawable(
     }
   }
 
-  private fun <T> withNewLayer(
-      newLayer: T,
-      id: Int,
-      setNewLayer: (T) -> Unit,
-  ): CompositeBackgroundDrawable where T : Drawable? {
-    setNewLayer(newLayer)
-    if (ReactNativeFeatureFlags.enableNewBackgroundAndBorderDrawables()) {
-      if (updateLayer(newLayer, id)) {
-        return this
-      }
+  companion object {
+    private fun createLayersArray(
+      originalBackground: Drawable?,
+      outerShadows: List<Drawable>,
+      cssBackground: CSSBackgroundDrawable?,
+      background: BackgroundDrawable?,
+      border: BorderDrawable?,
+      feedbackUnderlay: Drawable?,
+      innerShadows: List<Drawable>,
+      outline: OutlineDrawable?
+    ): Array<Drawable?> {
+      val layers = mutableListOf<Drawable?>()
+      originalBackground?.let { layers.add(it) }
+      layers.addAll(outerShadows.asReversed())
+      cssBackground?.let { layers.add(it) }
+      background?.let { layers.add(it) }
+      border?.let { layers.add(it) }
+      feedbackUnderlay?.let { layers.add(it) }
+      layers.addAll(innerShadows.asReversed())
+      outline?.let { layers.add(it) }
+      return layers.toTypedArray()
     }
-    return CompositeBackgroundDrawable(
-            context,
-            originalBackground,
-            outerShadows,
-            cssBackground,
-            background,
-            border,
-            feedbackUnderlay,
-            innerShadows,
-            outline)
-        .also { composite ->
-          composite.borderInsets = this.borderInsets
-          composite.borderRadius = this.borderRadius
-        }
-  }
-
-  private companion object {
-    private const val ORIGINAL_BACKGROUND_ID: Int = 0
-    private const val OUTER_SHADOWS_ID: Int = 1
-    private const val CSS_BACKGROUND_ID: Int = 2
-    private const val BACKGROUND_ID: Int = 3
-    private const val BORDER_ID: Int = 4
-    private const val FEEDBACK_UNDERLAY_ID: Int = 5
-    private const val INNER_SHADOWS_ID: Int = 6
-    private const val OUTLINE_ID: Int = 7
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/Drawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/Drawable.kt
@@ -1,0 +1,17 @@
+package com.facebook.react.uimanager.drawable
+
+import android.annotation.TargetApi
+import android.graphics.drawable.Drawable
+import android.os.Build
+import android.view.View
+
+internal abstract class Drawable: Drawable() {
+  @TargetApi(Build.VERSION_CODES.M)
+  override fun getLayoutDirection(): Int {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return super.getLayoutDirection()
+    }
+
+    return View.LAYOUT_DIRECTION_LTR;
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/LayerDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/LayerDrawable.kt
@@ -1,0 +1,19 @@
+package com.facebook.react.uimanager.drawable
+
+import android.annotation.TargetApi
+import android.graphics.drawable.Drawable
+import android.graphics.drawable.LayerDrawable
+import android.os.Build
+import android.view.View
+
+
+internal abstract class LayerDrawable(layers: Array<Drawable?>) : LayerDrawable(layers) {
+  @TargetApi(Build.VERSION_CODES.M)
+  override fun getLayoutDirection(): Int {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      return super.getLayoutDirection()
+    }
+
+    return View.LAYOUT_DIRECTION_LTR;
+  }
+}

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutlineDrawable.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/uimanager/drawable/OutlineDrawable.kt
@@ -17,7 +17,6 @@ import android.graphics.Path
 import android.graphics.PathEffect
 import android.graphics.PixelFormat
 import android.graphics.RectF
-import android.graphics.drawable.Drawable
 import com.facebook.react.uimanager.PixelUtil.pxToDp
 import com.facebook.react.uimanager.style.BorderRadiusStyle
 import com.facebook.react.uimanager.style.ComputedBorderRadius

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -337,7 +337,7 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
   protected int mHyphenationFrequency =
     (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? Layout.BREAK_STRATEGY_SIMPLE : Layout.HYPHENATION_FREQUENCY_NONE;
   protected int mJustificationMode =
-      (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? Layout.BREAK_STRATEGY_SIMPLE : Layout.JUSTIFICATION_MODE_NONE;
+      (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? 0 : Layout.JUSTIFICATION_MODE_NONE;
 
   protected float mTextShadowOffsetDx = 0;
   protected float mTextShadowOffsetDy = 0;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactBaseTextShadowNode.java
@@ -7,6 +7,7 @@
 
 package com.facebook.react.views.text;
 
+import android.annotation.TargetApi;
 import android.graphics.Color;
 import android.graphics.Typeface;
 import android.os.Build;
@@ -66,6 +67,7 @@ import java.util.Map;
  * <p>This also node calculates {@link Spannable} object based on subnodes of the same type, which
  * can be used in concrete classes to feed native views and compute layout.
  */
+@TargetApi(Build.VERSION_CODES.M)
 public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
 
   // Use a direction weak character so the placeholder doesn't change the direction of the previous
@@ -330,10 +332,12 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
 
   protected int mNumberOfLines = ReactConstants.UNSET;
   protected int mTextAlign = Gravity.NO_GRAVITY;
-  protected int mTextBreakStrategy = Layout.BREAK_STRATEGY_HIGH_QUALITY;
-  protected int mHyphenationFrequency = Layout.HYPHENATION_FREQUENCY_NONE;
+  protected int mTextBreakStrategy =
+    (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? Layout.BREAK_STRATEGY_SIMPLE : Layout.BREAK_STRATEGY_HIGH_QUALITY;
+  protected int mHyphenationFrequency =
+    (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? Layout.BREAK_STRATEGY_SIMPLE : Layout.HYPHENATION_FREQUENCY_NONE;
   protected int mJustificationMode =
-      (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? 0 : Layout.JUSTIFICATION_MODE_NONE;
+      (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) ? Layout.BREAK_STRATEGY_SIMPLE : Layout.JUSTIFICATION_MODE_NONE;
 
   protected float mTextShadowOffsetDx = 0;
   protected float mTextShadowOffsetDy = 0;
@@ -573,6 +577,10 @@ public abstract class ReactBaseTextShadowNode extends LayoutShadowNode {
 
   @ReactProp(name = ViewProps.TEXT_BREAK_STRATEGY)
   public void setTextBreakStrategy(@Nullable String textBreakStrategy) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return;
+    }
+
     if (textBreakStrategy == null || "highQuality".equals(textBreakStrategy)) {
       mTextBreakStrategy = Layout.BREAK_STRATEGY_HIGH_QUALITY;
     } else if ("simple".equals(textBreakStrategy)) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextShadowNode.java
@@ -224,21 +224,26 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
       // Is used when the width is not known and the text is not boring, ie. if it contains
       // unicode characters.
       int hintWidth = (int) Math.ceil(desiredWidth);
-      StaticLayout.Builder builder =
-          StaticLayout.Builder.obtain(text, 0, text.length(), textPaint, hintWidth)
-              .setAlignment(alignment)
-              .setLineSpacing(0.f, 1.f)
-              .setIncludePad(mIncludeFontPadding)
-              .setBreakStrategy(mTextBreakStrategy)
-              .setHyphenationFrequency(mHyphenationFrequency);
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        StaticLayout.Builder builder =
+          StaticLayout.Builder.obtain(text, 0, text.length(), textPaint, (int) width)
+            .setAlignment(alignment)
+            .setLineSpacing(0.f, 1.f)
+            .setIncludePad(mIncludeFontPadding)
+            .setBreakStrategy(mTextBreakStrategy)
+            .setHyphenationFrequency(mHyphenationFrequency);
 
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        builder.setJustificationMode(mJustificationMode);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          builder.setJustificationMode(mJustificationMode);
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+          builder.setUseLineSpacingFromFallbacks(true);
+        }
+        layout = builder.build();
+      } else {
+        layout = new StaticLayout(text, textPaint, (int) width, alignment, 1.f, 0.f, mIncludeFontPadding);
       }
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-        builder.setUseLineSpacingFromFallbacks(true);
-      }
-      layout = builder.build();
 
     } else if (boring != null && (unconstrainedWidth || boring.width <= width)) {
       // Is used for single-line, boring text when the width is either unknown or bigger
@@ -262,22 +267,26 @@ public class ReactTextShadowNode extends ReactBaseTextShadowNode {
         width = (float) Math.ceil(width);
       }
 
-      StaticLayout.Builder builder =
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        StaticLayout.Builder builder =
           StaticLayout.Builder.obtain(text, 0, text.length(), textPaint, (int) width)
-              .setAlignment(alignment)
-              .setLineSpacing(0.f, 1.f)
-              .setIncludePad(mIncludeFontPadding)
-              .setBreakStrategy(mTextBreakStrategy)
-              .setHyphenationFrequency(mHyphenationFrequency);
+            .setAlignment(alignment)
+            .setLineSpacing(0.f, 1.f)
+            .setIncludePad(mIncludeFontPadding)
+            .setBreakStrategy(mTextBreakStrategy)
+            .setHyphenationFrequency(mHyphenationFrequency);
 
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        builder.setJustificationMode(mJustificationMode);
-      }
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          builder.setJustificationMode(mJustificationMode);
+        }
 
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-        builder.setUseLineSpacingFromFallbacks(true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+          builder.setUseLineSpacingFromFallbacks(true);
+        }
+        layout = builder.build();
+      } else {
+        layout = new StaticLayout(text, textPaint, (int) width, alignment, 1.f, 0.f, mIncludeFontPadding);
       }
-      layout = builder.build();
     }
     return layout;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/ReactTextView.java
@@ -377,8 +377,8 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
             mMinimumFontSize,
             mNumberOfLines,
             getIncludeFontPadding(),
-            getBreakStrategy(),
-            getHyphenationFrequency(),
+            (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? -1 :getBreakStrategy(),
+            (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) ? -1 : getHyphenationFrequency(),
             // always passing ALIGN_NORMAL here should be fine, since this method doesn't depend on
             // how exactly lines are aligned, just their width
             Layout.Alignment.ALIGN_NORMAL,
@@ -441,7 +441,7 @@ public class ReactTextView extends AppCompatTextView implements ReactCompoundVie
       if (nextTextAlign != getGravityHorizontal()) {
         setGravityHorizontal(nextTextAlign);
       }
-      if (getBreakStrategy() != update.getTextBreakStrategy()) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && getBreakStrategy() != update.getTextBreakStrategy()) {
         setBreakStrategy(update.getTextBreakStrategy());
       }
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/text/TextLayoutManager.java
@@ -410,23 +410,26 @@ public class TextLayoutManager {
       if (widthYogaMeasureMode == YogaMeasureMode.EXACTLY) {
         desiredWidth = width;
       }
-
       int hintWidth = (int) Math.ceil(desiredWidth);
-      StaticLayout.Builder builder =
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        StaticLayout.Builder builder =
           StaticLayout.Builder.obtain(text, 0, spanLength, paint, hintWidth)
-              .setAlignment(alignment)
-              .setLineSpacing(0.f, 1.f)
-              .setIncludePad(includeFontPadding)
-              .setBreakStrategy(textBreakStrategy)
-              .setHyphenationFrequency(hyphenationFrequency)
-              .setTextDirection(
-                  isScriptRTL ? TextDirectionHeuristics.RTL : TextDirectionHeuristics.LTR);
+            .setAlignment(alignment)
+            .setLineSpacing(0.f, 1.f)
+            .setIncludePad(includeFontPadding)
+            .setBreakStrategy(textBreakStrategy)
+            .setHyphenationFrequency(hyphenationFrequency)
+            .setTextDirection(
+              isScriptRTL ? TextDirectionHeuristics.RTL : TextDirectionHeuristics.LTR);
 
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-        builder.setUseLineSpacingFromFallbacks(true);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+          builder.setUseLineSpacingFromFallbacks(true);
+        }
+
+        layout = builder.build();
+      } else {
+        layout = new StaticLayout(text, paint, hintWidth, alignment, 1.0f, 0.0f, includeFontPadding);
       }
-
-      layout = builder.build();
 
     } else if (boring != null && (unconstrainedWidth || boring.width <= width)) {
       int boringLayoutWidth = boring.width;
@@ -445,25 +448,29 @@ public class TextLayoutManager {
               text, paint, boringLayoutWidth, alignment, 1.f, 0.f, boring, includeFontPadding);
     } else {
       // Is used for multiline, boring text and the width is known.
-      StaticLayout.Builder builder =
-          StaticLayout.Builder.obtain(text, 0, spanLength, paint, (int) Math.ceil(width))
-              .setAlignment(alignment)
-              .setLineSpacing(0.f, 1.f)
-              .setIncludePad(includeFontPadding)
-              .setBreakStrategy(textBreakStrategy)
-              .setHyphenationFrequency(hyphenationFrequency)
-              .setTextDirection(
-                  isScriptRTL ? TextDirectionHeuristics.RTL : TextDirectionHeuristics.LTR);
+      if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+        StaticLayout.Builder builder =
+            StaticLayout.Builder.obtain(text, 0, spanLength, paint, (int) Math.ceil(width))
+                .setAlignment(alignment)
+                .setLineSpacing(0.f, 1.f)
+                .setIncludePad(includeFontPadding)
+                .setBreakStrategy(textBreakStrategy)
+                .setHyphenationFrequency(hyphenationFrequency)
+                .setTextDirection(
+                    isScriptRTL ? TextDirectionHeuristics.RTL : TextDirectionHeuristics.LTR);
 
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-        builder.setJustificationMode(justificationMode);
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+          builder.setJustificationMode(justificationMode);
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+          builder.setUseLineSpacingFromFallbacks(true);
+        }
+
+        layout = builder.build();
+      } else {
+        layout = new StaticLayout(text, paint, (int) Math.ceil(width), alignment, 1.0f, 0.0f, includeFontPadding);
       }
-
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-        builder.setUseLineSpacingFromFallbacks(true);
-      }
-
-      layout = builder.build();
     }
     return layout;
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -232,7 +232,9 @@ public class ReactEditText extends AppCompatEditText {
           public void onDestroyActionMode(ActionMode mode) {}
         };
     setCustomSelectionActionModeCallback(customActionModeCallback);
-    setCustomInsertionActionModeCallback(customActionModeCallback);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      setCustomInsertionActionModeCallback(customActionModeCallback);
+    }
   }
 
   @Override
@@ -753,7 +755,7 @@ public class ReactEditText extends AppCompatEditText {
     }
     mDisableTextDiffing = false;
 
-    if (getBreakStrategy() != reactTextUpdate.getTextBreakStrategy()) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && getBreakStrategy() != reactTextUpdate.getTextBreakStrategy()) {
       setBreakStrategy(reactTextUpdate.getTextBreakStrategy());
     }
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputLocalData.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputLocalData.java
@@ -7,6 +7,10 @@
 
 package com.facebook.react.views.textinput;
 
+import android.annotation.TargetApi;
+import android.graphics.text.LineBreaker;
+import android.os.Build;
+import android.text.Layout;
 import android.text.SpannableStringBuilder;
 import android.util.TypedValue;
 import android.widget.EditText;
@@ -22,6 +26,7 @@ public final class ReactTextInputLocalData {
   private final int mBreakStrategy;
   private final CharSequence mPlaceholder;
 
+  @TargetApi(Build.VERSION_CODES.M)
   public ReactTextInputLocalData(EditText editText) {
     mText = new SpannableStringBuilder(editText.getText());
     mTextSize = editText.getTextSize();
@@ -29,7 +34,11 @@ public final class ReactTextInputLocalData {
     mPlaceholder = editText.getHint();
     mMinLines = editText.getMinLines();
     mMaxLines = editText.getMaxLines();
-    mBreakStrategy = editText.getBreakStrategy();
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      mBreakStrategy = editText.getBreakStrategy();
+    } else {
+      mBreakStrategy = Layout.BREAK_STRATEGY_SIMPLE;
+    }
   }
 
   public void apply(EditText editText) {
@@ -39,6 +48,8 @@ public final class ReactTextInputLocalData {
     editText.setMaxLines(mMaxLines);
     editText.setInputType(mInputType);
     editText.setHint(mPlaceholder);
-    editText.setBreakStrategy(mBreakStrategy);
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+      editText.setBreakStrategy(mBreakStrategy);
+    }
   }
 }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputShadowNode.java
@@ -7,6 +7,8 @@
 
 package com.facebook.react.views.textinput;
 
+import android.annotation.TargetApi;
+import android.os.Build;
 import android.text.Layout;
 import android.util.TypedValue;
 import android.view.ViewGroup;
@@ -32,6 +34,7 @@ import com.facebook.yoga.YogaMeasureMode;
 import com.facebook.yoga.YogaMeasureOutput;
 import com.facebook.yoga.YogaNode;
 
+@TargetApi(Build.VERSION_CODES.M)
 @VisibleForTesting
 public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
     implements YogaMeasureFunction {
@@ -50,7 +53,9 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
   public ReactTextInputShadowNode(
       @Nullable ReactTextViewManagerCallback reactTextViewManagerCallback) {
     super(reactTextViewManagerCallback);
-    mTextBreakStrategy = Layout.BREAK_STRATEGY_HIGH_QUALITY;
+    mTextBreakStrategy = (Build.VERSION.SDK_INT < Build.VERSION_CODES.M)
+      ? Layout.BREAK_STRATEGY_SIMPLE
+      : Layout.BREAK_STRATEGY_HIGH_QUALITY;
 
     initMeasureFunction();
   }
@@ -112,7 +117,8 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
         editText.setLines(mNumberOfLines);
       }
 
-      if (editText.getBreakStrategy() != mTextBreakStrategy) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M
+          && editText.getBreakStrategy() != mTextBreakStrategy) {
         editText.setBreakStrategy(mTextBreakStrategy);
       }
     }
@@ -175,6 +181,10 @@ public class ReactTextInputShadowNode extends ReactBaseTextShadowNode
 
   @Override
   public void setTextBreakStrategy(@Nullable String textBreakStrategy) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return;
+    }
+
     if (textBreakStrategy == null || "simple".equals(textBreakStrategy)) {
       mTextBreakStrategy = Layout.BREAK_STRATEGY_SIMPLE;
     } else if ("highQuality".equals(textBreakStrategy)) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactDrawableHelper.java
@@ -13,6 +13,7 @@ import android.graphics.Color;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.graphics.drawable.RippleDrawable;
+import android.os.Build;
 import android.util.TypedValue;
 import androidx.annotation.Nullable;
 import com.facebook.infer.annotation.Nullsafe;
@@ -79,7 +80,7 @@ public class ReactDrawableHelper {
 
   private static @Nullable Drawable setRadius(
       ReadableMap drawableDescriptionDict, @Nullable Drawable drawable) {
-    if (drawableDescriptionDict.hasKey("rippleRadius") && drawable instanceof RippleDrawable) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && drawableDescriptionDict.hasKey("rippleRadius") && drawable instanceof RippleDrawable) {
       RippleDrawable rippleDrawable = (RippleDrawable) drawable;
       double rippleRadius = drawableDescriptionDict.getDouble("rippleRadius");
       rippleDrawable.setRadius((int) PixelUtil.toPixelFromDIP(rippleRadius));

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.views.view
 
 import android.accessibilityservice.AccessibilityServiceInfo
+import android.annotation.TargetApi
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Rect
@@ -282,11 +283,9 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
     BackgroundStyleApplicator.setFeedbackUnderlay(view, bg)
   }
 
+  @TargetApi(Build.VERSION_CODES.M)
   @ReactProp(name = "nativeForegroundAndroid")
   public open fun setNativeForeground(view: ReactViewGroup, foreground: ReadableMap?) {
-    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
-      return;
-    }
     view.foreground =
         foreground?.let { ReactDrawableHelper.createDrawableFromJSDescription(view.context, it) }
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -11,6 +11,7 @@ import android.accessibilityservice.AccessibilityServiceInfo
 import android.content.Context
 import android.content.pm.PackageManager
 import android.graphics.Rect
+import android.os.Build
 import android.view.View
 import android.view.ViewGroup
 import android.view.accessibility.AccessibilityManager
@@ -271,6 +272,9 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
 
   @ReactProp(name = "nativeForegroundAndroid")
   public open fun setNativeForeground(view: ReactViewGroup, foreground: ReadableMap?) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return;
+    }
     view.foreground =
         foreground?.let { ReactDrawableHelper.createDrawableFromJSDescription(view.context, it) }
   }

--- a/packages/react-native/gradle/libs.versions.toml
+++ b/packages/react-native/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 # Android versions
-minSdk = "24"
+minSdk = "22"
 targetSdk = "35"
 compileSdk = "35"
 buildTools = "35.0.0"


### PR DESCRIPTION
This PR adds Android API 22 support to React Native 0.77 version.

## Motivation
There are a lot of old Android devices in the TV hardware market still in use. Just like people are not replacing their TVs that often, they tend to not replace their smart TV hardwares. It's important to be able to provide service to those devices, if you want/need to.
 
## Description
Most of the code changes in this PR are based on the old codes where RN was officially supporting older Android versions. You can go simply go check 0.73 branch, which is the latest RN version supporting API 22, for a given file to validate the approaches if you'd like. Although, there are a couple of exceptions needs explaining.

The changes in [CompositeBackgroundDrawable.kt](https://github.com/react-native-tvos/react-native-tvos/compare/tvos-v0.77.0...feat/android-22-support-77#diff-b46a48b935da17c8845e66fddf1b621ad04b7a0298f60aab26f270dee410f707) and [BackgroundStyleApplicator.kt](https://github.com/react-native-tvos/react-native-tvos/compare/tvos-v0.77.0...feat/android-22-support-77#diff-2c7268828a8deab21c33455c3bea516542a0bb02b541260f7fac7c33d18e0d06) are based on their latest versions on the latest 0.79 RC branch. I basically copy-pasted those two files from the latest RC branch. Even though it looks and sounds weird, the reason behind it is quite simple. It roots back to this [commit](https://github.com/facebook/react-native/commit/61f01ade4288028757594f286f785d1a9fa1dc4e) which heavily changes the way things are operated in those two files. It transitions things to use [addLayer](https://developer.android.com/reference/android/graphics/drawable/LayerDrawable#addLayer(android.graphics.drawable.Drawable)) api (which requires API 23). This is the version of those files we have on the 0.77 branch. There's no easy way (as far as I'm aware) to get around this new `addLayer` api other than doing things the old way. Which means I need to convert things to the old way. It brings us to this [commit](https://github.com/facebook/react-native/commit/f89f191c26e5f2454e344332eb87de85a977acd8). Good thing it's been done already on the 0.79 branch due to performance regression. The only thing I did is leveraging that and copying the work over here.

An another worth mentioning topic is that we have two new classes [Drawable](https://github.com/react-native-tvos/react-native-tvos/compare/tvos-v0.77.0...feat/android-22-support-77#diff-c901ac278ac9a6851b62db05f2337047da9dbc1b2da5fd079b97912ac1dd2c15) and [LayerDrawable](https://github.com/react-native-tvos/react-native-tvos/compare/tvos-v0.77.0...feat/android-22-support-77#diff-6f925cbba21336c86e320a943c814a5b3ae8072403ece27993cbf5ad3da6edd9) which inherit from their Android counterparts. They do only one thing extra, providing an API 22 compatible `getLayoutDirection` function. 

There are tons of accesses to that function throughout the codebase. It would've been a nightmare to provide a local solution to every single one of them in their on file, on the spot. Instead of doing that, I created those two classes to "proxy" their Android SDK counterparts with minimal code change in the codebase. You'll see a bunch of `import android.graphics.drawable.Drawable` removal in the files while reviewing. Removing the Android SDK import statements makes Drawable and LayoutDrawable usages in those files to resolve to our own internal versions without requiring any extra change.

I tested the changes on an API 22 emulator and a real device using the RNTester app and our own company app. Did not encounter any issues.