### PR TITLE
Fix: Include tvosCommands.js in npm package

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -91,6 +91,7 @@
     "React-Core.podspec",
     "React-Core-prebuilt.podspec",
     "react-native.config.js",
+    "tvosCommands.js",
     "React.podspec",
     "React",
     "!React/Fabric/RCTThirdPartyFabricComponentsProvider.*",


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

Adds tvosCommands.js to the files array in package.json. This file is required by react-native.config.js but was missing from the published 0.83.1-0 package, causing tvOS CLI commands (run-tvos, log-tvos, build-tvos) to fail.

## Changelog:

[GENERAL] [FIXED] - Include tvosCommands.js in npm package to restore tvOS CLI commands

