### PR TITLE
[tvOS] Add action field to onSubmitEditing for tvOS

### DIFF
--- a/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
+++ b/packages/react-native/Libraries/Components/TextInput/AndroidTextInputNativeComponent.js
@@ -429,7 +429,7 @@ export type AndroidTextInputNativeProps = Readonly<{
     Readonly<{
       target: Int32,
       text: string,
-      action?: 'submit' | 'next' | 'previous',
+      action: 'submit' | 'next' | 'previous',
     }>,
   >,
 

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.d.ts
@@ -554,6 +554,7 @@ export type TextInputEndEditingEvent =
  */
 export interface TextInputSubmitEditingEventData {
   text: string;
+  action: 'submit' | 'next' | 'previous';
 }
 
 /**

--- a/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
+++ b/packages/react-native/Libraries/Components/TextInput/TextInput.flow.js
@@ -127,7 +127,7 @@ type TextInputSubmitEditingEventData = Readonly<{
   ...TargetEvent,
   eventCount: number,
   text: string,
-  action?: 'submit' | 'next' | 'previous',
+  action: 'submit' | 'next' | 'previous',
   ...
 }>;
 

--- a/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
+++ b/packages/react-native/React/CoreModules/RCTEventDispatcher.mm
@@ -99,6 +99,10 @@ RCT_EXPORT_MODULE()
     body[@"text"] = [text copy];
   }
 
+  if (type == RCTTextEventTypeSubmit) {
+    body[@"action"] = @"submit";
+  }
+
   if (key != nullptr) {
     if (key.length == 0) {
       key = @"Backspace"; // backspace

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -428,6 +428,7 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
   // (no connection to any specific "submitting" process).
 
   if (_eventEmitter && shouldSubmit) {
+    // iOS & tvOS only supports "submit"; action defaults to "submit" in the emitter.
     static_cast<const TextInputEventEmitter &>(*_eventEmitter).onSubmitEditing([self _textInputMetrics]);
   }
   return shouldSubmit;

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.cpp
@@ -161,8 +161,19 @@ void TextInputEventEmitter::onEndEditing(
 }
 
 void TextInputEventEmitter::onSubmitEditing(
-    const Metrics& textInputMetrics) const {
-  dispatchTextInputEvent("submitEditing", textInputMetrics);
+    const Metrics& textInputMetrics,
+    const std::string& action) const {
+  dispatchEvent(
+      "submitEditing", [textInputMetrics, action](jsi::Runtime& runtime) {
+        auto payload =
+            textInputMetricsPayload(runtime, textInputMetrics, false)
+                .asObject(runtime);
+        payload.setProperty(
+            runtime,
+            "action",
+            jsi::String::createFromUtf8(runtime, action));
+        return payload;
+      });
 }
 
 void TextInputEventEmitter::onKeyPress(

--- a/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/textinput/TextInputEventEmitter.h
@@ -41,7 +41,7 @@ class TextInputEventEmitter : public ViewEventEmitter {
   void onContentSizeChange(const Metrics &textInputMetrics) const;
   void onSelectionChange(const Metrics &textInputMetrics) const;
   void onEndEditing(const Metrics &textInputMetrics) const;
-  void onSubmitEditing(const Metrics &textInputMetrics) const;
+  void onSubmitEditing(const Metrics &textInputMetrics, const std::string &action = "submit") const;
   void onKeyPress(const KeyPressMetrics &keyPressMetrics) const;
   void onScroll(const Metrics &textInputMetrics) const;
 


### PR DESCRIPTION
## Summary
Fixes #1103. Companion to #1098.

Aligns the `onSubmitEditing` payload between Android and Apple by including the `action` property on text input submission. The property is non-optional, so cross-platform engineers can rely on it being present. Both Paper and Fabric implementations have been updated. No regression risk since `action` is a new field.

## Changelog
[TVOS] [ADDED] Add `action` field to `onSubmitEditing` event for Apple TV.

## Test Plan
Tested using the `rn-tester` app with the Text Input example. Verified via console logging that `action` is set to `"submit"` on form submission.