### PR TITLE
fix (Android): Fix hasTVPreferredFocus in TalkBack mode

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -147,22 +147,7 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
 
   @ReactProp(name = "hasTVPreferredFocus")
   public open fun setTVPreferredFocus(view: ReactViewGroup, hasTVPreferredFocus: Boolean) {
-    /*
-     * React prop functions like this one gets called repeatedly on the New Architecture
-     * no matter the prop has changed or not. Contrary to others, `hasTVPreferredFocus` has
-     * a side effect, calling `requestFocus` function on the view which disrupts the user flow
-     * and should only called once when the property changes to `true.
-     * We keep a special state in the View class and run a comparison here to mitigate
-     * that problem.
-     */
-    if (view.hasTVPreferredFocus == hasTVPreferredFocus) return;
-    view.hasTVPreferredFocus = hasTVPreferredFocus;
-
-    if (hasTVPreferredFocus) {
-      view.isFocusable = true
-      view.isFocusableInTouchMode = true
-      view.requestFocus()
-    }
+    view.setPreferredFocus(hasTVPreferredFocus)
   }
 
   @ReactProp(name = "autoFocus")


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

hasTVPreferredFocus does not work in TalkBack.

Core reason:
Android View's AccessibilityNode is registered after view is attached to window:
```
protected void onAttachedToWindow() {
  (...)
  AccessibilityNodeIdManager.getInstance().registerViewWithId(this, getAccessibilityViewId());
```
ReactViewManager does not wait for window attach while setting `hasTVPreferredFocus` though, causing unexpected behavior in TalkBack mode. Focus splits into separate "regular" focus (on component with hasTVPreferredFocus) and a11y-focus (stays on the previous element).

While regular focus attempt mostly succeeds even before the view is attached (with some edge cases), accessibility focus fails in 100% such cases.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID] [FIXED] - Fix hasTVPreferredFocus in TalkBack

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

## Test Plan:

- enable TalkBack
- create a Pressable with hasTVPreferredFocus
- mount it

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
