### PR TITLE
Support previous/next actions on FireOS

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -426,7 +426,11 @@ export type AndroidTextInputNativeProps = Readonly<{
    * Invalid if `multiline={true}` is specified.
    */
   onSubmitEditing?: ?BubblingEventHandler<
-    Readonly<{target: Int32, text: string, action?: 'submit' | 'next' | 'previous'}>,
+    Readonly<{
+      target: Int32,
+      text: string,
+      action?: 'submit' | 'next' | 'previous',
+    }>,
   >,
 
   /**

--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -426,7 +426,7 @@ export type AndroidTextInputNativeProps = Readonly<{
    * Invalid if `multiline={true}` is specified.
    */
   onSubmitEditing?: ?BubblingEventHandler<
-    Readonly<{target: Int32, text: string}>,
+    Readonly<{target: Int32, text: string, action?: 'submit' | 'next' | 'previous'}>,
   >,
 
   /**

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -127,6 +127,7 @@ type TextInputSubmitEditingEventData = Readonly<{
   ...TargetEvent,
   eventCount: number,
   text: string,
+  action?: 'submit' | 'next' | 'previous',
   ...
 }>;
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputManager.kt
@@ -928,6 +928,11 @@ public open class ReactTextInputManager public constructor() :
                   reactContext.surfaceId,
                   editText.id,
                   editText.text.toString(),
+                  action = when (actionId) {
+                    EditorInfo.IME_ACTION_NEXT -> ReactTextInputSubmitEditingEvent.ACTION_NEXT
+                    EditorInfo.IME_ACTION_PREVIOUS -> ReactTextInputSubmitEditingEvent.ACTION_PREVIOUS
+                    else -> ReactTextInputSubmitEditingEvent.ACTION_SUBMIT
+                  },
               )
           )
         }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSubmitEditingEvent.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/textinput/ReactTextInputSubmitEditingEvent.kt
@@ -11,11 +11,12 @@ import com.facebook.react.bridge.Arguments
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.uimanager.events.Event
 
-/** Event emitted by EditText native view when the user submits the text. */
+/** Event emitted by EditText native view when the user triggers an IME editor action. */
 internal class ReactTextInputSubmitEditingEvent(
     surfaceId: Int,
     viewId: Int,
     private val text: String,
+    private val action: String = ACTION_SUBMIT,
 ) : Event<ReactTextInputSubmitEditingEvent>(surfaceId, viewId) {
   override fun getEventName(): String = EVENT_NAME
 
@@ -23,6 +24,7 @@ internal class ReactTextInputSubmitEditingEvent(
     return Arguments.createMap().apply {
       putInt("target", viewTag)
       putString("text", text)
+      putString("action", action)
     }
   }
 
@@ -30,5 +32,8 @@ internal class ReactTextInputSubmitEditingEvent(
 
   companion object {
     private const val EVENT_NAME = "topSubmitEditing"
+    const val ACTION_SUBMIT = "submit"
+    const val ACTION_NEXT = "next"
+    const val ACTION_PREVIOUS = "previous"
   }
 }


### PR DESCRIPTION
## Summary:

On FireOS `IME_ACTION_NEXT` and `IME_ACTION_PREVIOUS` both fire the `onSubmitEditing` event, but there's no way for the JS side to distinguish between a "submit", "next", or "previous" action.
This makes it impossible to implement proper focus navigation between text inputs on this platform.

This PR adds an `action` field to the `onSubmitEditing` event payload, so developers can handle each case appropriately (e.g., moving focus to the next/previous input vs. submitting a form), in order to be able to handle previous actions on FireOS.

## Changelog:

[ANDROID] [ADDED] - Add action field ('submit' | 'next' | 'previous') to `onSubmitEditing` event for distinguishing IME editor actions in FireOS.

## Test Plan:

Verified that the `onSubmitEditing` event for FireOS now includes the correct action:

- After pressing `previous`
- After submitting the input with `next`
- After pressing back on the remote

Also tested for regressions on Android, no issues were found.

https://github.com/user-attachments/assets/2cdad9b8-ce04-4dd1-9d1b-312e562142b4

Fixes: https://github.com/react-native-tvos/react-native-tvos/issues/1070