### PR TITLE
[Android] [0.77]  fix: make `scrollEnabled` work properly for HorizontalScrollView

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -154,7 +154,7 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
 
   @Override
   protected int computeScrollDeltaToGetChildRectOnScreen(Rect rect) {
-    if (mScrollEnabled) {
+    if (!mScrollEnabled) {
       return 0;
     }
     return super.computeScrollDeltaToGetChildRectOnScreen(rect);


### PR DESCRIPTION
## Summary:

Fixes #940 for 0.77.0. Half of the issue seems to be fixed in https://github.com/react-native-tvos/react-native-tvos/pull/935.

## Changelog:
[ANDROID] [FIXED] - make `scrollEnabled` work properly for HorizontalScrollView
