### PR TITLE
fix: tvos request focus on unmounted views

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -88,6 +88,7 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   NSArray* _focusDestinations;
   id<UIFocusItem> _previouslyFocusedItem;
   RCTSwiftUIContainerViewWrapper *_swiftUIWrapper;
+  BOOL _shouldFocusOnMount;
 }
 
 #ifdef RCT_DYNAMIC_FRAMEWORKS
@@ -116,6 +117,8 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
     _tvParallaxProperties.pressMagnification = 1.0f;
     _tvParallaxProperties.pressDuration = 0.3f;
     _tvParallaxProperties.pressDelay = 0.0f;
+    
+    _shouldFocusOnMount = false;
 #endif
   }
   return self;
@@ -171,6 +174,15 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
 
 #pragma mark - Apple TV methods
 
+- (void)didMoveToWindow {
+  [super didMoveToWindow];
+
+  if (self->_shouldFocusOnMount) {
+    self->_shouldFocusOnMount = false;
+    [self focusSelf];
+  }
+}
+
 - (RCTSurfaceHostingProxyRootView *)containingRootView
 {
   UIView *rootview = self;
@@ -206,10 +218,8 @@ const CGFloat BACKGROUND_COLOR_ZPOSITION = -1024.0f;
   if (!focusedSync) {
     // `focusSelf` function relies on `rootView` which may not be present on the first render.
     // `focusSelf` fails and returns `false` in that case. We try re-executing the same action
-    // by putting it to the main queue to make sure it runs after UI creation is completed.
-    dispatch_async(dispatch_get_main_queue(), ^{
-      [self focusSelf];
-    });
+    // when the view has moved to the window. This is tracked by the `_shouldFocusOnMount` flag.
+    self->_shouldFocusOnMount = true;
   }
 }
 


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

When we navigate from screen A to screen B we try to move the initial focus to a button a bit further down the page. This is consistently failing ever since adopting the new arch, since `requestTVFocus` is getting called while the component exists but is not part of a view hierarchy yet. When debugging, this came down to `rootView` always being nil, even after the current attempt at skipping a render loop.

So far we have reliably been able to focus these components again with the following changes. This postpones the async re-execution until `didMoveToWindow` is called, under the assumption by that point `containingRootView` will resolve and focussing will succeed.

Of course always happy to get any feedback on this approach.

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[TVOS][FIXED] - Postpone request focus re-execution until view moved to window.

<!-- ## Test Plan: -->

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->
