### PR TITLE
Add KEYCODE_DEL to the Android hardware key event map

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/modules/core/ReactAndroidHWInputDeviceHelper.java
@@ -63,6 +63,7 @@ public class ReactAndroidHWInputDeviceHelper {
           .put(KeyEvent.KEYCODE_9, "9")
           .put(KeyEvent.KEYCODE_CHANNEL_DOWN, "channelDown")
           .put(KeyEvent.KEYCODE_CHANNEL_UP, "channelUp")
+          .put(KeyEvent.KEYCODE_DEL, "delete")
           .put(KeyEvent.KEYCODE_BOOKMARK, "bookmark")
           .put(KeyEvent.KEYCODE_AVR_INPUT, "avrInput")
           .put(KeyEvent.KEYCODE_AVR_POWER, "avrPower")


### PR DESCRIPTION
## Summary:

Some TV remotes expose `KEYCODE_DEL` as a physical button (for example, certain operator / STB remotes use it as a "previous channel" key). `ReactAndroidHWInputDeviceHelper` has no entry for it in `KEY_EVENTS_ACTIONS`, so React Native silently drops the key.

This adds a single mapping so `KEYCODE_DEL` reaches JS via `TVEventHandler` / `onHWKeyEvent`, consistent with the other remote keys already in the map (`channelUp` / `channelDown`, the PROG colour keys, `guide`, …). The event name `"delete"` follows the map's existing convention of naming by the **physical key** rather than an app-level meaning (e.g. `KEYCODE_PROG_RED → "red"`); apps assign semantics (previous channel, etc.) on the JS side.

## Changelog:

[ANDROID] [ADDED] - Map `KEYCODE_DEL` to a `"delete"` hardware key event in `ReactAndroidHWInputDeviceHelper`

## Test Plan:

- Build an Android TV app on this React Native, and register a `TVEventHandler` listener.
- Press DEL on the remote, or run `adb shell input keyevent 67`.
- Observe an `onHWKeyEvent` with `eventType: "delete"` and `eventKeyAction: ACTION_UP`, matching the shape of existing keys such as `channelUp`.
