### PR TITLE
fix (Android): prevent crash when setting focusable in focus guides

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -109,13 +109,13 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
 
   @ReactProp(name = "tvFocusable")
   public open fun setTvFocusable(view: ReactViewGroup, focusable: Boolean) {
-    setFocusable(view, focusable)
     if (!focusable) {
       view.isFocusable = false
       view.descendantFocusability = ViewGroup.FOCUS_BLOCK_DESCENDANTS
     } else {
       view.descendantFocusability = ViewGroup.FOCUS_AFTER_DESCENDANTS
     }
+    setFocusable(view, focusable)
   }
 
   @ReactProp(name = ViewProps.ACCESSIBILITY_ORDER)


### PR DESCRIPTION
## Summary:

When modifying the `focusable` prop of a `TVFocusGuideView` on Android, a crash can occur:

<img width="1039" height="649" alt="Screenshot 2026-01-17 at 11 59 32 AM" src="https://github.com/user-attachments/assets/97c5f107-17cb-4192-8d64-7e840a3bfec6" />

This is fixed by modifying the Android native `tvFocusable` setter in `ReactViewManager`, so that the descendant focusability is modified first before calling `setFocusable` on the view itself.

## Test Plan:

A demo of this issue is at https://github.com/douglowder/TVNewArchFocusTest .
