### PR TITLE
fix: prevent focus loops

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -1209,22 +1209,6 @@ public class ReactViewGroup extends ViewGroup
     return null;
   }
 
-  private static boolean requestFocusViewOrAncestor(View destination) {
-    View v = destination;
-    while (v != null) {
-      if (v.requestFocus()) {
-        return true;
-      }
-      ViewParent parent = v.getParent();
-      if (parent instanceof View) {
-        v = (View) parent;
-      } else {
-        v = null;
-      }
-    }
-    return false;
-  }
-
   private boolean isFocusDestinationsSet() {
     return focusDestinations.length > 0;
   }
@@ -1381,7 +1365,13 @@ public class ReactViewGroup extends ViewGroup
     if (isFocusDestinationsSet()) {
       View destination = findDestinationView();
 
-      if (destination != null && requestFocusViewOrAncestor(destination)) {
+      // Destination is set but there's no such element on the tree
+      // Just skip it to prevent cyclic issues.
+      if (destination == null) {
+       return false;
+      }
+
+      if (destination != null && destination.requestFocus()) {
         return true;
       }
     }
@@ -1406,9 +1396,7 @@ public class ReactViewGroup extends ViewGroup
       }
 
       // Try moving the focus to the first focusable element otherwise.
-      if (moveFocusToFirstFocusable(this)) {
-        return true;
-      }
+      return moveFocusToFirstFocusable(this)
     }
 
     return super.requestFocus(direction, previouslyFocusedRect);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java
@@ -1396,7 +1396,7 @@ public class ReactViewGroup extends ViewGroup
       }
 
       // Try moving the focus to the first focusable element otherwise.
-      return moveFocusToFirstFocusable(this)
+      return moveFocusToFirstFocusable(this);
     }
 
     return super.requestFocus(direction, previouslyFocusedRect);


### PR DESCRIPTION
## Summary:
I found three different edge cases in the focus logic that leads to endless `requestFocus` loops on Android side. This behavior was crashing the application with an impossible to understand and debug error. I fixed those cases by restructuring the code a bit.

## Changelog:
[ANDROID] [FIXED] - Improve TVFocusGuideView stability.