### PR TITLE
fix: remove non-null assertion on getFirstFocusableView return value

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -631,7 +631,7 @@ public open class ReactViewGroup public constructor(context: Context?) :
       index++
     }
 
-    return firstFocusableElement!!
+    return firstFocusableElement
   }
 
   private fun moveFocusToFirstFocusable(viewGroup: ReactViewGroup): Boolean {


### PR DESCRIPTION
The !! operator caused a NullPointerException crash when no focusable element was found in a view group. All callers already handle null.

Like mentioned in the DM this should fix the following crash

```
java.lang.NullPointerException
at com.facebook.react.views.view.ReactViewGroup.getFirstFocusableView(ReactViewGroup.kt:633)
at com.facebook.react.views.view.ReactViewGroup.moveFocusToFirstFocusable(ReactViewGroup.kt:637)
at com.facebook.react.views.view.ReactViewGroup.requestFocus(ReactViewGroup.kt:1481)
at android.view.View.requestFocus(View.java:14450)
at android.widget.ScrollView.arrowScroll(ScrollView.java:1305)
at android.widget.ScrollView.executeKeyEvent(ScrollView.java:545)
at com.facebook.react.views.scroll.ReactScrollView.executeKeyEvent(ReactScrollView.java:720)
at android.widget.ScrollView.dispatchKeyEvent(ScrollView.java:505)
at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1966)
at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1966)
at android.view.ViewGroup.dispatchKeyEvent(ViewGroup.java:1966)
```