### PR TITLE
fix: request focus on Android TV not opening keyboard when focused

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactEditText.java
@@ -411,6 +411,12 @@ public class ReactEditText extends AppCompatEditText {
     boolean focused = super.requestFocus(View.FOCUS_DOWN, null);
     if (isInTouchMode() && getShowSoftInputOnFocus()) {
       showSoftKeyboard();
+    } else {
+      if (isKeyboardOpened) {
+        showSoftKeyboard();
+      } else {
+        hideSoftKeyboard();
+      }
     }
 
     return focused;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.java
@@ -981,6 +981,12 @@ public class ReactTextInputManager extends BaseViewManager<ReactEditText, Layout
     view.setAutoFocus(autoFocus);
   }
 
+  @ReactProp(name = "accessible")
+  public void setAccessible(ReactEditText view, boolean accessible) {
+    view.setFocusable(accessible);
+    view.setFocusableInTouchMode(accessible);
+  }
+
   @ReactProp(name = ViewProps.TEXT_DECORATION_LINE)
   public void setTextDecorationLine(ReactEditText view, @Nullable String textDecorationLineString) {
     view.setPaintFlags(


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

The TextInput does not display keyboard when it's focused. The `requestFocusProgrammatically` didn't get the patch that was applied to `requestFocusInternal`. This is fixed since 0.80, because there is no `requestFocusInternal`, but we cannot upgrade to 0.80 (we're testing 0.79 now) so I thought I'll submit PR to fix, let me know if it's feasible to include it and release 0.79.5-1 maybe

Also compared to https://github.com/react-native-tvos/react-native-tvos/pull/934 instead of removing `isInTouchMode()` check, I'm aligning the `isFocusable` and `isFocusableInTouchMode` values - similar to what was done in https://github.com/react-native-tvos/react-native-tvos/pull/787 by the difference is that we should always keep them in sync (otherwise on devices like FireTV stick, `isInTouchMode()` always returns false, when user interacts with the TextInput)

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Focus the input on AndroidTV, it should display keyboard immediately
