### PR TITLE
TV: Workflows and build profiles for release builds

### DIFF
--- a/packages/rn-tester/modify-hermes-engine-for-rn-tester.sh
+++ b/packages/rn-tester/modify-hermes-engine-for-rn-tester.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 
-# No longer used, but may be needed again in the future
+# This script is needed when building RNTester for tvOS in release branches only.
 
-#sed -i '' 's/\"react-native\"/\"react-native-tvos\"/;' ../react-native/sdks/hermes-engine/hermes-engine.podspec
-#sed -i '' 's/\"react-native\"/\"react-native-tvos\"/;' ../react-native/third-party-podspecs/ReactNativeDependencies.podspec
+if [[ "$RNTV_RELEASE_BUILD" == "1" ]]; then
+  sed -i '' 's/\"react-native\"/\"react-native-tvos\"/;' ../react-native/sdks/hermes-engine/hermes-engine.podspec
+  sed -i '' 's/\"react-native\"/\"react-native-tvos\"/;' ../react-native/third-party-podspecs/ReactNativeDependencies.podspec
+fi

--- a/tools/rntv-workflows/.eas/workflows/run-builds.yml
+++ b/tools/rntv-workflows/.eas/workflows/run-builds.yml
@@ -2,11 +2,14 @@ name: Run RNTV builds
 
 on:
   push:
-    branches: [main, release-0.81*]
+    branches: [main]
   pull_request:
     branches: [main]
     paths:
       - packages/react-native/**
+      - packages/react-native-codegen/**
+      - packages/react-native-codegen-typescript-test/**
+      - packages/rn-tester/**
       - packages/virtualized-lists/**
       - tools/rntv-workflows/**
 

--- a/tools/rntv-workflows/.eas/workflows/run-release-builds.yml
+++ b/tools/rntv-workflows/.eas/workflows/run-release-builds.yml
@@ -1,0 +1,22 @@
+name: Run RNTV builds
+
+on:
+  push:
+    branches: [release-0.81*]
+
+jobs:
+  build_rncore:
+    type: build
+    params:
+      platform: ios
+      profile: rncore
+  build_rntester_apple:
+    type: build
+    params:
+      platform: ios
+      profile: rntester-prebuild-release
+  build_rntester_android:
+    type: build
+    params:
+      platform: android
+      profile: rntester-release

--- a/tools/rntv-workflows/eas.json
+++ b/tools/rntv-workflows/eas.json
@@ -37,6 +37,18 @@
       "android": {
         "config": "build-rntester-android.yml"
       }
+    },
+    "rntester-prebuild-release": {
+      "extends": "rntester-prebuild",
+      "env": {
+        "RNTV_RELEASE_BUILD": "1"
+      }
+    },
+    "rntester-release": {
+      "extends": "rntester",
+      "env": {
+        "RNTV_RELEASE_BUILD": "1"
+      }
     }
   }
 }


### PR DESCRIPTION
## Summary:

Have separate workflows for main and release branches, since RNTester builds in release branches need slightly modified podspecs that are not required elsewhere.

## Test Plan:

- CI should pass for this PR on main
- CI should pass on `release-0.81*` branches
