### PR TITLE
fix(tvos): continuous scroll animation on snap

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/ScrollView/RCTScrollViewComponentView.mm
@@ -1283,8 +1283,20 @@ static inline UIViewAnimationOptions animationOptionsWithCurve(UIViewAnimationCu
     CGPoint targetContentOffset = isHorizontalSnap
         ? CGPointMake(targetOffset, scrollView.contentOffset.y)
         : CGPointMake(scrollView.contentOffset.x, targetOffset);
+    // Where the focused item should snap to. We don't scroll to it here: this view's
+    // scrollViewWillEndDragging:withVelocity:targetContentOffset: override sets
+    // *targetContentOffset = preferredContentOffset. On tvOS the focus engine routes its
+    // focus-driven scroll through that delegate, so the item snaps to this offset via the
+    // engine's own scroll, even when it's already on screen. An explicit setContentOffset here
+    // would just scroll a second time.
+    // https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/scrollviewwillenddragging(_:withvelocity:targetcontentoffset:)
+    // https://developer.apple.com/forums/thread/22103?answerId=73300022#73300022
     self.preferredContentOffset = targetContentOffset;
-    [_scrollView setContentOffset:targetContentOffset animated:scrollProps.scrollAnimationEnabled];
+    if (!scrollProps.scrollAnimationEnabled) {
+        // Animations off: RCTEnhancedScrollView.didUpdateFocusInContext blocks the engine's
+        // scroll, so the delegate never fires — set the offset directly.
+        scrollView.contentOffset = targetContentOffset;
+    }
 }
 
 - (void)didUpdateFocusInContext:(UIFocusUpdateContext *)context


### PR DESCRIPTION
**Problem**
- On a tvOS `snapToAlignment="item"` list, the scroll animation stutters when holding the d-pad instead of running as one smooth, continuous animation.

**Cause**
- On each focus change the focus engine already scrolls to the snap offset — `scrollViewWillEndDragging` redirects its scroll to `preferredContentOffset` (added in #1068). The snap *also* ran an imperative `setContentOffset:` to the same offset: a second, duplicate scroll that competes with the engine's own scroll/animation, and that interference is the stutter.

**Fix**
- Remove the imperative `setContentOffset:`; setting `preferredContentOffset` and letting the engine's scroll position the item is enough.
- That's what the delegate is for — per Apple: *"Focus movements still cause this delegate method to be called as you would expect, and the targetContentOffset parameter can be used to specify an alternative final content offset."* ([Apple Frameworks Engineer](https://developer.apple.com/forums/thread/22103?answerId=73300022#73300022) · [`scrollViewWillEndDragging` docs](https://developer.apple.com/documentation/uikit/uiscrollviewdelegate/scrollviewwillenddragging(_:withvelocity:targetcontentoffset:)))
- `scrollAnimationEnabled={false}` keeps the instant path (the engine's reveal is suppressed there); tvOS-only, Android unchanged.

**AI usage**

Code-path and PR-history investigation and the change itself were produced with AI assistance (Claude Code), then human-reviewed and validated on a physical tvOS device.
