### PR TITLE
[Android] [0.78]  fix: make `scrollEnabled` work properly for ScrollView and HorizontalScrollView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -170,7 +170,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
 
   @Override
   protected int computeScrollDeltaToGetChildRectOnScreen(Rect rect) {
-    if (mScrollEnabled) {
+    if (!mScrollEnabled) {
       return 0;
     }
     return super.computeScrollDeltaToGetChildRectOnScreen(rect);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -401,6 +401,14 @@ public class ReactScrollView extends ScrollView
   }
 
   @Override
+  protected int computeScrollDeltaToGetChildRectOnScreen(Rect rect) {
+    if (!mScrollEnabled) {
+      return 0;
+    }
+    return super.computeScrollDeltaToGetChildRectOnScreen(rect);
+  }
+
+  @Override
   protected void onScrollChanged(int x, int y, int oldX, int oldY) {
     Systrace.beginSection(Systrace.TRACE_TAG_REACT_JAVA_BRIDGE, "ReactScrollView.onScrollChanged");
     try {


### PR DESCRIPTION
## Summary:

Fixes #940 for 0.78.0

## Changelog:
[ANDROID] [FIXED] - make `scrollEnabled` work properly for ScrollView and HorizontalScrollView
