### PR TITLE
[Apple TV] Allow external select recognizers to run

### DIFF
--- a/packages/react-native/React/Base/RCTTVRemoteSelectHandler.h
+++ b/packages/react-native/React/Base/RCTTVRemoteSelectHandler.h
@@ -24,4 +24,8 @@ NS_ASSUME_NONNULL_BEGIN
 
 @end
 
+@interface RCTTVRemoteSelectGestureRecognizer: UILongPressGestureRecognizer
+
+@end
+
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
## Summary:

Fixes #938 .

## Changelog:

[iOS][Fixed] - Allow other select recognizers (including react-native-bottom-tabs) to run correctly

## Test Plan:

Tested in https://github.com/react-native-tvos/ExpoRouterTV