### PR TITLE
Cherry-pick: Include tvosCommands.js in npm package in 0.84.0-0 (fix for #1030)

### DIFF
--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -91,6 +91,7 @@
     "React-Core.podspec",
     "React-Core-prebuilt.podspec",
     "react-native.config.js",
+    "tvosCommands.js",
     "React.podspec",
     "React",
     "!React/Fabric/RCTThirdPartyFabricComponentsProvider.*",


### PR DESCRIPTION
Cherry-picking d93fe75 from main into `release/0.84.0-rc2`.

This fixes a packaging issue where tvosCommands.js was missing from the npm package, causing the tvOS CLI commands (run-tvos, log-tvos, build-tvos) from #1030 to fail for consumers.

> [!NOTE] 
> Not sure if release/0.84.0-rc2 is the right target branch for this cherry-pick.

## Changelog:

[TVOS] [ADDED] - Added run-tvos, build-tvos, and log-tvos commands for tvOS development