### PR TITLE
[Android TV] fix talkback focus guide handling after Kotlin conversion

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -1174,7 +1174,7 @@ public open class ReactViewGroup public constructor(context: Context?) :
           return super.performAccessibilityAction(host, action, args)
         }
         if (action == AccessibilityNodeInfo.ACTION_FOCUS) {
-          if (args?.let { host.interceptAccessibilityEvents(action, it) } == true) {
+          if (host.interceptAccessibilityEvents(action, args) == true) {
             return true
           }
           // Handle case when focus guide cannot find any focusable child
@@ -1192,7 +1192,7 @@ public open class ReactViewGroup public constructor(context: Context?) :
           return super.performAccessibilityAction(host, action, args)
         }
         if (action == AccessibilityNodeInfo.ACTION_ACCESSIBILITY_FOCUS) {
-          if (args?.let { host.interceptAccessibilityEvents(action, it) } == true) {
+          if (host.interceptAccessibilityEvents(action, args) == true) {
             return true
           }
           // Handle case when focus guide cannot find any focusable child
@@ -1251,7 +1251,7 @@ public open class ReactViewGroup public constructor(context: Context?) :
     return this.isFocusGuideTalkbackAccessibilityDelegateSet
   }
 
-  private fun interceptAccessibilityEvents(action: Int, args: Bundle): Boolean {
+  private fun interceptAccessibilityEvents(action: Int, args: Bundle?): Boolean {
     if (!this.isTVFocusGuide) {
       return false
     }


### PR DESCRIPTION
After `ReactViewGroup` conversion to Kotlin, the logic to intercept a11y delegate events became wrongly executed only when there is non-null `Bundle` argument - as a result, the `destinations` or last focused element stopped receiving the events

The previous logic implemented in java didn't care about the nullability of `Bundle` argument, as it was always just forwarded to `performAccessibilityAction` on the target views, so to fix and maintain correct behavior, the `handleInterceptEvents` signature now expects optional `Bundle` args argument

<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

<!-- Explain the **motivation** for making this change. What existing problem does the pull request solve? -->

We're upgrading our client's React Native TV app from 0.79 to 0.85 and it turned out that the focus guide talkback handling (that I contributed 2 years ago in https://github.com/react-native-tvos/react-native-tvos/pull/792) stopped working after the `ReactViewGroup` was converted to Kotlin file (initial focus guide handling implementation was in java)

## Changelog:

<!-- Help reviewers and the release process by writing your own changelog entry.

Pick one each for the category and type tags:

[ANDROID|GENERAL|IOS|INTERNAL] [BREAKING|ADDED|CHANGED|DEPRECATED|REMOVED|FIXED|SECURITY] - Message

For more details, see:
https://reactnative.dev/contributing/changelogs-in-pull-requests
-->

[ANDROID] [FIXED] - talkback focus guide handling after Kotlin conversion

## Test Plan:

<!-- Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes the user interface. -->

Run RNTester focus guide example with Talkback before and after the change. Before the change the focus will be stuck on the focus guide container, after the change it will correctly redirect the focus to `destinations` or last focused element
