### PR TITLE
[Android] [0.80]  fix: make `scrollEnabled` work properly for HorizontalScrollView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -175,7 +175,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
 
   @Override
   protected int computeScrollDeltaToGetChildRectOnScreen(Rect rect) {
-    if (mScrollEnabled) {
+    if (!mScrollEnabled) {
       return 0;
     }
     return super.computeScrollDeltaToGetChildRectOnScreen(rect);


### PR DESCRIPTION
## Summary:

Fixes #940 for 0.80.0

## Changelog:
[ANDROID] [FIXED] - make `scrollEnabled` work properly for HorizontalScrollView
