### PR TITLE
[Android] [0.80.1] [Regression] fix: Key Events Propagation Issue on Android TV's Modals

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivity.java
@@ -164,6 +164,14 @@ public abstract class ReactActivity extends AppCompatActivity
     mDelegate.onConfigurationChanged(newConfig);
   }
 
+  public boolean onDialogKeyUp(int keyCode, KeyEvent event) {
+    return mDelegate != null && mDelegate.onDialogKeyUp(keyCode, event);
+  }
+
+  public boolean onDialogKeyDown(int keyCode, KeyEvent event) {
+    return mDelegate != null && mDelegate.onDialogKeyDown(keyCode, event);
+  }
+
   protected final ReactNativeHost getReactNativeHost() {
     return mDelegate.getReactNativeHost();
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactActivityDelegate.java
@@ -208,6 +208,14 @@ public class ReactActivityDelegate {
     return mReactDelegate.onBackPressed();
   }
 
+  public boolean onDialogKeyUp(int keyCode, KeyEvent event) {
+    return mReactDelegate != null && mReactDelegate.onDialogKeyUp(keyCode, event);
+  }
+
+  public boolean onDialogKeyDown(int keyCode, KeyEvent event) {
+    return mReactDelegate != null && mReactDelegate.onDialogKeyDown(keyCode, event);
+  }
+
   public boolean onNewIntent(Intent intent) {
     return mReactDelegate.onNewIntent(intent);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactDelegate.java
@@ -248,6 +248,43 @@ public class ReactDelegate {
     return false;
   }
 
+  /**
+   * Handles key up events for a dialog.
+   * <p>
+   * This method currently does not perform any action and always returns {@code false}. Subclasses
+   * can override this method to provide custom behavior.
+   * </p>
+   *
+   * @param keyCode the code of the key that was released
+   * @param event the {@link KeyEvent} object containing full information about the event
+   * @return {@code true} if the event was handled, {@code false} otherwise
+   *
+   * @see KeyEvent
+   * @see <a href="https://github.com/react-native-tvos/react-native-tvos/issues/829">GitHub Issue #829</a>
+   */
+  public boolean onDialogKeyUp(int keyCode, KeyEvent event) {
+    return false;
+  }
+
+  /**
+   * Handles key down events for a dialog.
+   * <p>
+   * This method currently does not perform any action and always returns {@code false}. Subclasses
+   * can override this method to provide custom behavior.
+   * </p>
+   *
+   * @param keyCode the code of the key that was pressed
+   * @param event the {@link KeyEvent} object containing full information about the event
+   * @return {@code false} indicating the event was not handled
+   *
+   * @see KeyEvent
+   * @see <a href="https://github.com/react-native-tvos/react-native-tvos/issues/829">GitHub Issue #829</a>
+   */
+  public boolean onDialogKeyDown(int keyCode, KeyEvent event) {
+    return false;
+  }
+
+
   public void reload() {
     DevSupportManager devSupportManager = getDevSupportManager();
     if (devSupportManager == null) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -32,6 +32,7 @@ import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.WindowInsetsControllerCompat
 import com.facebook.common.logging.FLog
 import com.facebook.react.R
+import com.facebook.react.ReactActivity
 import com.facebook.react.bridge.GuardedRunnable
 import com.facebook.react.bridge.LifecycleEventListener
 import com.facebook.react.bridge.ReactContext
@@ -302,12 +303,31 @@ public class ReactModalHostView(context: ThemedReactContext) :
                 // activity expects to receive those events and react to them, ie. in the case of
                 // the dev menu
                 val innerCurrentActivity =
-                    (this@ReactModalHostView.context as ReactContext).currentActivity
+                    (this@ReactModalHostView.context as ReactContext).currentActivity as? ReactActivity
                 if (innerCurrentActivity != null) {
-                  return innerCurrentActivity.onKeyUp(keyCode, event)
+                  return innerCurrentActivity.onDialogKeyUp(keyCode, event)
                 }
               }
             }
+
+            // @see https://github.com/react-native-tvos/react-native-tvos/issues/829
+            if (event.action == KeyEvent.ACTION_DOWN) {
+              // Allow BACK and ESCAPE keys to propagate to the dialog's activity.
+              // Returning false ensures these keys are not consumed here, so they
+              // can be processed during the ACTION_UP event where their functionality
+              // is handled by JavaScript.
+              if (keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_ESCAPE) {
+                return false
+              }
+
+              // Redirect all other key down events to the current activity.
+              val innerCurrentActivity =
+                (this@ReactModalHostView.context as ReactContext).currentActivity as? ReactActivity
+              if (innerCurrentActivity != null) {
+                return innerCurrentActivity.onDialogKeyDown(keyCode, event)
+              }
+            }
+
             return false
           }
         })

--- a/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
+++ b/packages/rn-tester/android/app/src/main/java/com/facebook/react/uiapp/RNTesterActivity.kt
@@ -10,12 +10,14 @@ package com.facebook.react.uiapp
 import android.graphics.Color
 import android.graphics.drawable.ColorDrawable
 import android.os.Bundle
