### PR TITLE
tvos: Add rntv_systemBackgroundColor for tvOS support

### DIFF
--- a/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTAppDelegate.mm
@@ -59,14 +59,6 @@ using namespace facebook::react;
   UIViewController *rootViewController = [self createRootViewController];
   [self setRootView:rootView toRootViewController:rootViewController];
   _window.rootViewController = rootViewController;
-#if TARGET_OS_TV
-  UIUserInterfaceStyle style = rootViewController.traitCollection.userInterfaceStyle;
-  if (style == UIUserInterfaceStyleDark) {
-    rootView.backgroundColor = [UIColor colorWithRed:0.0 green:0.0 blue:0.0 alpha:1.0];
-  } else {
-    rootView.backgroundColor = [UIColor colorWithRed:1.0 green:1.0 blue:1.0 alpha:1.0];
-  }
-#endif
   [_window makeKeyAndVisible];
 }
 

--- a/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTDefaultReactNativeFactoryDelegate.mm
@@ -59,9 +59,7 @@
 {
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, YES);
 
-#if !TARGET_OS_TV
-  rootView.backgroundColor = [UIColor systemBackgroundColor];
-#endif
+  rootView.backgroundColor = [UIColor rntv_systemBackgroundColor];
 
   return rootView;
 }

--- a/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
+++ b/packages/react-native/Libraries/AppDelegate/RCTRootViewFactory.mm
@@ -190,9 +190,7 @@
   RCTSurfaceHostingProxyRootView *surfaceHostingProxyRootView =
       [[RCTSurfaceHostingProxyRootView alloc] initWithSurface:surface];
 
-#if !TARGET_OS_TV
-  surfaceHostingProxyRootView.backgroundColor = [UIColor systemBackgroundColor];
-#endif
+  surfaceHostingProxyRootView.backgroundColor = [UIColor rntv_systemBackgroundColor];
   if (_configuration.customizeRootView != nil) {
     _configuration.customizeRootView(surfaceHostingProxyRootView);
   }
@@ -209,9 +207,7 @@
                            initProps:(NSDictionary *)initProps
 {
   UIView *rootView = RCTAppSetupDefaultRootView(bridge, moduleName, initProps, YES);
-#if !TARGET_OS_TV
-  rootView.backgroundColor = [UIColor systemBackgroundColor];
-#endif
+  rootView.backgroundColor = [UIColor rntv_systemBackgroundColor];
   
   return rootView;
 }

--- a/packages/react-native/React/Base/RCTDefines.h
+++ b/packages/react-native/React/Base/RCTDefines.h
@@ -175,3 +175,10 @@
     @throw _RCTNotImplementedException(_cmd, [self class]);                                             \
   }                                                                                                     \
   _Pragma("clang diagnostic pop")
+
+/**
+ * Import system color support for all platforms
+ */
+#if __OBJC__
+#import "RCTTVColorSupport.h"
+#endif

--- a/packages/react-native/React/Base/RCTTVColorSupport.h
+++ b/packages/react-native/React/Base/RCTTVColorSupport.h
@@ -1,0 +1,17 @@
+/*
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+/**
+ * Category on UIColor providing systemBackgroundColor for all platforms.
+ * On tvOS, provides a custom implementation since systemBackgroundColor is not available.
+ * On other platforms, returns the system's systemBackgroundColor.
+ */
+@interface UIColor (RNTVSystemColors)
+
++ (UIColor *)rntv_systemBackgroundColor;
+
+@end

--- a/packages/react-native/React/Base/RCTTVColorSupport.mm
+++ b/packages/react-native/React/Base/RCTTVColorSupport.mm
@@ -1,0 +1,23 @@
+/*
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ */
+
+#import <UIKit/UIKit.h>
+
+@implementation UIColor (RNTVSystemColors)
+
++ (UIColor *)rntv_systemBackgroundColor {
+ #if TARGET_OS_TV
+   UIColor *lightColor = [UIColor whiteColor];
+   UIColor *darkColor = [UIColor blackColor];
+
+   return [UIColor colorWithDynamicProvider:^UIColor *(UITraitCollection *traitCollection) {
+     return (traitCollection.userInterfaceStyle == UIUserInterfaceStyleDark) ? darkColor : lightColor;
+   }];
+ #else
+   return [UIColor systemBackgroundColor];
+ #endif
+}
+
+@end


### PR DESCRIPTION
## Summary:
tvOS doesn't have `systemBackgroundColor`, so this adds a new category method `rntv_systemBackgroundColor` that works across all platforms. On tvOS it returns white/black for light/dark mode. On other platforms it returns the system color.

Changes are isolated to new files (RCTTVColorSupport.h/mm) to minimize touching core React Native files. This reduces merge conflicts with upstream updates. The `rntv_` prefix makes resolution straightforward if conflicts do occur.

## Changelog:
[TVOS][ADDED] - Add rntv_systemBackgroundColor category for tvOS support

## Test Plan:
```bash
# Clean and setup workspace
git reset HEAD --hard
git clean -xdf
yarn
cd packages/rn-tester

# Download Hermes prebuilt binary
curl -Lo /tmp/hermes-ios-0.15.0-debug.tar.gz \
  https://repo1.maven.org/maven2/com/facebook/hermes/hermes-ios/0.15.0/hermes-ios-0.15.0-hermes-ios-debug.tar.gz

# Setup and open project
HERMES_ENGINE_TARBALL_PATH=/tmp/hermes-ios-0.15.0-debug.tar.gz yarn setup-tvos-hermes
xed .

# In a separate terminal
yarn start
```
In Xcode:

- Select a tvOS 18.0+ simulator
- Build and run
- Verify app launches

Note: tvOS 18+ avoids Hermes ABI issues.