### PR TITLE
[Android] [0.79.0]  fix: make `scrollEnabled` work properly for HorizontalScrollView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -171,7 +171,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
 
   @Override
   protected int computeScrollDeltaToGetChildRectOnScreen(Rect rect) {
-    if (mScrollEnabled) {
+    if (!mScrollEnabled) {
       return 0;
     }
     return super.computeScrollDeltaToGetChildRectOnScreen(rect);


### PR DESCRIPTION
## Summary:

Fixes #940 for 0.79.3

## Changelog:
[ANDROID] [FIXED] - make `scrollEnabled` work properly for HorizontalScrollView
