### PR TITLE
fix (tvOS): handle autoFocus correctly on view mount

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -1166,7 +1166,6 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   // `autoFocus`
   if (oldViewProps.autoFocus != newViewProps.autoFocus) {
     _autoFocus = newViewProps.autoFocus;
-    [self handleFocusGuide];
   }
 
   _trapFocusUp = newViewProps.trapFocusUp;
@@ -1228,7 +1227,7 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
       [self requestFocusSelf];
     }
   }
-
+  [self handleFocusGuide];
 #endif
 
   if (_swiftUIWrapper != nullptr) {


### PR DESCRIPTION
## Summary:

Under certain conditions (including pushing modals in react navigation), a tvOS view may attempt to set up the focus guides for autoFocus too early, leading to a view that cannot be navigated correctly with the remote.

This PR defers the focus guide setup until layout happens.

Fixes #989 .

## Test Plan:

See https://github.com/douglowder/TVNewArchFocusTest for the repro, which is fixed by this patch.
