### PR TITLE
fix (Android): auto focus restoration

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -754,14 +754,14 @@ public open class ReactViewGroup public constructor(context: Context?) :
     super.onViewAdded(child)
   }
   
-  public override fun removeView(view: View?) {
+  override fun removeView(view: View?) {
     if (view != null) {
       recoverFocus(view);
     }
     super.removeView(view);
   }
 
-  public override fun removeViewAt(index: Int) {
+  override fun removeViewAt(index: Int) {
     recoverFocus(getChildAt(index));
     super.removeViewAt(index);
   }


### PR DESCRIPTION
## Summary:
In tvos-v0.76.0 branch ReactViewGroup class we had focus recovery logic which runs when a view is deleted [here
](https://github.com/react-native-tvos/react-native-tvos/blob/tvos-v0.76.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java#L736) and [here](https://github.com/react-native-tvos/react-native-tvos/blob/tvos-v0.76.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java#L743). It was telling deleted view's parent view group to recover the focus to another view inside it.

However, the logic is deleted in v0.77.0 [ReactViewGroup](https://github.com/react-native-tvos/react-native-tvos/blob/tvos-v0.77.0/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.java).

This PR adds it back and also supports the focus recovery when subview clipping enabled.

## Changelog:
[ANDROID] [ADDED|FIXED]

## Test Plan:
Below is a video before the fix, as seen after deletion focus jumps to the top of the screen.

https://github.com/user-attachments/assets/f2b81f24-90c2-4bfa-a31b-3bc657ce4a2c

And a video after the fix where focus stays on the same view group.

https://github.com/user-attachments/assets/3ffd7538-87db-4fc8-85da-84fe8f489b40


