### PR TITLE
[Apple TV] Synchronize focus notifications and direct view events

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -590,9 +590,9 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
       [self becomeFirstResponder];
       [self enableDirectionalFocusGuides];
       [coordinator addCoordinatedAnimations:^(void){
-          [self addParallaxMotionEffects];
           if (self->_eventEmitter) self->_eventEmitter->onFocus();
           [self sendFocusNotification:context];
+          [self addParallaxMotionEffects];
       } completion:^(void){}];
       // Without this check, onBlur would also trigger when `TVFocusGuideView` transfers focus to its children.
       // [self isTVFocusGuide] is false when autofocus and destinations are not used, so we cannot use that.

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -587,23 +587,21 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
     }
 
     if (context.nextFocusedView == self) {
-      if(_eventEmitter) _eventEmitter->onFocus();
-
       [self becomeFirstResponder];
       [self enableDirectionalFocusGuides];
       [coordinator addCoordinatedAnimations:^(void){
           [self addParallaxMotionEffects];
+          if (self->_eventEmitter) self->_eventEmitter->onFocus();
           [self sendFocusNotification:context];
       } completion:^(void){}];
       // Without this check, onBlur would also trigger when `TVFocusGuideView` transfers focus to its children.
       // [self isTVFocusGuide] is false when autofocus and destinations are not used, so we cannot use that.
       // Generally speaking, it would happen for any non-collapsable `View`.
     } else if (context.previouslyFocusedView == self) {
-      if (_eventEmitter) _eventEmitter->onBlur();
-
       [self disableDirectionalFocusGuides];
       [coordinator addCoordinatedAnimations:^(void){
           [self removeParallaxMotionEffects];
+          if (self->_eventEmitter) self->_eventEmitter->onBlur();
           [self sendBlurNotification:context];
       } completion:^(void){}];
       [self resignFirstResponder];

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -304,20 +304,20 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   }
     
   if (context.nextFocusedView == self) {
-    if (self.onFocus) self.onFocus(nil);
     [self becomeFirstResponder];
     [self enableDirectionalFocusGuides];
     [coordinator addCoordinatedAnimations:^(void){
       [self addParallaxMotionEffects];
+      if (self.onFocus) self.onFocus(nil);
       [self sendFocusNotification:context];
     } completion:^(void){}];
     // Without this check, onBlur would also trigger when `TVFocusGuideView` transfers focus to its children.
     // [self isTVFocusGuide] is false when autofocus and destinations are not used, so we cannot use that.
     // Generally speaking, it would happen for any non-collapsable `View`.
   } else if (context.previouslyFocusedView == self ) {
-    if (self.onBlur) self.onBlur(nil);
     [self disableDirectionalFocusGuides];
     [coordinator addCoordinatedAnimations:^(void){
+      if (self.onBlur) self.onBlur(nil);
       [self sendBlurNotification:context];
       [self removeParallaxMotionEffects];
     } completion:^(void){}];

--- a/packages/react-native/React/Views/RCTTVView.m
+++ b/packages/react-native/React/Views/RCTTVView.m
@@ -307,9 +307,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
     [self becomeFirstResponder];
     [self enableDirectionalFocusGuides];
     [coordinator addCoordinatedAnimations:^(void){
-      [self addParallaxMotionEffects];
       if (self.onFocus) self.onFocus(nil);
       [self sendFocusNotification:context];
+      [self addParallaxMotionEffects];
     } completion:^(void){}];
     // Without this check, onBlur would also trigger when `TVFocusGuideView` transfers focus to its children.
     // [self isTVFocusGuide] is false when autofocus and destinations are not used, so we cannot use that.
@@ -317,9 +317,9 @@ RCT_NOT_IMPLEMENTED(-(instancetype)initWithCoder : unused)
   } else if (context.previouslyFocusedView == self ) {
     [self disableDirectionalFocusGuides];
     [coordinator addCoordinatedAnimations:^(void){
+      [self removeParallaxMotionEffects];
       if (self.onBlur) self.onBlur(nil);
       [self sendBlurNotification:context];
-      [self removeParallaxMotionEffects];
     } completion:^(void){}];
     [self resignFirstResponder];
   }


### PR DESCRIPTION
This ensures the same order of focus&blur events for global notifier and direct event listeners. Currently, it's 50/50 for onFocus/onBlur order, while global NSNotification based events are always in deterministic order (onFocus(new) -> onBlur(old)).

Deterministic order makes it easier to handle in custom JS focus mechanisms.

Also, placing onFocus/Blur in coordinatedAnimated ensures visual feedback (parallax animation) is coordinated with onFocus/onBlur listeners making the animation & focus changes more smooth looking.