### PR TITLE
fix: only trigger onPressOut on the same component

### DIFF
--- a/packages/react-native/Libraries/Pressability/Pressability.js
+++ b/packages/react-native/Libraries/Pressability/Pressability.js
@@ -398,6 +398,7 @@ export default class Pressability {
   _touchActivateTime: ?number;
   _touchState: TouchState = 'NOT_RESPONDER';
   _longPressSent: boolean = false;
+  _tvPressInReceived: boolean = false;
 
   constructor(config: PressabilityConfig) {
     this.configure(config);
@@ -416,6 +417,7 @@ export default class Pressability {
     this._cancelLongPressDelayTimeout();
     this._cancelPressDelayTimeout();
     this._cancelPressOutDelayTimeout();
+    this._tvPressInReceived = false;
 
     // Ensure that, if any async event handlers are fired after unmount
     // due to a race, we don't call any configured callbacks.
@@ -443,6 +445,7 @@ export default class Pressability {
           return;
         }
 
+        this._tvPressInReceived = true;
         this._longPressSent = false;
 
         const {onPressIn, onLongPress} = this._config;
@@ -463,6 +466,10 @@ export default class Pressability {
         if (this._config.disabled === true) {
           return;
         }
+        if (!this._tvPressInReceived) {
+          return;
+        }
+        this._tvPressInReceived = false;
         this._cancelLongPressDelayTimeout();
         const {onPress, onLongPress, onPressOut, android_disableSound} =
           this._config;


### PR DESCRIPTION
Hope this one is simple enough to not have an example code setup ;)

On Android TV, when Pressable A has onLongPress and the user holds the select button, if focus moves to Pressable B while the button is still held (e.g., the onLongPress handler programmatically changes focus), releasing the button triggers onPress on Pressable B, which the user never intended to press.
Root cause: ReactViewGroup.onKeyUp dispatches PressOutEvent to whatever view currently has focus. If focus moved between key-down and key-up, the PressOutEvent arrives at a different Pressability instance than the one that received PressInEvent. That instance has _longPressSent = false (default), so it calls onPress.

I've opted for fixing it in Pressability.js because that seems to already have other similar things in place related to the long press.

See the example here, remote event are displayed in the bottom right. First `longSelect` is the down, second is the up.

With the fix:

https://github.com/user-attachments/assets/a7af354f-07ff-4125-947c-0ca57ca45fd9



Without the fix, it triggers the `Watch now` button onPress:

https://github.com/user-attachments/assets/d504f95c-2e49-4a74-9f65-a833f55aeb20

