### PR TITLE
[CI][Android] Generate RNTester artifact on PRs and pushes

### DIFF
--- a/tools/rntv-workflows/.eas/build/build-rntester-android.yml
+++ b/tools/rntv-workflows/.eas/build/build-rntester-android.yml
@@ -1,0 +1,15 @@
+build:
+  name: Build RNTester app for Android TV
+  steps:
+    - eas/checkout
+    - eas/install_node_modules
+    - run:
+        name: Build RNTester app
+        command: |
+          ./build-rntester-android.sh
+    - eas/upload_artifact:
+        name: Upload RNTester artifacts
+        inputs:
+          type: application-archive
+          path: |
+            packages/rn-tester/android/app/build/outputs/apk/hermes/debug/app-hermes-arm64-v8a-debug.apk

--- a/tools/rntv-workflows/app.json
+++ b/tools/rntv-workflows/app.json
@@ -9,7 +9,7 @@
       "bundleIdentifier": "com.meta.RNTester.localDevelopment"
     },
     "android": {
-      "packageName": "com.facebook.react.uiapp"
+      "package": "com.facebook.react.uiapp"
     },
     "extra": {
       "eas": {

--- a/tools/rntv-workflows/build-rntester-android.sh
+++ b/tools/rntv-workflows/build-rntester-android.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Fail if anything errors
+set -eox pipefail
+
+# Print some environment variables
+echo "JAVA_HOME: $JAVA_HOME"
+echo "ANDROID_HOME: $ANDROID_HOME"
+echo "ANDROID_SDK_ROOT: $ANDROID_SDK_ROOT"
+# Check that sdkmanager is in the path
+which sdkmanager
+# Set custom sdkmanager path for Android build
+export ANDROID_CUSTOM_SDKMANAGER_PATH=`which sdkmanager`
+# Change directory
+cd ../../packages/rn-tester
+echo "Cleaning build directories..."
+yarn clean-android
+echo "Building RNTester..."
+yarn build-android-hermes
+echo "Build completed."
+

--- a/tools/rntv-workflows/eas.json
+++ b/tools/rntv-workflows/eas.json
@@ -16,9 +16,14 @@
       "withoutCredentials": true,
       "distribution": "internal"
     },
-    "build_rntester_apple": {
+    "rntester": {
       "extends": "base",
-      "config": "build-rntester-apple.yml"
+      "ios": {
+        "config": "build-rntester-apple.yml"
+      },
+      "android": {
+        "config": "build-rntester-android.yml"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary

Add scripts and EAS build profile for building Android RNTester artifact on pull requests, similar to PR #930 for Apple TV.

Builds will now be invoked with custom labels `eas-build-android:rntester` and `eas-build-ios:rntester`.