### PR TITLE
fix(android): fix snapToAlignment="item" and computeScroll for disabled animation

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -257,6 +257,8 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
         && !mScrollAnimationEnabled
         && mScroller != null
         && !mScroller.isFinished()) {
+      // Jump instantly to the target position instead of animating.
+      scrollTo(mScroller.getFinalX(), mScroller.getFinalY());
       mScroller.forceFinished(true);
       return;
     }
@@ -832,12 +834,11 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   public boolean arrowScroll(int direction) {
     boolean handled = false;
 
-    if (!mScrollAnimationEnabled) {
-      // When scroll animation is disabled, find the next focusable and request focus directly.
-      // This must come before the mPagingEnabled check because snapToInterval on Android
-      // auto-enables paging, and the paging branch uses smoothScrollToNextPage which
-      // scrolls by full page width instead of by snap interval.
-      // requestChildFocus → tryScrollSnapToChild/scrollToChild handles instant scrolling.
+    if (mSnapToAlignment == SNAP_ALIGNMENT_ITEM) {
+      // When snapToAlignment is "item", find the next focusable and request focus directly.
+      // This avoids super.arrowScroll() which starts its own scroll animation that conflicts
+      // with tryScrollSnapToChild's snap scrolling.
+      // requestChildFocus → tryScrollSnapToChild handles scrolling.
       View currentFocused = findFocus();
       View nextFocused = FocusFinder.getInstance().findNextFocus(this, currentFocused, direction);
       if (nextFocused != null && nextFocused != currentFocused && nextFocused != this) {

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -24,6 +24,7 @@ import android.graphics.Rect;
 import android.graphics.drawable.ColorDrawable;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
+import android.view.FocusFinder;
 import android.view.KeyEvent;
 import android.view.MotionEvent;
 import android.view.View;
@@ -546,6 +547,24 @@ public class ReactScrollView extends ScrollView
     return true;
   }
 
+  @Override
+  public boolean arrowScroll(int direction) {
+    if (mSnapToAlignment == SNAP_ALIGNMENT_ITEM) {
+      // When snapToAlignment is "item", find the next focusable and request focus directly.
+      // This avoids super.arrowScroll() which starts its own scroll animation that conflicts
+      // with tryScrollSnapToChild's snap scrolling.
+      // requestChildFocus → tryScrollSnapToChild handles scrolling.
+      View currentFocused = findFocus();
+      View nextFocused = FocusFinder.getInstance().findNextFocus(this, currentFocused, direction);
+      if (nextFocused != null && nextFocused != currentFocused && nextFocused != this) {
+        nextFocused.requestFocus(direction);
+        return true;
+      }
+      return false;
+    }
+    return super.arrowScroll(direction);
+  }
+
   /**
    * Since ReactScrollView handles layout changes on JS side, it does not call super.onlayout due to
    * which mIsLayoutDirty flag in ScrollView remains true and prevents scrolling to child when
@@ -621,9 +640,8 @@ public class ReactScrollView extends ScrollView
         && !mScrollAnimationEnabled
         && mScroller != null
         && !mScroller.isFinished()) {
-      // When scroll animation is disabled, just abort any in-flight smooth scroll.
-      // The correct position has already been set synchronously by
-      // requestChildFocus → tryScrollSnapToChild/scrollToChild.
+      // Jump instantly to the target position instead of animating.
+      scrollTo(mScroller.getFinalX(), mScroller.getFinalY());
       mScroller.forceFinished(true);
       return;
     }


### PR DESCRIPTION
## Summary

Fixes two related Android scroll view issues:

- **`snapToAlignment="item"` snaps to wrong positions when `scrollAnimationEnabled={true}`**: `arrowScroll()` fell through to `super.arrowScroll()` which starts its own scroll animation that conflicts with `tryScrollSnapToChild`'s snap-based scrolling. For example, scrolling to a partial clipped element, would result in the native focus taking over instead of the snapping behaviour. Fix: when `snapToAlignment` is `"item"`, bypass `super.arrowScroll()` and use manual focus finding via `FocusFinder` → `requestFocus()` → `requestChildFocus` → `tryScrollSnapToChild`, which computes the correct snap offset.

- **`scrollAnimationEnabled={false}` prevents reaching off-screen items**: `computeScroll()` called `mScroller.forceFinished(true)` which kills the scroll at the *current* position, so `super.arrowScroll()`'s scroll never actually moved the viewport. Fix: jump instantly to the scroller's *target* position via `scrollTo(getFinalX(), getFinalY())` before finishing, so the viewport moves and off-screen items become reachable.

Both fixes apply to `ReactHorizontalScrollView` and `ReactScrollView`.

## Test plan

- [ ] `snapToAlignment="item"` with `scrollAnimationEnabled={true}`: scroll forward and backward — items should snap to correct positions in both directions
- [ ] `snapToAlignment="item"` with `scrollAnimationEnabled={false}`: same as above but with instant scrolling
- [ ] `scrollAnimationEnabled={false}` without `snapToAlignment`: should be able to navigate to all items including those initially off-screen
- [ ] `scrollAnimationEnabled={true}` without `snapToAlignment`: default behavior should be unaffected
- [ ] Verify both horizontal and vertical scroll views
- [ ] FlatList with `removeClippedSubviews={false}` should work correctly with all combinations above

🤖 Generated with [Claude Code](https://claude.com/claude-code)