### PR TITLE
feat(rn-tester/android): support building against precompiled Maven artifacts

### DIFF
--- a/packages/rn-tester/android/app/build.gradle.kts
+++ b/packages/rn-tester/android/app/build.gradle.kts
@@ -16,6 +16,39 @@ plugins {
 val reactNativeDirPath = "$rootDir/packages/react-native"
 val isNewArchEnabled = project.property("newArchEnabled") == "true"
 
+// Optional artifacts-mode toggle. When `reactNativeMavenLocalPath` is set (e.g.
+// `-PreactNativeMavenLocalPath=/tmp/maven-local`) RN-Tester consumes the
+// `react-android` AAR from that local Maven repo and the upstream Hermes AAR
+// (via the npm hermes-compiler) instead of compiling React Native from source.
+// When unset, the historical source-build behavior is preserved unchanged.
+val reactNativeMavenLocalPath: String? =
+    project.findProperty("reactNativeMavenLocalPath")?.toString()?.takeIf { it.isNotBlank() }
+val useReactNativeArtifacts: Boolean = reactNativeMavenLocalPath != null
+val reactNativeArtifactVersion: String =
+    project.findProperty("reactNativeArtifactVersion")?.toString() ?: "1000.0.0"
+val reactNativeArtifactGroup: String =
+    project.findProperty("reactNativeArtifactGroup")?.toString() ?: "io.github.react-native-tvos"
+
+if (useReactNativeArtifacts) {
+  repositories {
+    maven { url = uri(file(reactNativeMavenLocalPath!!)) }
+  }
+
+  // Workspace native modules (e.g. react-native-popup-menu-android) declare a
+  // project() dependency on :packages:react-native:ReactAndroid. When rn-tester
+  // autolinks them, that source project rides along into the runtime classpath
+  // alongside our AAR, producing duplicate classes that R8 rejects in release
+  // builds. Redirect any such project reference to the published AAR coordinate
+  // to keep the classpath single-sourced.
+  configurations.all {
+    resolutionStrategy.dependencySubstitution {
+      substitute(project(":packages:react-native:ReactAndroid"))
+          .using(module("$reactNativeArtifactGroup:react-android:$reactNativeArtifactVersion"))
+          .because("artifacts-mode: source ReactAndroid -> published AAR")
+    }
+  }
+}
+
 /**
  * This is the configuration block to customize your React Native Android app. By default you don't
  * need to apply any configuration, just uncomment the lines you need.
@@ -63,7 +96,8 @@ react {
   //   The hermes compiler command to run. By default it is 'hermesc'
   hermesCommand =
       if (
-          project.findProperty("react.internal.useHermesStable")?.toString()?.toBoolean() == true ||
+          useReactNativeArtifacts ||
+              project.findProperty("react.internal.useHermesStable")?.toString()?.toBoolean() == true ||
               project.findProperty("react.internal.useHermesNightly")?.toString()?.toBoolean() ==
                   true
       )
@@ -78,7 +112,12 @@ val enableProguardInReleaseBuilds = true
 
 /** This allows to customized the CMake version used for compiling RN Tester. */
 val cmakeVersion =
-    project(":packages:react-native:ReactAndroid").properties["cmake_version"].toString()
+    if (useReactNativeArtifacts) {
+      // Match ReactAndroid/build.gradle.kts default; avoids referencing the source project.
+      System.getenv("CMAKE_VERSION") ?: "3.30.5"
+    } else {
+      project(":packages:react-native:ReactAndroid").properties["cmake_version"].toString()
+    }
 
 /** Architectures to build native code for. */
 fun reactNativeArchitectures(): List<String> {
@@ -148,11 +187,16 @@ android {
 }
 
 dependencies {
-  // Build React Native from source
-  implementation(project(":packages:react-native:ReactAndroid"))
-
-  // Consume Hermes as built from source.
-  implementation(project(":packages:react-native:ReactAndroid:hermes-engine"))
+  if (useReactNativeArtifacts) {
+    // Consume the prebuilt React Native AAR from the local Maven repo. Hermes is
+    // pulled transitively via the upstream `hermes-android` AAR.
+    implementation("$reactNativeArtifactGroup:react-android:$reactNativeArtifactVersion")
+  } else {
+    // Build React Native from source
+    implementation(project(":packages:react-native:ReactAndroid"))
+    // Consume Hermes as built from source.
+    implementation(project(":packages:react-native:ReactAndroid:hermes-engine"))
+  }
 
   testImplementation(libs.junit)
   implementation(libs.androidx.profileinstaller)
@@ -186,20 +230,27 @@ tasks.withType<KotlinCompile>().configureEach {
 
 afterEvaluate {
   if (
-      (project.findProperty("react.internal.useHermesNightly") == null ||
-          project.findProperty("react.internal.useHermesNightly").toString() == "false") &&
+      !useReactNativeArtifacts &&
+          (project.findProperty("react.internal.useHermesNightly") == null ||
+              project.findProperty("react.internal.useHermesNightly").toString() == "false") &&
           (project.findProperty("react.internal.useHermesStable") == null ||
               project.findProperty("react.internal.useHermesStable").toString() == "false")
   ) {
     // As we're consuming Hermes from source, we want to make sure
-    // `hermesc` is built before we actually invoke the `emit*HermesResource` task
+    // `hermesc` is built before we actually invoke the `emit*HermesResource` task.
+    // In artifacts mode, hermesc comes from `node_modules/hermes-compiler` and the
+    // libhermes.so runtime ships in the upstream hermes-android AAR, so this is a
+    // no-op there.
     tasks
         .getByName("createBundleReleaseJsAndAssets")
         .dependsOn(":packages:react-native:ReactAndroid:hermes-engine:buildHermesC")
   }
 
-  // As RN-Tester consumes the codegen from source, we need to make sure the codegen exists before
-  // we can actually invoke it. It's built by the ReactAndroid:buildCodegenCLI task.
+  // The codegen JS lib (`node_modules/@react-native/codegen/lib/`) is required even in
+  // artifacts mode: the `react-android` AAR doesn't ship it, and Yarn workspaces resolve
+  // `@react-native/codegen` to the workspace package via a symlink, which skips the npm
+  // `prepare` step that would normally pre-build `lib/`. The buildCodegenCLI task runs
+  // the codegen package's build script and is the canonical way to produce that output.
   tasks
       .getByName("generateCodegenSchemaFromJavaScript")
       .dependsOn(":packages:react-native:ReactAndroid:buildCodegenCLI")


### PR DESCRIPTION
## Why

This is needed to support CI workflows where Maven artifacts are generated first, then RNTester app images are built in a separate CI job.

## How

Adds an opt-in artifacts mode for the RN-Tester Android app, driven by the
presence of a Gradle property:

    ./gradlew :packages:rn-tester:android:app:assembleDebug \
        -PreactNativeMavenLocalPath=/tmp/maven-local

When the property is unset the historical source-build behavior is preserved
exactly. When set, the build:

  - Adds the supplied path as a Maven repository.
  - Replaces the project(":packages:react-native:ReactAndroid") and
    :hermes-engine dependencies with the published react-android AAR. Hermes is
    pulled transitively via the upstream hermes-android AAR.
  - Routes hermesCommand to the npm hermes-compiler binary so the JS bundle is
    hermesc'd against the same compiler version the AAR ships with.
  - Reads cmake_version from $CMAKE_VERSION (defaulting to 3.30.5, matching
    ReactAndroid/build.gradle.kts) instead of reaching into the source
    ReactAndroid project's properties.
  - Skips the source-only buildHermesC task dependency (libhermes.so ships in
    the AAR; hermesc comes from node_modules/hermes-compiler).
  - Adds a configuration-wide dependency substitution that redirects any
    project(":packages:react-native:ReactAndroid") reference to the published
    AAR coordinate. Workspace native modules (e.g. react-native-popup-menu-
    android) declare such project deps, and without this substitution they
    drag the source RA classes into the runtime classpath alongside the AAR,
    causing duplicate-class failures in R8 (release builds).

The buildCodegenCLI task dependency is intentionally retained in both modes:
the @react-native/codegen package is resolved via a Yarn workspace symlink to
packages/react-native-codegen, which doesn't ship a pre-built lib/ directory
(the npm `prepare` step that would normally produce it is skipped for symlinked
workspace deps). buildCodegenCLI runs the codegen package's build script and
populates lib/ on disk, which is required by generateCodegenSchemaFromJavaScript
regardless of whether react-android comes from source or AAR.

Optional overrides:

  -PreactNativeArtifactGroup=...   (default: io.github.react-native-tvos)
  -PreactNativeArtifactVersion=... (default: 1000.0.0)

settings.gradle.kts is intentionally unchanged: the source modules remain in
the build graph but are not depended on for compilation in artifacts mode, so
Gradle configures but does not compile them.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