+import android.view.KeyEvent
 import android.view.View
 import android.widget.FrameLayout
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import com.facebook.react.FBRNTesterEndToEndHelper
 import com.facebook.react.ReactActivity
+import com.facebook.react.bridge.Arguments
 import com.facebook.react.defaults.DefaultNewArchitectureEntryPoint.fabricEnabled
 import com.facebook.react.defaults.DefaultReactActivityDelegate
 import java.io.FileDescriptor
@@ -80,5 +82,27 @@ internal class RNTesterActivity : ReactActivity() {
       args: Array<String>?
   ) {
     FBRNTesterEndToEndHelper.maybeDump(prefix, writer, args)
+  }
+
+  override fun onDialogKeyUp(keyCode: Int, event: KeyEvent?): Boolean {
+    val data = Arguments.createMap()
+    data.putString("keyCode", KeyEvent.keyCodeToString(keyCode))
+
+    reactActivityDelegate.currentReactContext
+      ?.getJSModule(com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+      ?.emit(::onDialogKeyUp.name + "Event", data)
+
+    return super.onDialogKeyUp(keyCode, event)
+  }
+
+  override fun onDialogKeyDown(keyCode: Int, event: KeyEvent?): Boolean {
+    val data = Arguments.createMap()
+    data.putString("keyCode", KeyEvent.keyCodeToString(keyCode))
+
+    reactActivityDelegate.currentReactContext
+      ?.getJSModule(com.facebook.react.modules.core.DeviceEventManagerModule.RCTDeviceEventEmitter::class.java)
+      ?.emit(::onDialogKeyDown.name + "Event", data)
+
+    return super.onDialogKeyDown(keyCode, event)
   }
 }

--- a/packages/rn-tester/js/examples/Modal/ModalOnShow.js
+++ b/packages/rn-tester/js/examples/Modal/ModalOnShow.js
@@ -12,8 +12,9 @@ import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
 import RNTesterText from '../../components/RNTesterText';
 import * as React from 'react';
-import {useState} from 'react';
+import {useEffect, useState} from 'react';
 import {
+  DeviceEventEmitter,
   Modal,
   Platform,
   Pressable,
@@ -43,6 +44,8 @@ function ModalOnShowOnDismiss(): React.Node {
   const [onDismissCount, setOnDismissCount] = useState(0);
 
   const [lastEvent, setLastEvent] = React.useState('');
+  const [lastDialogKeyUpEvent, setLastDialogKeyUpEvent] = React.useState('');
+  const [lastDialogKeyDownEvent, setLastDialogKeyDownEvent] = React.useState('');
 
   const buttonOpacity = (pressed: boolean, focused: boolean) =>
     pressed || focused ? 0.7 : 1.0;
@@ -50,6 +53,21 @@ function ModalOnShowOnDismiss(): React.Node {
   useTVEventHandler(evt => {
     setLastEvent(evt.eventType);
   });
+
+  useEffect(() => {
+    const onDialogKeyUpEventSubscription = DeviceEventEmitter.addListener('onDialogKeyUpEvent', (event) => {
+      setLastDialogKeyUpEvent(event.keyCode);
+    });
+
+    const onDialogKeyDownEventSubscription = DeviceEventEmitter.addListener('onDialogKeyDownEvent', (event) => {
+      setLastDialogKeyDownEvent(event.keyCode);
+    });
+
+    return () => {
+      onDialogKeyUpEventSubscription.remove();
+      onDialogKeyDownEventSubscription.remove();
+    };
+  }, []);
 
   return (
     <View style={styles.container}>
@@ -76,6 +94,11 @@ function ModalOnShowOnDismiss(): React.Node {
               <Text testID="modal-on-dismiss-count">
                 onDismiss is called {onDismissCount} times
               </Text>
+              {Platform.OS === 'android' && (
+                <Text>
+                  Delegated to MainActivity: keyUp={lastDialogKeyUpEvent}, keyDown={lastDialogKeyDownEvent}
+                </Text>
+              )}
               <Pressable
                 style={({pressed, focused}) => [
                   styles.button,


### PR DESCRIPTION
## Summary:

Fixing a regression with key propagation on Android TV's Modals by cherry-picking the changes in #847. This update is in the main branch but was not included in the latest release, v0.80.1-0.

```
git cherry-pick 79e2cca
```

The cherry-pick is clean with no conflicts.

## Changelog:
[ANDROID] [FIXED] Key Events Propagation Issue on Android TV's Modals

## Test Plan:

Using the RNTester app, I opened the modal UI and observed D-pad events being captured within the modal and delegated to the main activity.

In this video, I pressed left, right, down, and up, and the display text showed the key event, while other keys like "Enter" dismiss the modal (as expected).

https://github.com/user-attachments/assets/4d2d4a40-44ff-42b8-9d51-4f9b643dd4f4

