### PR TITLE
Extend Community CLI with tvOS commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Using Expo's [continuous native generation (CNG)](https://docs.expo.dev/workflow
 
 ### Creating a new project with the Community CLI
 
-We maintain [template-tv](https://github.com/react-native-tvos/template-tv), a TV-specific template for developers using the React Native Community CLI.
+We maintain [template-tv](https://github.com/react-native-tvos/template-tv), a TV-specific template for developers using the React Native Community CLI. This project extends the Community CLI with `run-tvos`, `build-tvos`, and `log-tvos` commands for tvOS development.
 
 > [!NOTE]
 > This template only supports Apple TV and Android TV. Multiple platform targets are no longer supported in React Native app Podfiles.
@@ -110,7 +110,7 @@ npx @react-native-community/cli@latest init TVTest --template @react-native-tvos
 cd TVTest
 
 # Build and run on tvOS Simulator (macOS only, requires Apple TV simulator)
-npx react-native run-ios --simulator "Apple TV"
+npx react-native run-tvos --simulator "Apple TV"
 
 # Build and run on Android TV emulator (requires Android TV emulator)
 npx react-native run-android --device tv_api_31

--- a/packages/react-native/react-native.config.js
+++ b/packages/react-native/react-native.config.js
@@ -136,4 +136,21 @@ if (android != null) {
   };
 }
 
+try {
+  const apple = require('@react-native-community/cli-platform-apple');
+  const tvosCommands = require('./tvosCommands');
+
+  config.commands.push(...tvosCommands);
+  config.platforms.tvos = {
+    projectConfig: apple.getProjectConfig({platformName: 'tvos'}),
+    dependencyConfig: apple.getDependencyConfig({platformName: 'tvos'}),
+  };
+} catch {
+  if (verbose) {
+    console.warn(
+      '@react-native-community/cli-platform-apple not found, the react-native.config.js may be unusable.',
+    );
+  }
+}
+
 module.exports = config;

--- a/packages/react-native/tvosCommands.js
+++ b/packages/react-native/tvosCommands.js
@@ -1,0 +1,51 @@
+/**
+ * @flow
+ */
+
+let apple;
+try {
+  apple = require('@react-native-community/cli-platform-apple');
+} catch {
+  if (verbose) {
+    console.warn(
+      '@react-native-community/cli-platform-apple not found, the react-native.config.js may be unusable.'
+    );
+  }
+}
+
+const platformName = 'tvos';
+
+const run = {
+  name: `run-${platformName}`,
+  description: 'builds your app and starts it on a tvOS simulator or Apple TV device',
+  func: apple.createRun({platformName}),
+  examples: [
+    {
+      desc: 'Run on a specific simulator',
+      cmd: `npx react-native run-${platformName} --simulator "Apple TV"`,
+    },
+  ],
+  options: apple.getRunOptions({platformName}),
+};
+
+const log = {
+  name: `log-${platformName}`,
+  description: 'displays system logs from a connected tvOS device or simulator',
+  func: apple.createLog({platformName: platformName}),
+  options: apple.getLogOptions({platformName}),
+};
+
+const build = {
+  name: `build-${platformName}`,
+  description: 'builds your app for tvOS',
+  func: apple.createBuild({platformName}),
+  examples: [
+      {
+      desc: 'Build the app for all tvOS devices in Release mode',
+      cmd: `npx react-native build-${platformName} --mode "Release"`,
+      },
+  ],
+  options: apple.getBuildOptions({platformName}),
+};
+
+module.exports = [run, log, build];


### PR DESCRIPTION
## Summary:

This PR adds dedicated tvOS commands (`run-tvos`, `build-tvos`, and `log-tvos`) to fully support out-of-tree (OOT) platform development in the Community CLI. 

Beyond being a nice quality-of-life improvement, this fixes an issue where tvOS simulators don't appear when running `*-ios` commands. Now `--list-devices` and other commands correctly display tvOS simulators.

The existing iOS commands continue to work as expected. I've been patching this change locally for several months, and it has significantly simplified my build & delivery workflow!

## Changelog:

[TVOS] [ADDED] - Added run-tvos, build-tvos, and log-tvos commands for tvOS development

## Test Plan:

### Setup
There is a minor issue with the Community CLI and rn-tester structure, so I cherry-picked the commit into a testing branch for easier testing: [cgoldsby-tvos-commands-for-testing](https://github.com/react-native-tvos/react-native-tvos/tree/cgoldsby-tvos-commands-for-testing#)
```sh
gh repo clone react-native-tvos/react-native-tvos
git checkout cgoldsby-tvos-commands-for-testing
git reset HEAD --hard
git clean -xdf
yarn
cd packages/rn-tester
yarn setup-tvos-hermes
```

### Before (using iOS commands for tvOS)

**`npx react-native run-ios --scheme RNTester --list-devices`**
❌ Lists only iOS simulators. tvOS simulators are excluded.
<img width="1126" height="715" alt="Screenshot 2025-12-17 at 1 49 38 PM" src="https://github.com/user-attachments/assets/e66dc316-d4f5-4b23-ba81-d27d12967695" />


**`npx react-native run-ios --scheme RNTester -i`**
❌ Lists only iOS simulators. tvOS simulators are excluded.

**`npx react-native log-ios`**
❌ Error: "No booted and available iOS simulators found." Does not recognize tvOS Simulator.

**`npx react-native run-ios --scheme RNTester --simulator "Apple TV"`**
✅ Works, but you must explicitly pass the simulator name to override the Community CLI's default iOS simulator selection.

### After (using new tvOS commands)

**`npx react-native run-tvos --scheme RNTester --list-devices`**
✅ Works! Correctly lists tvOS simulators.
<img width="1287" height="579" alt="Screenshot 2025-12-17 at 2 12 35 PM" src="https://github.com/user-attachments/assets/53b775c0-75c3-4668-9cb7-d3af7ea9e542" />

**`npx react-native run-tvos --scheme RNTester`**
✅ Passing a simulator is no longer required (still supported). The CLI will automatically pick an available tvOS Simulator.

**`npx react-native log-tvos`**
✅ Works!
```
info Tailing logs for device Apple TV (EBC12F60-D450-4397-BFEC-0770E74AC822)
NOTE: Most system logs have moved to a new logging system. See log(1) for more information.
Dec 15 14:28:35 macmini-cgoldsby syslogd[21276] <Notice>: --- syslogd restarted ---
```

## Related PRs
- https://github.com/react-native-community/cli/pull/2208
- https://github.com/react-native-community/cli/pull/2608