### PR TITLE
fix(android): re-attempt focus if target isn't initially attached

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewGroup.kt
@@ -456,7 +456,7 @@ public open class ReactViewGroup public constructor(context: Context?) :
 
   internal fun requestFocusFromJS() {
     if (isAttachedToWindow) {
-      super.requestFocus(FOCUS_DOWN, null)
+      requestFocus(FOCUS_DOWN, null)
     } else {
       focusOnAttach = true
     }

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/view/ReactViewManager.kt
@@ -526,7 +526,7 @@ public open class ReactViewManager : ReactClippingViewManager<ReactViewGroup>() 
       HOTSPOT_UPDATE_KEY -> handleHotspotUpdate(root, args)
       "setPressed" -> handleSetPressed(root, args)
       "setDestinations" -> handleSetDestinations(root, args)
-      "requestTVFocus" -> root.requestFocus()
+      "requestTVFocus" -> root.requestFocusFromJS()
       "focus" -> handleFocus(root)
       "blur" -> handleBlur(root)
       else -> {}


### PR DESCRIPTION
<!-- Thanks for submitting a pull request! We appreciate you spending the time to work on these changes. Please provide enough information so that others can review your pull request. The three fields below are mandatory. -->

## Summary:

I noticed that calling `focus` (with the `enableImperativeFocus` feature flag enabled) resolved a number of reliability issues with initial focus after navigating to a screen (specific to Android).

Looking into it further, the `focus` method runs through `requestFocusFromJS` which includes an additional check for whether the view is attached yet, and if it's not, it instructs the `onAttachedToWindow` callback to try focusing again when the view attaches.

This PR is the Android counterpart to Douwe's tvOS-specific fix [here](https://github.com/react-native-tvos/react-native-tvos/pull/1054). See that PR for additional context. @RuudBurger already knows about these changes, but let me know if you have any questions 🙂

## Changelog:

[ANDROID][FIXED] - Postpone requestTVFocus until the view is attached to the window
