### PR TITLE
fix(Android): clean up unused and duplicate focus event code

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactAndroidHWInputDeviceHelper.kt
@@ -33,26 +33,6 @@ internal class ReactAndroidHWInputDeviceHelper {
     }
   }
 
-  /** Called from [ReactRootView] when focused view changes. */
-  fun onFocusChanged(newFocusedView: View, context: ReactContext) {
-    if (lastFocusedViewId == newFocusedView.id) {
-      return
-    }
-    if (lastFocusedViewId != View.NO_ID) {
-      dispatchEvent(context, "blur", lastFocusedViewId)
-    }
-    lastFocusedViewId = newFocusedView.id
-    dispatchEvent(context, "focus", newFocusedView.id)
-  }
-
-  /** Called from [ReactRootView] when the whole view hierarchy looses focus. */
-  fun clearFocus(context: ReactContext) {
-    if (lastFocusedViewId != View.NO_ID) {
-      dispatchEvent(context, "blur", lastFocusedViewId)
-    }
-    lastFocusedViewId = View.NO_ID
-  }
-
   private fun dispatchEvent(
       context: ReactContext,
       eventType: String?,

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/ReactRootView.java
@@ -341,39 +341,6 @@ public class ReactRootView extends FrameLayout implements RootView, ReactRoot {
     return super.dispatchKeyEvent(ev);
   }
 
-  @Override
-  protected void onFocusChanged(boolean gainFocus, int direction, Rect previouslyFocusedRect) {
-    if (!hasActiveReactContext() || !isViewAttachedToReactInstance()) {
-      FLog.w(
-          TAG,
-          "Unable to handle focus changed event as the catalyst instance has not been attached");
-      super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
-      return;
-    }
-    ReactContext context = getCurrentReactContext();
-    if (context != null) {
-      mAndroidHWInputDeviceHelper.clearFocus(context);
-    }
-    super.onFocusChanged(gainFocus, direction, previouslyFocusedRect);
-  }
-
-  @Override
-  public void requestChildFocus(View child, View focused) {
-    if (!hasActiveReactContext() || !isViewAttachedToReactInstance()) {
-      FLog.w(
-          TAG,
-          "Unable to handle child focus changed event as the catalyst instance has not been"
-              + " attached");
-      super.requestChildFocus(child, focused);
-      return;
-    }
-    ReactContext context = getCurrentReactContext();
-    if (context != null) {
-      mAndroidHWInputDeviceHelper.onFocusChanged(focused, context);
-    }
-    super.requestChildFocus(child, focused);
-  }
-
   protected void dispatchJSPointerEvent(MotionEvent event, boolean isCapture) {
     if (!hasActiveReactContext() || !isViewAttachedToReactInstance()) {
       FLog.w(TAG, "Unable to dispatch touch to JS as the catalyst instance has not been attached");

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
@@ -192,26 +192,6 @@ public class ReactAndroidHWInputDeviceHelper {
     );
   }
 
-  /** Called from {@link com.facebook.react.ReactRootView} when focused view changes. */
-  public void onFocusChanged(View newFocusedView, ReactContext context) {
-    if (mLastFocusedViewId == newFocusedView.getId()) {
-      return;
-    }
-    if (mLastFocusedViewId != View.NO_ID) {
-      dispatchEvent("blur", mLastFocusedViewId, context);
-    }
-    mLastFocusedViewId = newFocusedView.getId();
-    dispatchEvent("focus", newFocusedView.getId(), context);
-  }
-
-  /** Called from {@link com.facebook.react.ReactRootView} when the whole view hierarchy looses focus. */
-  public void clearFocus(ReactContext context) {
-    if (mLastFocusedViewId != View.NO_ID) {
-      dispatchEvent("blur", mLastFocusedViewId, context);
-    }
-    mLastFocusedViewId = View.NO_ID;
-  }
-
   private void dispatchEvent(String eventType, int targetViewId, ReactContext context) {
     dispatchEvent(eventType, targetViewId, -1, context);
   }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/modal/ReactModalHostView.kt
@@ -560,15 +560,6 @@ public class ReactModalHostView(context: ThemedReactContext) :
       updateState(viewWidth, viewHeight)
     }
 
-    protected override fun onFocusChanged(
-      gainFocus: Boolean,
-      direction: Int,
-      previouslyFocusedRect: Rect?
-    ) {
-      androidHWInputDeviceHelper.clearFocus(reactContext)
-      super.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
-    }
-
     /*
     public override fun requestChildFocus(child: View?, focused: View?) {
       androidHWInputDeviceHelper.onFocusChanged(focused, reactContext)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -70,9 +70,7 @@ import com.facebook.react.uimanager.UIManagerHelper
 import com.facebook.react.uimanager.ViewGroupDrawingOrderHelper
 import com.facebook.react.uimanager.common.UIManagerType
 import com.facebook.react.uimanager.common.ViewUtil.getUIManagerType
-import com.facebook.react.uimanager.events.BlurEvent
 import com.facebook.react.uimanager.events.EventDispatcher
-import com.facebook.react.uimanager.events.FocusEvent
 import com.facebook.react.uimanager.events.PressInEvent
 import com.facebook.react.uimanager.events.PressOutEvent
 import com.facebook.react.uimanager.style.BorderRadiusProp
@@ -1368,31 +1366,7 @@ public open class ReactViewGroup public constructor(context: Context?) :
   }
 
   override fun onFocusChanged(gainFocus: Boolean, direction: Int, previouslyFocusedRect: Rect?) {
-    // Calling the super method causes duplicate events
-    // super.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
-
-    val mEventDispatcher: EventDispatcher? =
-      UIManagerHelper.getEventDispatcherForReactTag(
-        this.context as ReactContext, this.id
-      )
-
-    if (mEventDispatcher == null) {
-      return
-    }
-
-    if (gainFocus) {
-      mEventDispatcher.dispatchEvent(
-        FocusEvent(
-          UIManagerHelper.getSurfaceId(this.context), this.id
-        )
-      )
-    } else {
-      mEventDispatcher.dispatchEvent(
-        BlurEvent(
-          UIManagerHelper.getSurfaceId(this.context), this.id
-        )
-      )
-    }
+    super.onFocusChanged(gainFocus, direction, previouslyFocusedRect)
   }
 
   override fun onKeyDown(keyCode: Int, event: KeyEvent): Boolean {


### PR DESCRIPTION
## Summary:

The core team has added code for emitting focus and blur events on Android (https://github.com/facebook/react-native/pull/52093) so we need to remove the code in `ReactViewGroup.kt` that is emitting duplicate events.

Concurrently with this change, we can remove old code for emitting focus and blur events that is no longer active.

## Changelog:

[Android][Fixed] Remove duplicate focus and blur events

## Test Plan:

Tested with the TVEventHandlerExample in RNTester and with the ModalExample.
