### PR TITLE
[Apple TV] Fix for missing select events

### DIFF
--- a/packages/react-native/React/Base/RCTRootView.h
+++ b/packages/react-native/React/Base/RCTRootView.h
@@ -14,6 +14,9 @@
 extern NSString * _Nonnull const RCTTVEnableMenuKeyNotification;
 extern NSString * _Nonnull const RCTTVDisableMenuKeyNotification;
 
+#if TARGET_OS_TV
+#import "RCTTVRemoteSelectHandler.h"
+#endif
 
 @protocol RCTRootViewDelegate;
 
@@ -51,8 +54,11 @@ extern
  * like any ordinary UIView. You can have multiple RCTRootViews on screen at
  * once, all controlled by the same JavaScript application.
  */
+#if TARGET_OS_TV
+@interface RCTRootView : UIView <RCTTVRemoteSelectHandlerDelegate>
+#else
 @interface RCTRootView : UIView
-
+#endif
 /**
  * - Designated initializer -
  */

--- a/packages/react-native/React/Base/RCTRootView.m
+++ b/packages/react-native/React/Base/RCTRootView.m
@@ -31,6 +31,8 @@
 #if TARGET_OS_TV
 #import "RCTTVNavigationEventEmitter.h"
 #import "RCTTVRemoteHandler.h"
+#import "RCTTVRemoteSelectHandler.h"
+#import <React/RCTTVNavigationEventNotification.h>
 #endif
 
 #if RCT_DEV
@@ -98,6 +100,7 @@ NSString *const RCTContentDidAppearNotification = @"RCTContentDidAppearNotificat
 #endif
       
     self.tvRemoteHandler = [[RCTTVRemoteHandler alloc] initWithView:self];
+    self.tvRemoteSelectHandler = [[RCTTVRemoteSelectHandler alloc] initWithView:self];
 #endif
 
     [self showLoadingView];
@@ -424,9 +427,44 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 {
 #if TARGET_OS_TV
   self.tvRemoteHandler = nil;
+  self.tvRemoteSelectHandler = nil;
 #endif
   [_contentView invalidate];
 }
+
+#if TARGET_OS_TV
+
+#pragma mark -
+#pragma mark RCTTVRemoteSelectHandlerDelegate methods
+
+- (void)animatePressIn {
+}
+
+- (void)animatePressOut { 
+}
+
+- (void)emitPressInEvent { 
+}
+
+- (void)emitPressOutEvent { 
+}
+
+- (void)sendSelectNotification
+{
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventSelect keyAction:RCTTVRemoteEventKeyActionUp tag:self.reactTag target:self.reactTag];
+}
+
+- (void)sendLongSelectBeganNotification
+{
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:RCTTVRemoteEventKeyActionDown tag:self.reactTag target:self.reactTag];
+}
+
+- (void)sendLongSelectEndedNotification
+{
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:RCTTVRemoteEventKeyActionUp tag:self.reactTag target:self.reactTag];
+}
+
+#endif
 
 @end
 

--- a/packages/react-native/React/Base/RCTRootViewInternal.h
+++ b/packages/react-native/React/Base/RCTRootViewInternal.h
@@ -26,6 +26,7 @@
  */
 #if TARGET_OS_TV
 @property (nonatomic, strong, nullable) RCTTVRemoteHandler *tvRemoteHandler;
+@property (nonatomic, strong, nullable) RCTTVRemoteSelectHandler *tvRemoteSelectHandler;
 @property (nonatomic, weak) UIView *reactPreferredFocusedView;
 @property (nonatomic, copy, nullable) NSArray<id<UIFocusEnvironment>> *reactPreferredFocusEnvironments;
 #endif

--- a/packages/react-native/React/Base/RCTTVRemoteSelectHandler.m
+++ b/packages/react-native/React/Base/RCTTVRemoteSelectHandler.m
@@ -36,7 +36,7 @@
 
 // Press recognizer should allow long press recognizer to work (but not the reverse)
 - (BOOL)gestureRecognizer:(UIGestureRecognizer *)gestureRecognizer shouldRecognizeSimultaneouslyWithGestureRecognizer:(UIGestureRecognizer *)otherGestureRecognizer {
-  return gestureRecognizer == _pressRecognizer;
+  return gestureRecognizer == self.pressRecognizer && otherGestureRecognizer == self.longPressRecognizer;
 }
 
 #pragma mark -
