### PR TITLE
View and TVFocusGuideView should use useMergeRefs

### DIFF
--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -11,7 +11,7 @@
 import type {ViewProps} from './ViewPropTypes';
 
 import TextAncestorContext from '../../Text/TextAncestorContext';
-import setAndForwardRef from '../../Utilities/setAndForwardRef';
+import useMergeRefs from '../../Utilities/useMergeRefs';
 import ViewNativeComponent from './ViewNativeComponent';
 import {Commands} from './ViewNativeComponent';
 import * as React from 'react';
@@ -38,26 +38,23 @@ component View(
     }
   }, []);
 
-  const _setNativeRef = React.useMemo(() => {
-    return setAndForwardRef({
-      getForwardedRef: () => viewRef.current,
-      setLocalRef: _ref => {
-        viewRef.current = _ref;
+  const setLocalRef = React.useCallback(
+    (instance: HostInstance | null) => {
+      // $FlowExpectedError[incompatible-type]
+      viewRef.current = instance;
 
-        // This is a hack. Ideally we would forwardRef to the underlying
-        // host component. However, since TVFocusGuide has its own methods that can be
-        // called as well, if we used the standard forwardRef then these
-        // methods wouldn't be accessible
-        //
-        // Here we mutate the ref, so that the user can use the standart native
-        // methods like `measureLayout()` etc. while also having access to
-        // imperative methods of this component like `requestTVFocus()`.
-        if (_ref) {
-          _ref.requestTVFocus = requestTVFocus;
-        }
-      },
-    })
-  }, [requestTVFocus]);
+      if (instance != null) {
+        // $FlowFixMe[prop-missing]
+        // $FlowFixMe[unsafe-object-assign]
+        Object.assign(instance, {
+          requestTVFocus,
+        });
+      }
+    },
+    [requestTVFocus],
+  );
+
+  const mergedRef = useMergeRefs(setLocalRef, ref);
 
   const {
     accessibilityState,
@@ -148,7 +145,7 @@ component View(
     ref == null ? (
       <ViewNativeComponent {...processedProps} />
     ) : (
-      <ViewNativeComponent {...processedProps} ref={_setNativeRef} />
+      <ViewNativeComponent {...processedProps} ref={mergedRef} />
     );
 
   if (hasTextAncestor) {


### PR DESCRIPTION
## Summary:

Testing with a RNTV 0.82 release candidate branch showed some regressions:

- From 0.81 to 0.82, the `destinations` prop in `TVFocusGuideView` stopped working
- Since 0.79, the `requestTVFocus` imperative method in `View` stopped working

Both of these features were implemented by manipulating view refs using `setAndForwardRef()`.

To fix the regressions and align with the way this is done in the rest of the codebase, this PR reimplements the features with the `useMergeRefs()` API (as is already done in `TextInput`, `Pressable`, and other components).

## Changelog:

[General][Fixed] Fix regressions by moving to useMergeRefs() for TVFocusGuideView and View

## Test Plan:

Tested with 0.82.0-0rc0 RNTester builds. Without this fix, the focus guide examples do not work correctly.