### PR TITLE
port focus loop fix from #969 to Kotlin

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -1458,7 +1458,13 @@ public open class ReactViewGroup public constructor(context: Context?) :
     if (isFocusDestinationsSet) {
       val destination = findDestinationView()
 
-      if (destination != null && requestFocusViewOrAncestor(destination)) {
+      // Destination is set but there's no such element on the tree
+      // Just skip it to prevent cyclic issues.
+      if (destination == null) {
+        return false
+      }
+
+      if (destination.requestFocus()) {
         return true
       }
     }
@@ -1482,9 +1488,7 @@ public open class ReactViewGroup public constructor(context: Context?) :
       }
 
       // Try moving the focus to the first focusable element otherwise.
-      if (moveFocusToFirstFocusable(this)) {
-        return true
-      }
+      return moveFocusToFirstFocusable(this)
     }
 
     return super.requestFocus(direction, previouslyFocusedRect)
@@ -1615,22 +1619,6 @@ public open class ReactViewGroup public constructor(context: Context?) :
 
     fun setViewClipped(view: View, clipped: Boolean) {
       view.setTag(R.id.view_clipped, clipped)
-    }
-
-    private fun requestFocusViewOrAncestor(destination: View): Boolean {
-      var v: View? = destination
-      while (v != null) {
-        if (v.requestFocus()) {
-          return true
-        }
-        val parent = v.parent
-        v = if (parent is View) {
-          parent
-        } else {
-          null
-        }
-      }
-      return false
     }
   }
 }


### PR DESCRIPTION
## Summary:
I made some changes in #969 to improve the TVFocusGuideView stability quite a while ago. It's been used in production for quite some time. It's ready to be landed on main so that everybody can benefit from the stability improvements.

## Changelog:
[ANDROID] [FIXED] - Improve TVFocusGuideView stability.