### PR TITLE
[tvOS] Fix text size of system keyboard 

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/TextInput/RCTTextInputComponentView.mm
@@ -771,12 +771,23 @@ static NSSet<NSNumber *> *returnKeyTypesSet;
 
 - (void)_setAttributedString:(NSAttributedString *)attributedString
 {
+#if TARGET_OS_TV
+  // Attribute-free string prevents the tvOS keyboard from inheriting the component's small font.
+  if ([attributedString.string isEqualToString:_backedTextInputView.attributedText.string]) {
+    return;
+  }
+#else
   if ([self _textOf:attributedString equals:_backedTextInputView.attributedText]) {
     return;
   }
+#endif
   UITextRange *selectedRange = _backedTextInputView.selectedTextRange;
   NSInteger oldTextLength = _backedTextInputView.attributedText.string.length;
+#if TARGET_OS_TV
+  _backedTextInputView.attributedText = [[NSAttributedString alloc] initWithString:attributedString.string];
+#else
   _backedTextInputView.attributedText = attributedString;
+#endif
   // Updating the UITextView attributedText, for example changing the lineHeight, the color or adding
   // a new paragraph with \n, causes the cursor to move to the end of the Text and scroll.
   // This is fixed by restoring the cursor position and scrolling to that position (iOS issue 652653).


### PR DESCRIPTION
## Summary:

On tvOS, when a TextInput uses the controlled value prop, the system fullscreen keyboard renders its text preview using the font size from the component's style. It could be too small or too large depending on the app's fontSize. Without value, the keyboard preview is empty so it always appears with native defaults.

Root cause: _setAttributedString: sets UITextField.attributedText with an NSAttributedString that carries an explicit NSFontAttributeName from the component style. The tvOS system keyboard reads this attribute to render its preview instead of using its own native defaults.

Fix: on tvOS, set an attribute-free NSAttributedString (string content only). The keyboard finds no explicit font and uses its native TV-appropriate defaults regardless of the component's fontSize. In-app rendering is unaffected. UITextField falls back to defaultTextAttributes (set from the component's style in updateProps:) when attributedText carries no explicit font attribute.

(Fix #1134)

## Changelog:

- [TVOS][FIXED] - TextInput: system keyboard no longer renders the text preview at the component's font size when the value prop is set.

## Test Plan:

1. Open RNTester on tvOS 
2. Navigate to Components > Text Input
3. Select "Auto-focus & select text on focus"
4. Once the fullscreen keyboard is presented, start typing

Before: The text preview in the fullscreen keyboard changed it's size making it barely visible
After: The text preview in the fullscreen keyboard uses the default style of the platform and it is not affected by the type of the Text Input component