### PR TITLE
feat: add scrollSnapOffset for per-item snap offsets

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,7 @@ class Game2048 extends React.Component {
   | Prop (View) | Value | Description |
   |---|---|---|
   | scrollSnapAlign | `'start'` \| `'center'` \| `'end'` | Controls where this item snaps inside its parent ScrollView. Only used when the parent has `snapToAlignment="item"`. |
+  | scrollSnapOffset | `number` | Per-item pixel offset (in dp/pt). When set, the focus engine lands this item's leading edge at `scrollSnapOffset` from the viewport origin. Standalone alternative to `scrollSnapAlign` — takes precedence if both are set on the same item. Only used when the parent has `snapToAlignment="item"`. |
 
   ```jsx
   <ScrollView
@@ -291,6 +292,16 @@ class Game2048 extends React.Component {
   </ScrollView>
   ```
 
+  `scrollSnapOffset` is useful when different items in the same ScrollView need to land at different positions — e.g. a hero row peeking 27dp from the top while poster rows peek 550dp:
+
+  ```jsx
+  <ScrollView snapToAlignment="item">
+    <View scrollSnapOffset={27}><Hero /></View>
+    <View scrollSnapOffset={100}><Featured /></View>
+    <View scrollSnapOffset={550}><PosterRow /></View>
+  </ScrollView>
+  ```
+
   - _ScrollView animation control_: The `scrollAnimationEnabled` prop allows disabling scroll animations when focus changes on TV. When set to `false`, the scroll view jumps instantly to the focused item instead of animating. This only affects TV platforms and has no effect on mobile.
 
   | Prop (ScrollView) | Value | Description |
@@ -307,7 +318,8 @@ class Game2048 extends React.Component {
 
   - _Interaction with existing ScrollView props_: The TV scroll props build on top of existing React Native ScrollView behavior. Here is how they interact:
 
-    - `snapToAlignment="item"` does not require `snapToInterval` to be set. It works as a standalone snapping mode where each child's `scrollSnapAlign` determines the snap position. If `snapToInterval` is also set, the interval is applied as an additional constraint after the item offset is computed.
+    - `snapToAlignment="item"` does not require `snapToInterval` to be set. It works as a standalone snapping mode where each child's `scrollSnapAlign` or `scrollSnapOffset` determines the snap position. If `snapToInterval` is also set, the interval is applied as an additional constraint after the item offset is computed.
+    - `scrollSnapOffset` ignores `snapToItemPadding`. The padding is a global value applied to `scrollSnapAlign` cases; `scrollSnapOffset` is itself a per-item pixel offset that fully specifies where the item lands.
     - `snapToAlignment="item"` should not be combined with `pagingEnabled`. Both attempt to control scroll positioning independently, which leads to unpredictable behavior. Use one or the other.
     - `snapToStart` and `snapToEnd` work independently of `snapToAlignment="item"`. They control edge behavior during swipe/drag momentum (whether the scroll view snaps to the first or last position), but do not affect focus driven item snapping.
     - `scrollAnimationEnabled={false}` disables all scroll animations, including programmatic `scrollTo({animated: true})` calls. When disabled, all scrolling is instant.

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -515,7 +515,7 @@ export interface ScrollViewPropsIOS {
    *      - `start` (the default) will align the snap at the left (horizontal) or top (vertical)
    *      - `center` will align the snap in the center
    *      - `end` will align the snap at the right (horizontal) or bottom (vertical)
-   *      - `item` will align the snap according to the value of `scrollSnapAlign` for individual items in the scroll view (TV platforms only).
+   *      - `item` will align the snap according to each item's own `scrollSnapAlign` or `scrollSnapOffset` prop (TV platforms only).
    */
   snapToAlignment?: 'start' | 'center' | 'end' | 'item' | undefined;
 

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -619,7 +619,7 @@ type ScrollViewBaseProps = Readonly<{
    *   - `'start'` (the default) will align the snap at the left (horizontal) or top (vertical)
    *   - `'center'` will align the snap in the center
    *   - `'end'` will align the snap at the right (horizontal) or bottom (vertical)
-   *   - `'item'` will align the snap according to the value of `scrollSnapAlign` for individual items in the scroll view (TV platforms only).
+   *   - `'item'` will align the snap according to each item's own `scrollSnapAlign` or `scrollSnapOffset` prop (TV platforms only).
    */
   snapToAlignment?: ?('start' | 'center' | 'end' | 'item'),
   /**

--- a/packages/react-native/Libraries/Components/TV/TVViewPropTypes.js
+++ b/packages/react-native/Libraries/Components/TV/TVViewPropTypes.js
@@ -131,4 +131,13 @@ export type TVViewProps = $ReadOnly<{|
    */
   scrollSnapAlign?: ?('start' | 'center' | 'end'),
 
+  /**
+   * Per-item scroll snap offset in dp/pt. When set on a View inside a
+   * ScrollView with `snapToAlignment="item"`, the focus engine lands the
+   * View's top at viewport y = scrollSnapOffset. Standalone alternative to
+   * `scrollSnapAlign` — set one or the other; if both are set on the same
+   * View, `scrollSnapOffset` takes precedence.
+   */
+  scrollSnapOffset?: ?number,
+
 |}>;

--- a/packages/react-native/Libraries/Components/View/View.js
+++ b/packages/react-native/Libraries/Components/View/View.js
@@ -177,9 +177,13 @@ component View(
       delete resolvedProps.isTVSelectable;
     }
 
-    // Views with scrollSnapAlign must not be flattened by Fabric, otherwise
-    // the prop never reaches the native view and scroll snapping breaks.
-    if (resolvedProps.scrollSnapAlign != null) {
+    // Views with scrollSnapAlign or scrollSnapOffset must not be flattened by
+    // Fabric, otherwise the prop never reaches the native view and scroll
+    // snapping breaks.
+    if (
+      resolvedProps.scrollSnapAlign != null ||
+      resolvedProps.scrollSnapOffset != null
+    ) {
       resolvedProps.collapsable = false;
     }
 

--- a/packages/react-native/Libraries/NativeComponent/TVViewConfig.js
+++ b/packages/react-native/Libraries/NativeComponent/TVViewConfig.js
@@ -26,5 +26,6 @@ export const validAttributesForTVProps = {
   trapFocusDown: true,
   trapFocusUp: true,
   scrollSnapAlign: true,
+  scrollSnapOffset: true,
 };
 

--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -1180,13 +1180,20 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
   self->_eventEmitter->onBlur();
 }
 
-// Focus marker helper: traverses view hierarchy to find scrollSnapAlign prop
-// Returns the view that has the property via the output parameter
-- (NSString *)findScrollSnapAlignInView:(UIView *)view foundView:(UIView **)outView
+// Focus marker helper: traverses view hierarchy to find either scrollSnapAlign
+// or scrollSnapOffset. Returns the view that has the property via the output
+// parameter and the marker type via outAlign/outOffset (exactly one non-nil on
+// return). Walk is inner→outer, latest marker wins (same as PR-1068's
+// scrollSnapAlign behavior). On a single view declaring both, scrollSnapOffset
+// wins as the more specific config.
+- (UIView *)findScrollSnapInView:(UIView *)view
+                        outAlign:(NSString **)outAlign
+                       outOffset:(NSNumber **)outOffset
 {
     UIView *testView = view;
     UIView *snapTarget;
-    NSString *marker;
+    NSString *align;
+    NSNumber *offset;
 
     while (testView && testView != self) {
         if (![testView isKindOfClass:RCTViewComponentView.class])
@@ -1197,28 +1204,37 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
         RCTViewComponentView *componentView = (RCTViewComponentView *)testView;
 
         const auto &viewProps = static_cast<const facebook::react::BaseViewProps &>(*componentView.props);
-        if (viewProps.scrollSnapAlign.has_value() && !viewProps.scrollSnapAlign.value().empty()) {
-            marker = [NSString stringWithUTF8String:viewProps.scrollSnapAlign.value().c_str()];
+        if (viewProps.scrollSnapOffset.has_value()) {
+            offset = @(viewProps.scrollSnapOffset.value());
+            align = nil;
+            snapTarget = componentView;
+        } else if (viewProps.scrollSnapAlign.has_value() && !viewProps.scrollSnapAlign.value().empty()) {
+            align = [NSString stringWithUTF8String:viewProps.scrollSnapAlign.value().c_str()];
+            offset = nil;
             snapTarget = componentView;
         }
 
         testView = [testView superview];
     }
-    *outView = snapTarget;
-    return marker;
+    *outAlign = align;
+    *outOffset = offset;
+    return snapTarget;
 }
 
 - (void)_handleScrollSnapForFocusedView:(UIView *)focusedView
 {
     const auto &scrollProps = static_cast<const ScrollViewProps &>(*_props);
-    UIView *snapAlignView = nil;
-    NSString *scrollSnapAlign = [self findScrollSnapAlignInView:focusedView foundView:&snapAlignView];
-    if (scrollSnapAlign == nil || snapAlignView == nil) {
+
+    NSString *scrollSnapAlign = nil;
+    NSNumber *scrollSnapOffset = nil;
+    UIView *snapTargetView = [self findScrollSnapInView:focusedView
+                                               outAlign:&scrollSnapAlign
+                                              outOffset:&scrollSnapOffset];
+    if (snapTargetView == nil || (scrollSnapAlign == nil && scrollSnapOffset == nil)) {
         return;
     }
-
     RCTEnhancedScrollView *scrollView = (RCTEnhancedScrollView *)_scrollView;
-    CGRect focusedFrame = [snapAlignView convertRect:snapAlignView.bounds toView:_scrollView];
+    CGRect focusedFrame = [snapTargetView convertRect:snapTargetView.bounds toView:_scrollView];
     CGFloat targetOffset;
     CGFloat snapToItemPadding = scrollProps.snapToItemPadding;
 
@@ -1238,8 +1254,12 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
         currentOffset = scrollView.contentOffset.y;
         maxContentSize = scrollView.contentSize.height;
     }
-    // Calculate target offset based on scrollSnapAlign (unified for both axes)
-    if ([scrollSnapAlign isEqualToString:@"start"]) {
+
+    if (scrollSnapOffset != nil) {
+        // Per-item pixel offset path: land the snap target's leading edge
+        // at viewport coordinate = scrollSnapOffset.
+        targetOffset = focusedOrigin - scrollSnapOffset.doubleValue;
+    } else if ([scrollSnapAlign isEqualToString:@"start"]) {
         targetOffset = focusedOrigin - snapToItemPadding;
     } else if ([scrollSnapAlign isEqualToString:@"center"]) {
         CGFloat viewportCenter = viewportSize / 2;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.java
@@ -578,28 +578,38 @@ public class ReactHorizontalScrollView extends HorizontalScrollView
   }
 
   /**
-   * Attempts to scroll-snap to the focused child based on snapToAlignment/scrollSnapAlign.
-   * Returns true if snap scrolling was performed, false otherwise.
+   * Attempts to scroll-snap to the focused child based on snapToAlignment/scrollSnapAlign
+   * or scrollSnapOffset. Returns true if snap scrolling was performed, false otherwise.
    */
   private boolean tryScrollSnapToChild(View focused) {
     if (mSnapToAlignment != SNAP_ALIGNMENT_ITEM) {
       return false;
     }
 
-    kotlin.Pair<View, String> result = ReactScrollViewHelper.findScrollSnapAlign(focused, this);
+    kotlin.Triple<View, String, Integer> result =
+        ReactScrollViewHelper.findScrollSnap(focused, this);
     if (result == null) {
       return false;
     }
 
     View snapTarget = result.getFirst();
     String alignment = result.getSecond();
+    Integer snapOffset = result.getThird();
 
     Rect rect = new Rect();
     snapTarget.getDrawingRect(rect);
     offsetDescendantRectToMyCoords(snapTarget, rect);
 
-    int viewportWidth = getWidth() - getPaddingLeft() - getPaddingRight();
     int maxScrollX = Math.max(0, computeHorizontalScrollRange() - getWidth());
+
+    if (snapOffset != null) {
+      int targetOffset = ReactScrollViewHelper.computeScrollSnapTargetForOffset(
+          rect.left, snapOffset, mSnapInterval, maxScrollX);
+      reactSmoothScrollTo(targetOffset, getScrollY());
+      return true;
+    }
+
+    int viewportWidth = getWidth() - getPaddingLeft() - getPaddingRight();
 
     Integer targetOffset = ReactScrollViewHelper.computeScrollSnapOffset(
         rect.left, rect.right, viewportWidth, alignment, mSnapInterval, mSnapToItemPadding, maxScrollX);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.java
@@ -520,28 +520,38 @@ public class ReactScrollView extends ScrollView
   }
 
   /**
-   * Attempts to scroll-snap to the focused child based on snapToAlignment/scrollSnapAlign.
-   * Returns true if snap scrolling was performed, false otherwise.
+   * Attempts to scroll-snap to the focused child based on snapToAlignment/scrollSnapAlign
+   * or scrollSnapOffset. Returns true if snap scrolling was performed, false otherwise.
    */
   private boolean tryScrollSnapToChild(View focused) {
     if (mSnapToAlignment != SNAP_ALIGNMENT_ITEM) {
       return false;
     }
 
-    kotlin.Pair<View, String> result = ReactScrollViewHelper.findScrollSnapAlign(focused, this);
+    kotlin.Triple<View, String, Integer> result =
+        ReactScrollViewHelper.findScrollSnap(focused, this);
     if (result == null) {
       return false;
     }
 
     View snapTarget = result.getFirst();
     String alignment = result.getSecond();
+    Integer snapOffset = result.getThird();
 
     Rect rect = new Rect();
     snapTarget.getDrawingRect(rect);
     offsetDescendantRectToMyCoords(snapTarget, rect);
 
-    int viewportHeight = getHeight() - getPaddingTop() - getPaddingBottom();
     int maxScrollY = getMaxScrollY();
+
+    if (snapOffset != null) {
+      int targetOffset = ReactScrollViewHelper.computeScrollSnapTargetForOffset(
+          rect.top, snapOffset, mSnapInterval, maxScrollY);
+      reactSmoothScrollTo(getScrollX(), targetOffset);
+      return true;
+    }
+
+    int viewportHeight = getHeight() - getPaddingTop() - getPaddingBottom();
 
     Integer targetOffset = ReactScrollViewHelper.computeScrollSnapOffset(
         rect.top, rect.bottom, viewportHeight, alignment, mSnapInterval, mSnapToItemPadding, maxScrollY);

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -576,27 +576,67 @@ public object ReactScrollViewHelper {
 
   /**
    * Walks up the view hierarchy from the focused view to find a ReactViewGroup with
-   * scrollSnapAlign set. Returns a Pair of (snapTarget, alignment) or null if not found.
+   * either scrollSnapAlign or scrollSnapOffset set. Returns a Triple of (snapTarget,
+   * alignment, offsetPx) or null if neither marker was found. Exactly one of
+   * alignment/offsetPx is non-null on return.
+   *
+   * Walk is inner→outer, latest marker wins. On a single view declaring both,
+   * scrollSnapOffset wins as the more specific config.
    *
    * Shared by [ReactScrollView] and [ReactHorizontalScrollView].
    */
   @JvmStatic
-  public fun findScrollSnapAlign(focused: View, scrollView: ViewGroup): Pair<View, String>? {
+  public fun findScrollSnap(focused: View, scrollView: ViewGroup): Triple<View, String?, Int?>? {
     var view: View? = focused
     var snapTarget: View? = null
     var alignment: String? = null
+    var offset: Int? = null
     while (view != null && view !== scrollView) {
       if (view is ReactViewGroup) {
-        val snap = view.scrollSnapAlign
-        if (snap != null) {
-          alignment = snap
+        val o = view.scrollSnapOffset
+        val a = view.scrollSnapAlign
+        if (o != null) {
+          offset = o
+          alignment = null
+          snapTarget = view
+        } else if (a != null) {
+          alignment = a
+          offset = null
           snapTarget = view
         }
       }
       val parent = view.parent
       view = if (parent is View) parent else null
     }
-    return if (alignment != null && snapTarget != null) Pair(snapTarget, alignment) else null
+    return if (snapTarget != null && (alignment != null || offset != null))
+        Triple(snapTarget, alignment, offset) else null
+  }
+
+  /**
+   * Computes the target scroll offset for the per-item scrollSnapOffset path:
+   * land the snap target's leading edge at `snapOffset` pixels from the viewport origin.
+   *
+   * Returns the clamped target offset.
+   *
+   * Shared by [ReactScrollView] and [ReactHorizontalScrollView].
+   *
+   * @param focusedStart the start coordinate of the snap target in scroll view coordinates
+   * @param snapOffset the per-item pixel offset from the viewport origin
+   * @param snapInterval the snap interval (0 if not set)
+   * @param maxScrollOffset the maximum scroll offset for clamping
+   */
+  @JvmStatic
+  public fun computeScrollSnapTargetForOffset(
+      focusedStart: Int,
+      snapOffset: Int,
+      snapInterval: Int,
+      maxScrollOffset: Int,
+  ): Int {
+    var targetOffset = focusedStart - snapOffset
+    if (snapInterval > 0) {
+      targetOffset = (Math.floor(targetOffset.toDouble() / snapInterval) * snapInterval).toInt()
+    }
+    return Math.max(0, Math.min(targetOffset, maxScrollOffset))
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -173,6 +173,7 @@ public open class ReactViewGroup public constructor(context: Context?) :
   private var onInterceptTouchEventListener: OnInterceptTouchEventListener? = null
   private var needsOffscreenAlphaCompositing = false
   public var scrollSnapAlign: String? = null
+  public var scrollSnapOffset: Int? = null
   private var backfaceOpacity = 0f
   private var backfaceVisible = false
   private var childrenRemovedWhileTransitioning: MutableSet<Int>? = null

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -192,6 +192,11 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
     view.scrollSnapAlign = value
   }
 
+  @ReactProp(name = "scrollSnapOffset", defaultFloat = Float.NaN)
+  public open fun setScrollSnapOffset(view: ReactViewGroup, value: Float) {
+    view.scrollSnapOffset = if (value.isNaN()) null else value.dpToPx().toInt()
+  }
+
   @ReactProp(name = ViewProps.BACKGROUND_IMAGE, customType = "BackgroundImage")
   public open fun setBackgroundImage(view: ReactViewGroup, backgroundImage: ReadableArray?) {
     if (backgroundImage != null && backgroundImage.size() > 0) {

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.cpp
@@ -455,6 +455,12 @@ BaseViewProps::BaseViewProps(
           "scrollSnapAlign",
           sourceProps.scrollSnapAlign,
           {}))
+      ,scrollSnapOffset(ReactNativeFeatureFlags::enableCppPropsIteratorSetter() ? sourceProps.scrollSnapOffset : convertRawProp(
+          context,
+          rawProps,
+          "scrollSnapOffset",
+          sourceProps.scrollSnapOffset,
+          {}))
 #endif
       {}
 
@@ -528,6 +534,7 @@ void BaseViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(trapFocusLeft);
     RAW_SET_PROP_SWITCH_CASE_BASIC(trapFocusRight);
     RAW_SET_PROP_SWITCH_CASE_BASIC(scrollSnapAlign);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollSnapOffset);
 #endif
     // events field
     VIEW_EVENT_CASE(PointerEnter);

--- a/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/BaseViewProps.h
@@ -126,6 +126,7 @@ class BaseViewProps : public YogaStylableProps, public AccessibilityProps {
 
 #if TARGET_OS_TV
   std::optional<std::string> scrollSnapAlign;
+  std::optional<int> scrollSnapOffset;
 #endif
 
 #pragma mark - Convenience Methods

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.cpp
@@ -109,6 +109,15 @@ HostPlatformViewProps::HostPlatformViewProps(
                     "scrollSnapAlign",
                     sourceProps.scrollSnapAlign,
                     {})),
+      scrollSnapOffset(
+          ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
+              ? sourceProps.scrollSnapOffset
+              : convertRawProp(
+                    context,
+                    rawProps,
+                    "scrollSnapOffset",
+                    sourceProps.scrollSnapOffset,
+                    {})),
       needsOffscreenAlphaCompositing(
           ReactNativeFeatureFlags::enableCppPropsIteratorSetter()
               ? sourceProps.needsOffscreenAlphaCompositing
@@ -213,6 +222,7 @@ void HostPlatformViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(focusable);
     RAW_SET_PROP_SWITCH_CASE_BASIC(hasTVPreferredFocus);
     RAW_SET_PROP_SWITCH_CASE_BASIC(scrollSnapAlign);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollSnapOffset);
     RAW_SET_PROP_SWITCH_CASE_BASIC(needsOffscreenAlphaCompositing);
     RAW_SET_PROP_SWITCH_CASE_BASIC(renderToHardwareTextureAndroid);
     RAW_SET_PROP_SWITCH_CASE_BASIC(screenReaderFocusable);
@@ -1082,6 +1092,14 @@ folly::dynamic HostPlatformViewProps::getDiffProps(
       result["scrollSnapAlign"] = scrollSnapAlign.value();
     } else {
       result["scrollSnapAlign"] = folly::dynamic(nullptr);
+    }
+  }
+
+  if (scrollSnapOffset != oldProps->scrollSnapOffset) {
+    if (scrollSnapOffset.has_value()) {
+      result["scrollSnapOffset"] = scrollSnapOffset.value();
+    } else {
+      result["scrollSnapOffset"] = folly::dynamic(nullptr);
     }
   }
 

--- a/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/view/platform/android/react/renderer/components/view/HostPlatformViewProps.h
@@ -48,6 +48,7 @@ class HostPlatformViewProps : public BaseViewProps {
   bool trapFocusLeft{false};
   bool trapFocusRight{false};
   std::optional<std::string> scrollSnapAlign{};
+  std::optional<int> scrollSnapOffset{};
 
   bool needsOffscreenAlphaCompositing{false};
   bool renderToHardwareTextureAndroid{false};

--- a/packages/react-native/ReactNativeApi.d.ts
+++ b/packages/react-native/ReactNativeApi.d.ts
@@ -5741,6 +5741,7 @@ declare type TVViewProps = {
   readonly nextFocusUp?: number
   readonly safePadding?: null | string
   readonly scrollSnapAlign?: "center" | "end" | "start"
+  readonly scrollSnapOffset?: number
   readonly tvParallaxProperties?: TVParallaxPropertiesType
   readonly onPressIn?: (event: any) => void
   readonly onPressOut?: (event: any) => void

--- a/packages/react-native/types/public/ReactNativeTVTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTVTypes.d.ts
@@ -31,6 +31,15 @@ declare module 'react-native' {
   scrollSnapAlign?: 'start' | 'center' | 'end' | undefined;
 
   /**
+   * Per-item scroll snap offset in dp/pt. When set, the focus engine lands
+   * this view's top at viewport y = scrollSnapOffset. Standalone alternative
+   * to `scrollSnapAlign`; takes precedence if both are set on the same View.
+   *
+   * @platform tv
+   */
+  scrollSnapOffset?: number | undefined;
+
+  /**
    * Android TV only prop
    */
   tvFocusable?: boolean | undefined,

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewTVSnapExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewTVSnapExample.js
@@ -8,7 +8,7 @@
  * @format
  */
 
-'use strict';
+
 
 import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
 
@@ -49,14 +49,14 @@ const Card = ({
     <Pressable
       style={({focused}) => [
         {
-          borderRadius: px(12),
-          justifyContent: 'center' as const,
           alignItems: 'center' as const,
-          borderWidth: px(3),
-          borderColor: 'transparent',
-          width: px(width),
-          height: px(height),
           backgroundColor: COLORS[colorIndex % COLORS.length],
+          borderColor: 'transparent',
+          borderRadius: px(12),
+          borderWidth: px(3),
+          height: px(height),
+          justifyContent: 'center' as const,
+          width: px(width),
         },
         focused && {borderColor: '#ffffff'},
       ]}>
@@ -64,9 +64,9 @@ const Card = ({
         <Text
           style={[
             {
+              color: 'rgba(255,255,255,0.8)',
               fontSize: px(22),
               fontWeight: '600',
-              color: 'rgba(255,255,255,0.8)',
             },
             focused && {color: '#ffffff'},
           ]}>
@@ -80,7 +80,7 @@ const Card = ({
 // Section header
 const SectionHeader = ({title}: {title: string}) => (
   <View style={{marginBottom: px(16)}}>
-    <Text style={{fontSize: px(28), fontWeight: '600', color: '#e0e0e0'}}>
+    <Text style={{color: '#e0e0e0', fontSize: px(28), fontWeight: '600' }}>
       {title}
     </Text>
   </View>
@@ -92,15 +92,64 @@ const HorizontalExample = ({align}: {align: 'start' | 'center' | 'end'}) => (
     <SectionHeader title={`Horizontal — snapAlign: ${align}`} />
     <ScrollView
       horizontal
-      snapToAlignment="item"
-      showsHorizontalScrollIndicator={false}>
+      showsHorizontalScrollIndicator={false}
+      snapToAlignment="item">
       {Array.from({length: 15}, (_, i) => (
         <View key={i} scrollSnapAlign={align} style={{marginRight: px(20)}}>
           <Card
+            colorIndex={i}
+            height={160}
             label={`Item ${i + 1}`}
             width={280}
-            height={160}
-            colorIndex={i}
+          />
+        </View>
+      ))}
+    </ScrollView>
+  </View>
+);
+
+// Example: Per-item `scrollSnapOffset` — alternative to `scrollSnapAlign`.
+// The focus engine lands the snap target's leading edge at `scrollSnapOffset`
+// pixels from the viewport origin (top of this ScrollView). Mirrors the
+// VerticalMixedExample varieties — same heights, but instead of strings
+// 'start'/'center'/'end', uses fixed numeric offsets computed to land each
+// row at the equivalent position. Demonstrates that `scrollSnapOffset` can
+// reproduce alignment behaviour without `snapToItemPadding` and adds finer
+// control: any pixel offset is valid, not just the three alignment buckets.
+const OFFSET_VIEWPORT_HEIGHT = 500;
+const offsetMixedHeight = (i: number): number =>
+  [100, 200, 150, 50, 300][i % 5];
+const offsetMixedAlignName = (i: number): string =>
+  ['start', 'center', 'end'][i % 3];
+const offsetMixedValue = (i: number): number => {
+  const h = offsetMixedHeight(i);
+  switch (i % 3) {
+    case 0: // start
+      return 0;
+    case 1: // center
+      return (OFFSET_VIEWPORT_HEIGHT - h) / 2;
+    default: // end
+      return OFFSET_VIEWPORT_HEIGHT - h;
+  }
+};
+
+const VerticalOffsetExample = () => (
+  <View>
+    <SectionHeader title={`Vertical — per-item scrollSnapOffset (mixed)`} />
+    <ScrollView
+      showsVerticalScrollIndicator={false}
+      snapToAlignment="item"
+      style={{height: px(OFFSET_VIEWPORT_HEIGHT)}}>
+      {Array.from({length: 10}, (_, i) => (
+        <View
+          key={i}
+          scrollSnapOffset={px(offsetMixedValue(i))}
+          style={{marginBottom: px(16)}}>
+          <Card
+            colorIndex={i + 5}
+            height={offsetMixedHeight(i)}
+            label={`Row ${i + 1} offset ${offsetMixedValue(i)} (≈ ${offsetMixedAlignName(i)})`}
+            width={450}
           />
         </View>
       ))}
@@ -113,18 +162,18 @@ const ScrollPaddingExample = () => (
   <View>
     <SectionHeader title="Horizontal — snapAlign: start, snapToItemPadding: 60" />
     <ScrollView
+      contentContainerStyle={{paddingVertical: px(4)}}
       horizontal
-      snapToAlignment="item"
-      snapToItemPadding={px(60)}
       showsHorizontalScrollIndicator={false}
-      contentContainerStyle={{paddingVertical: px(4)}}>
+      snapToAlignment="item"
+      snapToItemPadding={px(60)}>
       {Array.from({length: 15}, (_, i) => (
         <View key={i} scrollSnapAlign="start" style={{marginRight: px(20)}}>
           <Card
+            colorIndex={i}
+            height={160}
             label={`Item ${i + 1}`}
             width={280}
-            height={160}
-            colorIndex={i}
           />
         </View>
       ))}
@@ -137,16 +186,16 @@ const VerticalExample = ({align}: {align: 'start' | 'center' | 'end'}) => (
   <View>
     <SectionHeader title={`Vertical — snapAlign: ${align}`} />
     <ScrollView
-      snapToAlignment="item"
       showsVerticalScrollIndicator={false}
+      snapToAlignment="item"
       style={{height: px(500)}}>
       {Array.from({length: 10}, (_, i) => (
         <View key={i} scrollSnapAlign={align} style={{marginBottom: px(16)}}>
           <Card
+            colorIndex={i + 5}
+            height={120}
             label={`Row ${i + 1}`}
             width={400}
-            height={120}
-            colorIndex={i + 5}
           />
         </View>
       ))}
@@ -163,8 +212,8 @@ const VerticalMixedExample = () => (
   <View>
     <SectionHeader title={`Vertical — snapAlignMixed`} />
     <ScrollView
-      snapToAlignment="item"
       showsVerticalScrollIndicator={false}
+      snapToAlignment="item"
       style={{height: px(500)}}>
       {Array.from({length: 10}, (_, i) => (
         <View
@@ -172,10 +221,10 @@ const VerticalMixedExample = () => (
           scrollSnapAlign={mixedItemAlignment(i)}
           style={{marginBottom: px(16)}}>
           <Card
+            colorIndex={i + 5}
+            height={mixedItemHeight(i)}
             label={`Row ${i + 1} align ${mixedItemAlignment(i)}`}
             width={450}
-            height={mixedItemHeight(i)}
-            colorIndex={i + 5}
           />
         </View>
       ))}
@@ -188,10 +237,10 @@ const NestedExample = () => (
   <View>
     <SectionHeader title="Nested — Vertical + Horizontal" />
     <ScrollView
-      snapToAlignment="item"
+      contentContainerStyle={{gap: px(40)}}
       showsVerticalScrollIndicator={false}
-      style={{height: px(500)}}
-      contentContainerStyle={{gap: px(40)}}>
+      snapToAlignment="item"
+      style={{height: px(500)}}>
       <View scrollSnapAlign="start">
         <HorizontalExample align={'start'} />
       </View>
@@ -206,26 +255,26 @@ const ScrollViewTVSnapExample = (): any => {
   return (
     <View
       style={{
-        flex: 1,
         backgroundColor: '#1a1a2e',
-        paddingTop: px(60),
+        flex: 1,
         paddingHorizontal: px(40),
+        paddingTop: px(60),
       }}>
       <Text
         style={{
+          color: '#ffffff',
           fontSize: px(42),
           fontWeight: '700',
-          color: '#ffffff',
           marginBottom: px(8),
         }}>
         Scroll Snap Type Demo
       </Text>
 
       <ScrollView
-        snapToAlignment="item"
+        contentContainerStyle={{gap: px(40)}}
         showsVerticalScrollIndicator={false}
-        style={{flex: 1}}
-        contentContainerStyle={{gap: px(40)}}>
+        snapToAlignment="item"
+        style={{flex: 1}}>
         <View
           scrollSnapAlign="center"
           style={{flexDirection: 'row', gap: px(16)}}>
@@ -245,6 +294,9 @@ const ScrollViewTVSnapExample = (): any => {
         </View>
         <View scrollSnapAlign="center">
           <ScrollPaddingExample />
+        </View>
+        <View scrollSnapAlign="center">
+          <VerticalOffsetExample />
         </View>
         <View scrollSnapAlign="center">
           <NestedExample />


### PR DESCRIPTION
## Summary:

Adds `scrollSnapOffset?: number` — a per-item pixel-offset complement to #1068's `scrollSnapAlign`. Each row in a `snapToAlignment="item"` ScrollView can declare its own landing position from the top of the viewport.

The motivating use case is a vertical list of mixed-purpose rows that each want a different vertical landing position when focused:

- **Hero** — peeks a few dp from the top, leaving most of itself on-screen.
- **Featured tiles** — basically full-screen tiles; should land flush at the top so the tile fills the viewport.
- **Poster rows** — land lower in the viewport, leaving the area above free for film metadata that updates as focus moves between posters.

`scrollSnapAlign`'s `start`/`center`/`end` don't fit the poster-row case: `end` leaves too much empty space between the metadata and the row, `center` puts the row over the metadata, and `start` collapses the metadata area entirely. `scrollSnapOffset` gives full control — each row declares its exact top position.

## Demo:

https://github.com/user-attachments/assets/25073d12-564d-4d1b-9d5d-6e15e6a46f1e

## AI usage:

Pair-programmed with Claude Code (Opus 4.7).

- Implementation across iOS, Android, Fabric C++ props, JS wiring, and the RNTester demo.
- One architectural pivot during real-device testing: an early two-finder version broke nested scrollers, replaced with a single walker mirroring #1068's pattern.
- Verified on tvOS Simulator and Android TV (Chromecast with Google TV).