### PR TITLE
Regression since 0.77 : fix vertical scroll views auto scrolling to children on Android when scroll is disabled

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -401,6 +401,14 @@ public class ReactScrollView extends ScrollView
   }
 
   @Override
+  protected int computeScrollDeltaToGetChildRectOnScreen(Rect rect) {
+    if (!mScrollEnabled) {
+      return 0;
+    }
+    return super.computeScrollDeltaToGetChildRectOnScreen(rect);
+  }
+
+  @Override
   protected void onScrollChanged(int x, int y, int oldX, int oldY) {
     Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactScrollView.onScrollChanged");
     try {


### PR DESCRIPTION
Native Android ScrollView TV changes from #321 have disappeared since 0.77.0-0 (see `ReactScrollView.java` in [0.76.9-0](https://github.com/react-native-tvos/react-native-tvos/blob/9930ee9dbe09b760ca4e072b66fa526397ad477b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java#L416) vs [0.77.0-0](https://github.com/react-native-tvos/react-native-tvos/blob/fad8580bbe478661208ef72aa0ddceedd23dd3fb/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java#L402)). It makes disabled vertical scroll views scroll on children focus on Android, unlike tvOS.

The changes were reverted in commit [Back out TV changes in native Android scroll view](https://github.com/react-native-tvos/react-native-tvos/commit/0025b4f726a0f83edd6368689393c6361402f311#diff-959888a4e3a97d5c688d9e4afbbcff08b0ad499165c8234b74f94f5335bcf3d0). They have been reintroduced only on `ReactHorizontalScrollView.java` in commit [Merge some Android TV scrollview changes from 0.76](https://github.com/react-native-tvos/react-native-tvos/commit/ac19219a00f6502f91c1e8f6982339a64eeb7619).

🙏 Could you release this as v0.77.2-1 so that we can benefit from the recent SDK 22 support ? I believe it should be added to later versions as well.

# Test plan

I tested the fix in RN tester ScrollViewSimpleExample with `scrollEnabled={false}`. It now works the same on both Android and tvOS.

https://github.com/user-attachments/assets/f07270d4-37f5-427b-9b53-3cfd7b25b05a


https://github.com/user-attachments/assets/cdba581c-dd7d-4240-ad50-8ddb63ca7e6b

