### PR TITLE
Fix crash on tvOS 26.5 when using directional focus APIs

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -630,11 +630,10 @@ static BOOL RCTLayerTransformCollapsesAxis(CALayer *layer)
       // [self isTVFocusGuide] is false when autofocus and destinations are not used, so we cannot use that.
       // Generally speaking, it would happen for any non-collapsable `View`.
     } else if (context.previouslyFocusedView == self) {
-      [self disableDirectionalFocusGuides];
       [coordinator addCoordinatedAnimations:^(void){
           [self removeParallaxMotionEffects];
           if (self->_eventEmitter) self->_eventEmitter->onBlur();
-      } completion:^(void){}];
+      } completion:^(void){[self disableDirectionalFocusGuides];}];
       [self resignFirstResponder];
     }
 }


### PR DESCRIPTION
## Summary:

Fixes a crash on tvOS 26.5 when using the directional focus APIs (nextFocusUp/Down/Left/Right). Resolves #1123.

`disableDirectionalFocusGuides` calls `removeLayoutGuide:` during the focus update cycle (inside `didUpdateFocusInContext`). On tvOS 26.5, UIKit's internal `_didUpdateFocus` accesses the removed guide's `preferredFocusEnvironments` after they've been freed, causing an `objc_msgSend` crash on a deallocated object.

Moves `disableDirectionalFocusGuides` into the completion block of `addCoordinatedAnimations` so the guides stay alive until UIKit finishes the focus transition.

The crash does not occur on tvOS 26.2.

## Changelog:

[TVOS] [FIXED] - Fix crash on tvOS 26.5 when using directional focus APIs (nextFocusUp/Down/Left/Right)

## Test Plan:

1. Run RNTester on Apple TV (tvOS 26.5)
2. Navigate to APIs > TV > "TVDirectionalNextFocus example"
3. Focus starts on "nextLeft destination"
4. Press left (focus moves to "nextRight destination")
5. Press up (focus moves to "Starting point")
6. Press left

Before: crash in `objc_msgSend` via `[UIFocusUpdateContext _didUpdateFocus]`
After: focus moves to "nextLeft destination", no crash