### PR TITLE
TV: showsScrollIndex should only be active on tvOS

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -375,10 +375,12 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   if (oldScrollViewProps.indicatorStyle != newScrollViewProps.indicatorStyle) {
     _scrollView.indicatorStyle = RCTUIScrollViewIndicatorStyleFromProps(newScrollViewProps);
   }
-    
+
+#if TARGET_OS_TV
   if (oldScrollViewProps.showsScrollIndex != newScrollViewProps.showsScrollIndex) {
       _scrollView.indexDisplayMode = newScrollViewProps.showsScrollIndex ? UIScrollViewIndexDisplayModeAutomatic : UIScrollViewIndexDisplayModeAlwaysHidden;
   }
+#endif
 
   _endDraggingSensitivityMultiplier = newScrollViewProps.endDraggingSensitivityMultiplier;
 

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.h
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.h
@@ -60,7 +60,9 @@
 @property (nonatomic, assign) CGRect firstResponderFocus;
 /** newly-activated text input outside of the scroll view */
 @property (nonatomic, weak) UIView *firstResponderViewOutsideScrollView;
+#if TARGET_OS_TV
 @property (nonatomic, assign) BOOL showsScrollIndex;
+#endif
 
 // NOTE: currently these event props are only declared so we can export the
 // event names to JS - we don't call the blocks directly because scroll events

--- a/packages/react-native/React/Views/ScrollView/RCTScrollView.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollView.m
@@ -510,11 +510,13 @@ static inline void RCTApplyTransformationAccordingLayoutDirection(
 
 - (void)updateScrollIndex
 {
+#if TARGET_OS_TV
   if (self.showsScrollIndex) {
       self.scrollView.indexDisplayMode = UIScrollViewIndexDisplayModeAutomatic;
   } else {
       self.scrollView.indexDisplayMode = UIScrollViewIndexDisplayModeAlwaysHidden;
   }
+#endif
 }
 
 - (BOOL)centerContent

--- a/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
+++ b/packages/react-native/React/Views/ScrollView/RCTScrollViewManager.m
@@ -102,7 +102,9 @@ RCT_EXPORT_VIEW_PROPERTY(onScrollEndDrag, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollBegin, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(onMomentumScrollEnd, RCTDirectEventBlock)
 RCT_EXPORT_VIEW_PROPERTY(inverted, BOOL)
+#if TARGET_OS_TV
 RCT_EXPORT_VIEW_PROPERTY(showsScrollIndex, BOOL)
+#endif
 RCT_EXPORT_VIEW_PROPERTY(automaticallyAdjustsScrollIndicatorInsets, BOOL)
 RCT_EXPORT_VIEW_PROPERTY(contentInsetAdjustmentBehavior, UIScrollViewContentInsetAdjustmentBehavior)
 

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.cpp
@@ -22,6 +22,7 @@ BaseScrollViewProps::BaseScrollViewProps(
     const BaseScrollViewProps& sourceProps,
     const RawProps& rawProps)
     : ViewProps(context, sourceProps, rawProps),
+#if TARGET_OS_TV
       showsScrollIndex(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.showsScrollIndex
@@ -31,6 +32,7 @@ BaseScrollViewProps::BaseScrollViewProps(
                     "showsScrollIndex",
                     sourceProps.showsScrollIndex,
                     {})),
+#endif
       alwaysBounceHorizontal(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.alwaysBounceHorizontal
@@ -396,7 +398,9 @@ void BaseScrollViewProps::setProp(
   static auto defaults = BaseScrollViewProps{};
 
   switch (hash) {
+#if TARGET_OS_TV
     RAW_SET_PROP_SWITCH_CASE_BASIC(showsScrollIndex);
+#endif
     RAW_SET_PROP_SWITCH_CASE_BASIC(alwaysBounceHorizontal);
     RAW_SET_PROP_SWITCH_CASE_BASIC(alwaysBounceVertical);
     RAW_SET_PROP_SWITCH_CASE_BASIC(bounces);
@@ -446,10 +450,12 @@ SharedDebugStringConvertibleList BaseScrollViewProps::getDebugProps() const {
 
   return ViewProps::getDebugProps() +
       SharedDebugStringConvertibleList{
+#if TARGET_OS_TV
           debugStringConvertibleItem(
               "showsScrollIndex",
               snapToEnd,
               defaultScrollViewProps.showsScrollIndex),
+#endif
           debugStringConvertibleItem(
               "alwaysBounceHorizontal",
               alwaysBounceHorizontal,

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/BaseScrollViewProps.h
@@ -32,7 +32,9 @@ class BaseScrollViewProps : public ViewProps {
 
 #pragma mark - Props
 
+#if TARGET_OS_TV
   bool showsScrollIndex{true};
+#endif
   bool alwaysBounceHorizontal{};
   bool alwaysBounceVertical{};
   bool bounces{true};


### PR DESCRIPTION
## Summary:

This is an adjustment to #568 . This repo allows building apps for both iOS and tvOS. We would like iOS builds to be interoperable with the packager and JS bundles from the RN core repo.

Here, we wrap references to `showsScrollIndex` so that they are only compiled for tvOS, not iOS, where they are not needed. This keeps the iOS native code compatible with the core repo, which does not have the `showsScrollIndex` view prop.

## Test Plan:

- CI should pass
- The RNTester iOS app built by CI should work with the packager from the RN core repo of the same version (currently testing against core version 0.81.0-rc.2)
- The RNTester iOS app should pass the RN core repo's Maestro tests