@@ -54,6 +54,7 @@
   UILongPressGestureRecognizer *longPressRecognizer = [[UILongPressGestureRecognizer alloc] initWithTarget:self action:@selector(handleLongPress:)];
   longPressRecognizer.allowedPressTypes = @[ @(UIPressTypeSelect) ];
   longPressRecognizer.minimumPressDuration = 0.5;
+  longPressRecognizer.delegate = self;
 
   [self.view addGestureRecognizer:longPressRecognizer];
   self.longPressRecognizer = longPressRecognizer;

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.h
@@ -14,6 +14,7 @@
 
 #if TARGET_OS_TV
 #import <React/RCTTVRemoteHandler.h>
+#import <React/RCTTVRemoteSelectHandler.h>
 #endif
 
 NS_ASSUME_NONNULL_BEGIN
@@ -25,7 +26,11 @@ NS_ASSUME_NONNULL_BEGIN
  *
  * WARNING: In the future, RCTRootView will be deprecated in favor of RCTSurfaceHostingView.
  */
+#if TARGET_OS_TV
+@interface RCTSurfaceHostingProxyRootView : RCTSurfaceHostingView <RCTTVRemoteSelectHandlerDelegate>
+#else
 @interface RCTSurfaceHostingProxyRootView : RCTSurfaceHostingView
+#endif
 
 #pragma mark RCTRootView compatibility - keep these sync'ed with RCTRootView.h
 
@@ -44,6 +49,7 @@ NS_ASSUME_NONNULL_BEGIN
 @property (nonatomic, assign) CGSize minimumSize;
 #if TARGET_OS_TV
 @property (nonatomic, strong, nullable) RCTTVRemoteHandler *tvRemoteHandler;
+@property (nonatomic, strong, nullable) RCTTVRemoteSelectHandler *tvRemoteSelectHandler;
 @property (nonatomic, weak, nullable) UIView *reactPreferredFocusedView;
 @property (nonatomic, copy, nullable) NSArray<id<UIFocusEnvironment>> *reactPreferredFocusEnvironments;
 #endif

--- a/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
+++ b/packages/react-native/React/Base/Surface/SurfaceHostingView/RCTSurfaceHostingProxyRootView.mm
@@ -20,6 +20,10 @@
 #import "RCTSurface.h"
 #import "UIView+React.h"
 
+#if TARGET_OS_TV
+#import <React/RCTTVNavigationEventNotification.h>
+#endif
+
 static RCTSurfaceSizeMeasureMode convertToSurfaceSizeMeasureMode(RCTRootViewSizeFlexibility sizeFlexibility)
 {
   switch (sizeFlexibility) {
@@ -61,9 +65,11 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithFrame : (CGRect)frame)
 RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
 
 #if TARGET_OS_TV
+
 - (void)dealloc
 {
   self.tvRemoteHandler = nil;
+  self.tvRemoteSelectHandler = nil;
 }
 
 - (NSArray<id<UIFocusEnvironment>> *)preferredFocusEnvironments {
@@ -77,6 +83,36 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
     return @[self.reactPreferredFocusedView];
   }
   return [super preferredFocusEnvironments];
+}
+
+#pragma mark -
+#pragma mark RCTTVRemoteSelectHandlerDelegate methods
+
+- (void)animatePressIn {
+}
+
+- (void)animatePressOut {
+}
+
+- (void)emitPressInEvent {
+}
+
+- (void)emitPressOutEvent {
+}
+
+- (void)sendSelectNotification
+{
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventSelect keyAction:RCTTVRemoteEventKeyActionUp tag:self.reactTag target:self.reactTag];
+}
+
+- (void)sendLongSelectBeganNotification
+{
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:RCTTVRemoteEventKeyActionDown tag:self.reactTag target:self.reactTag];
+}
+
+- (void)sendLongSelectEndedNotification
+{
+    [[NSNotificationCenter defaultCenter] postNavigationPressEventWithType:RCTTVRemoteEventLongSelect keyAction:RCTTVRemoteEventKeyActionUp tag:self.reactTag target:self.reactTag];
 }
 #endif
 
@@ -145,6 +181,7 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : (NSCoder *)aDecoder)
     dispatch_async(dispatch_get_main_queue(), ^{
 #if TARGET_OS_TV
      self.tvRemoteHandler = [[RCTTVRemoteHandler alloc] initWithView:[self contentView]];
+     self.tvRemoteSelectHandler = [[RCTTVRemoteSelectHandler alloc] initWithView:self];
 #endif
     });
   }


### PR DESCRIPTION
Fixes #904 .

We add a RCTTVRemoteSelectHandler to the root view, and ensure that its gesture recognizer does not run if there is a pressable or touchable present with its own handler.