### PR TITLE
Fix callback ref triggering on each render

### DIFF
--- a/packages/react-native/Libraries/Components/TV/TVFocusGuideView.js
+++ b/packages/react-native/Libraries/Components/TV/TVFocusGuideView.js
@@ -84,24 +84,26 @@ function TVFocusGuideView(
     [],
   );
 
-  const _setNativeRef = setAndForwardRef({
-    getForwardedRef: () => forwardedRef,
-    setLocalRef: ref => {
-      focusGuideRef.current = ref;
+  const _setNativeRef = React.useMemo(() => {
+    return setAndForwardRef({
+      getForwardedRef: () => forwardedRef,
+      setLocalRef: ref => {
+        focusGuideRef.current = ref;
 
-      // This is a hack. Ideally we would forwardRef to the underlying
-      // host component. However, since TVFocusGuide has its own methods that can be
-      // called as well, if we used the standard forwardRef then these
-      // methods wouldn't be accessible
-      //
-      // Here we mutate the ref, so that the user can use the standard native
-      // methods like `focus()`, `blur()`, etc. while also having access to
-      // imperative methods of this component like `setDestinations()`.
-      if (ref) {
-        ref.setDestinations = setDestinations;
-      }
-    },
-  });
+        // This is a hack. Ideally we would forwardRef to the underlying
+        // host component. However, since TVFocusGuide has its own methods that can be
+        // called as well, if we used the standard forwardRef then these
+        // methods wouldn't be accessible
+        //
+        // Here we mutate the ref, so that the user can use the standard native
+        // methods like `focus()`, `blur()`, etc. while also having access to
+        // imperative methods of this component like `setDestinations()`.
+        if (ref) {
+          ref.setDestinations = setDestinations;
+        }
+      },
+    })
+  }, [forwardedRef, setDestinations]);
 
   React.useEffect(() => {
     if (destinationsProp !== null && destinationsProp !== undefined) {

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -39,6 +39,27 @@ export default component View(
     }
   }, []);
 
+  const _setNativeRef = React.useMemo(() => {
+    return setAndForwardRef({
+      getForwardedRef: () => viewRef.current,
+      setLocalRef: _ref => {
+        viewRef.current = _ref;
+
+        // This is a hack. Ideally we would forwardRef to the underlying
+        // host component. However, since TVFocusGuide has its own methods that can be
+        // called as well, if we used the standard forwardRef then these
+        // methods wouldn't be accessible
+        //
+        // Here we mutate the ref, so that the user can use the standart native
+        // methods like `measureLayout()` etc. while also having access to
+        // imperative methods of this component like `requestTVFocus()`.
+        if (_ref) {
+          _ref.requestTVFocus = requestTVFocus;
+        }
+      },
+    })
+  }, [requestTVFocus]);
+
   let actualView;
   if (ReactNativeFeatureFlags.reduceDefaultPropsInView()) {
     const {
@@ -192,25 +213,6 @@ export default component View(
             text: ariaValueText ?? accessibilityValue?.text,
           }
         : undefined;
-
-    const _setNativeRef = setAndForwardRef({
-      getForwardedRef: () => viewRef.current,
-      setLocalRef: _ref => {
-        viewRef.current = _ref;
-
-        // This is a hack. Ideally we would forwardRef to the underlying
-        // host component. However, since TVFocusGuide has its own methods that can be
-        // called as well, if we used the standard forwardRef then these
-        // methods wouldn't be accessible
-        //
-        // Here we mutate the ref, so that the user can use the standart native
-        // methods like `measureLayout()` etc. while also having access to
-        // imperative methods of this component like `requestTVFocus()`.
-        if (_ref) {
-          _ref.requestTVFocus = requestTVFocus;
-        }
-      },
-    });
 
     actualView = (
       <ViewNativeComponent


### PR DESCRIPTION
When using a callback function React and React Native only call that function when the node is mounted, or the callback handle has been updated. The tvos code changes this behaviour and calls it on each render.

But because of the `setAndForwardRef` helper that is used, the handle changes each render, and thus calling the callback ref each render. First with the `null` value and then with (the same) node ref again.

Basic test, which on and Expo build should only show the log once, but on an Expo TV build shows the log each second.

```ts
import {Text, View} from 'react-native';
import {useCallback, useEffect, useState} from "react";

export default function App() {
  return <View>
    <MyView />
  </View>

}

const MyView = () => {
  const [focused, setFocused] = useState(false);

  const callbackRef = useCallback((node) => {
    console.log('This should only be called once on mount', node);
  }, []);

  useEffect(() => {
    const interval = setInterval(() => {
      setFocused(prev => !prev);
    }, 1000);

    return () => clearInterval(interval);
  }, []);

  return <View ref={callbackRef}>
    <Text>I'm a tile {focused ? 'focused' : ''}</Text>
  </View>
}
```
