### PR TITLE
Add onFocusEnter / onFocusLeave to TVFocusGuideView

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,8 @@ class Game2048 extends React.Component {
   | autoFocus | boolean? | If true, `TVFocusGuide` will automatically manage focus for you. It will redirect the focus to the first focusable child on the first visit. It also remembers the last focused child and redirects the focus to it on the subsequent visits. `destinations` prop takes precedence over this prop when used together. |
   | focusable | boolean? | When set to false, this view and all its subviews will be NOT focusable. |
   | trapFocus* (Up, Down, Left, Right) | Prevents focus escaping from the container for the given directions. |
+  | onFocusEnter | function? | Fires once when focus enters the FocusGuideView's subtree from outside. Unlike `onFocus`, it does not fire again when focus moves between descendants. |
+  | onFocusLeave | function? | Fires once when focus leaves the FocusGuideView's subtree entirely. Does not fire when focus moves between descendants. |
   
   More information on the focus handling improvements above can be found in [this article](https://medium.com/xite-engineering/revolutionizing-focus-management-in-tv-applications-with-react-native-10ba69bd90).
   

--- a/packages/react-native/Libraries/Components/TV/TVFocusGuideView.js
+++ b/packages/react-native/Libraries/Components/TV/TVFocusGuideView.js
@@ -8,6 +8,7 @@
  * @format
  */
 
+import type {BlurEvent, FocusEvent} from '../../Types/CoreEventTypes';
 import type {ViewProps} from '../View/ViewPropTypes';
 import type {ComponentOrHandleType} from './tagForComponentOrHandle';
 
@@ -16,6 +17,7 @@ import useMergeRefs from '../../Utilities/useMergeRefs';
 import View from '../View/View';
 import {Commands} from '../View/ViewNativeComponent';
 import tagForComponentOrHandle from './tagForComponentOrHandle';
+import useFocusEnterLeave from './useFocusEnterLeave';
 
 const StyleSheet = require('../../StyleSheet/StyleSheet').default;
 const React = require('react');
@@ -51,6 +53,20 @@ type TVFocusGuideViewProps = $ReadOnly<{
    * When set to false, this view and all its subviews will be NOT focusable.
    */
   focusable?: boolean | void,
+
+  /**
+   * Fires once when focus enters this focus guide's subtree from outside.
+   * Unlike `onFocus`, which bubbles and fires for every descendant, this does
+   * not fire again when focus moves between descendants. Boundary-crossing
+   * only, same idea as `onMouseEnter` vs `onMouseOver`.
+   */
+  onFocusEnter?: ?(event: FocusEvent) => void,
+
+  /**
+   * Fires once when focus leaves this focus guide's subtree entirely. Does
+   * not fire when focus moves between descendants. Pairs with `onFocusEnter`.
+   */
+  onFocusLeave?: ?(event: BlurEvent) => void,
 }>;
 
 export type TVFocusGuideViewImperativeMethods = $ReadOnly<{
@@ -63,6 +79,10 @@ function TVFocusGuideView({
   destinations: destinationsProp,
   autoFocus,
   focusable,
+  onFocusEnter,
+  onFocusLeave,
+  onFocusCapture,
+  onBlurCapture,
   ref,
   ...props
 }: TVFocusGuideViewProps): React.Node {
@@ -103,6 +123,15 @@ function TVFocusGuideView({
 
   const mergedRef = useMergeRefs(setLocalRef, ref);
 
+  // Collapse the bubbled per-descendant focus/blur into a single enter when
+  // focus crosses into the guide's subtree and a single leave when it exits.
+  const {handleFocusCapture, handleBlurCapture} = useFocusEnterLeave(
+    onFocusEnter,
+    onFocusLeave,
+    onFocusCapture,
+    onBlurCapture,
+  );
+
   React.useEffect(() => {
     if (focusable === false) {
       setDestinations([]);
@@ -131,6 +160,8 @@ function TVFocusGuideView({
       isTVSelectable={tvOSSelectable}
       // Android TV only prop
       tvFocusable={focusable}
+      onFocusCapture={handleFocusCapture}
+      onBlurCapture={handleBlurCapture}
     />
   );
 }

--- a/packages/react-native/Libraries/Components/TV/__tests__/useFocusEnterLeave-test.js
+++ b/packages/react-native/Libraries/Components/TV/__tests__/useFocusEnterLeave-test.js
@@ -1,0 +1,137 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow
+ * @format
+ */
+
+'use strict';
+
+const useFocusEnterLeave = require('../useFocusEnterLeave').default;
+const {create, unmount} = require('@react-native/jest-preset/jest/renderer');
+const React = require('react');
+
+// Drives the capture handlers the hook injects. The native focus engine
+// delivers focus/blur down the capture path; here we call them directly.
+let handlers: $FlowFixMe = null;
+
+function Harness(props: $FlowFixMe): null {
+  handlers = useFocusEnterLeave(
+    props.onFocusEnter,
+    props.onFocusLeave,
+    props.onFocusCapture,
+    props.onBlurCapture,
+  );
+  return null;
+}
+
+const event: $FlowFixMe = {nativeEvent: {target: 1}};
+
+describe('useFocusEnterLeave', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    handlers = null;
+  });
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('fires onFocusEnter once on entry and onFocusLeave once on exit', async () => {
+    const onFocusEnter = jest.fn();
+    const onFocusLeave = jest.fn();
+    await create(
+      <Harness onFocusEnter={onFocusEnter} onFocusLeave={onFocusLeave} />,
+    );
+
+    handlers.handleFocusCapture(event);
+    expect(onFocusEnter).toHaveBeenCalledTimes(1);
+    expect(onFocusLeave).toHaveBeenCalledTimes(0);
+
+    handlers.handleBlurCapture(event);
+    jest.runAllTimers();
+    expect(onFocusLeave).toHaveBeenCalledTimes(1);
+    expect(onFocusEnter).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not re-fire when focus moves between descendants', async () => {
+    const onFocusEnter = jest.fn();
+    const onFocusLeave = jest.fn();
+    await create(
+      <Harness onFocusEnter={onFocusEnter} onFocusLeave={onFocusLeave} />,
+    );
+
+    handlers.handleFocusCapture(event); // focus enters child A
+    expect(onFocusEnter).toHaveBeenCalledTimes(1);
+
+    // child A -> child B in the same tick: blur then focus, no timer flush in
+    // between. The incoming focus must cancel the pending leave.
+    handlers.handleBlurCapture(event);
+    handlers.handleFocusCapture(event);
+    jest.runAllTimers();
+
+    expect(onFocusEnter).toHaveBeenCalledTimes(1); // no second enter
+    expect(onFocusLeave).toHaveBeenCalledTimes(0); // leave cancelled
+  });
+
+  it('re-fires onFocusEnter after a real leave', async () => {
+    const onFocusEnter = jest.fn();
+    const onFocusLeave = jest.fn();
+    await create(
+      <Harness onFocusEnter={onFocusEnter} onFocusLeave={onFocusLeave} />,
+    );
+
+    handlers.handleFocusCapture(event);
+    handlers.handleBlurCapture(event);
+    jest.runAllTimers();
+    handlers.handleFocusCapture(event);
+
+    expect(onFocusEnter).toHaveBeenCalledTimes(2);
+    expect(onFocusLeave).toHaveBeenCalledTimes(1);
+  });
+
+  it('still calls user-provided onFocusCapture / onBlurCapture', async () => {
+    const userFocusCapture = jest.fn();
+    const userBlurCapture = jest.fn();
+    await create(
+      <Harness
+        onFocusEnter={jest.fn()}
+        onFocusCapture={userFocusCapture}
+        onBlurCapture={userBlurCapture}
+      />,
+    );
+
+    handlers.handleFocusCapture(event);
+    handlers.handleBlurCapture(event);
+    expect(userFocusCapture).toHaveBeenCalledTimes(1);
+    expect(userBlurCapture).toHaveBeenCalledTimes(1);
+  });
+
+  it('clears a pending leave on unmount (state resets)', async () => {
+    const onFocusLeave = jest.fn();
+    const component = await create(
+      <Harness onFocusEnter={jest.fn()} onFocusLeave={onFocusLeave} />,
+    );
+
+    handlers.handleFocusCapture(event);
+    handlers.handleBlurCapture(event); // schedules a deferred leave
+    await unmount(component);
+    jest.runAllTimers();
+
+    expect(onFocusLeave).toHaveBeenCalledTimes(0); // no leave after unmount
+  });
+
+  it('passes the caller capture handlers through when no enter/leave props', async () => {
+    const onFocusCapture = jest.fn();
+    const onBlurCapture = jest.fn();
+    await create(
+      <Harness onFocusCapture={onFocusCapture} onBlurCapture={onBlurCapture} />,
+    );
+
+    // Nothing to track, so the hook hands back exactly what it was given.
+    expect(handlers.handleFocusCapture).toBe(onFocusCapture);
+    expect(handlers.handleBlurCapture).toBe(onBlurCapture);
+  });
+});

--- a/packages/react-native/Libraries/Components/TV/useFocusEnterLeave.js
+++ b/packages/react-native/Libraries/Components/TV/useFocusEnterLeave.js
@@ -1,0 +1,105 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {BlurEvent, FocusEvent} from '../../Types/CoreEventTypes';
+
+import * as React from 'react';
+
+type FocusEnterLeaveState = {
+  entered: boolean,
+  pendingLeave: ?TimeoutID,
+};
+
+export type FocusEnterLeaveHandlers = {
+  handleFocusCapture: ?(event: FocusEvent) => void,
+  handleBlurCapture: ?(event: BlurEvent) => void,
+};
+
+/**
+ * Collapses the per-descendant focus/blur events into a single enter (focus
+ * crosses into the subtree) and a single leave (focus fully exits). A
+ * child-to-child move fires blur then focus back to back, so the deferred
+ * leave gets cancelled by the incoming focus and nothing fires.
+ *
+ * Hooks the capture phase, not bubble: capture reaches the container before
+ * any descendant sees the event, so a descendant calling stopPropagation
+ * can't leave us desynced.
+ */
+export default function useFocusEnterLeave(
+  onFocusEnter: ?(event: FocusEvent) => void,
+  onFocusLeave: ?(event: BlurEvent) => void,
+  onFocusCapture: ?(event: FocusEvent) => void,
+  onBlurCapture: ?(event: BlurEvent) => void,
+): FocusEnterLeaveHandlers {
+  const stateRef = React.useRef<FocusEnterLeaveState>({
+    entered: false,
+    pendingLeave: null,
+  });
+
+  const handleFocusCapture = React.useCallback(
+    (event: FocusEvent) => {
+      const state = stateRef.current;
+      if (state.pendingLeave != null) {
+        clearTimeout(state.pendingLeave);
+        state.pendingLeave = null;
+      }
+      if (!state.entered) {
+        state.entered = true;
+        onFocusEnter?.(event);
+      }
+      onFocusCapture?.(event);
+    },
+    [onFocusEnter, onFocusCapture],
+  );
+
+  const handleBlurCapture = React.useCallback(
+    (event: BlurEvent) => {
+      const state = stateRef.current;
+      if (state.pendingLeave != null) {
+        clearTimeout(state.pendingLeave);
+      }
+      // Defer: if focus lands on another descendant this same tick, the focus
+      // handler clears this before it runs.
+      state.pendingLeave = setTimeout(() => {
+        state.pendingLeave = null;
+        if (state.entered) {
+          state.entered = false;
+          onFocusLeave?.(event);
+        }
+      }, 0);
+      onBlurCapture?.(event);
+    },
+    [onFocusLeave, onBlurCapture],
+  );
+
+  // Reset on unmount so a remounted instance starts clean and no deferred
+  // leave fires after we're gone.
+  React.useEffect(() => {
+    const state = stateRef.current;
+    return () => {
+      if (state.pendingLeave != null) {
+        clearTimeout(state.pendingLeave);
+        state.pendingLeave = null;
+      }
+      state.entered = false;
+    };
+  }, []);
+
+  // Nothing to track: hand back the caller's own capture handlers untouched.
+  // (Kept after the hooks above so the hook count stays stable per render.)
+  if (onFocusEnter == null && onFocusLeave == null) {
+    return {
+      handleFocusCapture: onFocusCapture,
+      handleBlurCapture: onBlurCapture,
+    };
+  }
+
+  return {handleFocusCapture, handleBlurCapture};
+}

--- a/packages/react-native/types/public/ReactNativeTVTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTVTypes.d.ts
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { View, ScrollViewProps, HostComponent, EventSubscription, TVParallaxProperties } from 'react-native';
+import type { View, ScrollViewProps, HostComponent, EventSubscription, TVParallaxProperties, FocusEvent, BlurEvent } from 'react-native';
 
 declare module 'react-native' {
   export type FocusDestination = null | number | React.Component<any, any> | React.ComponentClass<any>;
@@ -179,6 +179,17 @@ declare module 'react-native' {
      * @deprecated Don't use it, no longer necessary.
      */
     safePadding?: 'both' | 'vertical' | 'horizontal' | null | undefined;
+    /**
+     * Fires once when focus enters this focus guide's subtree from outside.
+     * Unlike `onFocus`, which bubbles and fires for every descendant, this
+     * does not fire again when focus moves between descendants.
+     */
+    onFocusEnter?: ((event: FocusEvent) => void) | undefined;
+    /**
+     * Fires once when focus leaves this focus guide's subtree entirely. Does
+     * not fire when focus moves between descendants. Pairs with `onFocusEnter`.
+     */
+    onFocusLeave?: ((event: BlurEvent) => void) | undefined;
   }
 
   export type FocusGuideMethods = {

--- a/packages/rn-tester/js/examples/FocusEventsExample/FocusEnterLeaveExample.js
+++ b/packages/rn-tester/js/examples/FocusEventsExample/FocusEnterLeaveExample.js
@@ -1,0 +1,141 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {RNTesterModuleExample} from '../../types/RNTesterTypes';
+
+import RNTesterText from '../../components/RNTesterText';
+import * as React from 'react';
+import {useState} from 'react';
+import {Pressable, StyleSheet, TVFocusGuideView, View} from 'react-native';
+
+const ROWS = ['Row 1', 'Row 2', 'Row 3'];
+
+const Row = ({label}: {label: string}): React.Node => (
+  <Pressable
+    focusable={true}
+    style={({focused}) => [styles.rowInner, focused && styles.rowInnerFocused]}>
+    <RNTesterText style={styles.rowText}>{label}</RNTesterText>
+  </Pressable>
+);
+
+const Group = ({title}: {title: string}): React.Node => {
+  // Bubbled onFocus/onBlur: fire for every descendant, on every d-pad move.
+  const [bubbledFocus, setBubbledFocus] = useState(0);
+  const [bubbledBlur, setBubbledBlur] = useState(0);
+
+  // Enter/leave: fire once when focus crosses the group boundary.
+  const [entered, setEntered] = useState(false);
+  const [enters, setEnters] = useState(0);
+  const [leaves, setLeaves] = useState(0);
+
+  return (
+    <TVFocusGuideView
+      style={[styles.group, entered && styles.groupEntered]}
+      onFocus={() => setBubbledFocus(c => c + 1)}
+      onBlur={() => setBubbledBlur(c => c + 1)}
+      onFocusEnter={() => {
+        setEntered(true);
+        setEnters(c => c + 1);
+      }}
+      onFocusLeave={() => {
+        setEntered(false);
+        setLeaves(c => c + 1);
+      }}>
+      <RNTesterText style={styles.groupTitle}>
+        {title} — entered: {entered ? 'true' : 'false'}
+      </RNTesterText>
+      <RNTesterText style={styles.stat}>
+        enter/leave: enter {enters} / leave {leaves}
+      </RNTesterText>
+      <RNTesterText style={styles.stat}>
+        bubbled: onFocus {bubbledFocus} / onBlur {bubbledBlur}
+      </RNTesterText>
+      <View style={styles.rows}>
+        {ROWS.map(label => (
+          <Row key={label} label={label} />
+        ))}
+      </View>
+    </TVFocusGuideView>
+  );
+};
+
+const FocusEnterLeaveExample = (): React.Node => (
+  <View style={styles.container}>
+    <RNTesterText style={styles.intro}>
+      Move focus across the rows inside one group: the bubbled onFocus/onBlur
+      counters climb on every move, while onFocusEnter fires once. Move to the
+      other group to see onFocusLeave fire once on the way out.
+    </RNTesterText>
+    <Group title="Group A" />
+    <Group title="Group B" />
+  </View>
+);
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 8,
+    rowGap: 16,
+  },
+  intro: {
+    paddingBottom: 8,
+  },
+  group: {
+    borderColor: 'transparent',
+    borderRadius: 8,
+    borderWidth: 2,
+    padding: 8,
+    rowGap: 4,
+  },
+  groupEntered: {
+    borderColor: 'blue',
+  },
+  groupTitle: {
+    fontSize: 18,
+  },
+  stat: {
+    color: '#666',
+  },
+  rows: {
+    flexDirection: 'row',
+    columnGap: 8,
+    marginTop: 8,
+  },
+  rowInner: {
+    backgroundColor: '#424B54',
+    borderColor: 'transparent',
+    borderRadius: 8,
+    borderWidth: 2,
+    flexGrow: 1,
+    height: 60,
+    justifyContent: 'center',
+    padding: 4,
+  },
+  rowInnerFocused: {
+    borderColor: 'white',
+  },
+  rowText: {
+    color: 'white',
+    textAlign: 'center',
+  },
+});
+
+export default {
+  title: 'Focus Enter / Leave (onFocusEnter / onFocusLeave)',
+  description:
+    'onFocusEnter/onFocusLeave fire once when focus crosses a subtree boundary, unlike the bubbled onFocus/onBlur.',
+  examples: [
+    {
+      title: 'Focus Enter / Leave',
+      render: function (): React.Node {
+        return <FocusEnterLeaveExample />;
+      },
+    },
+  ] as Array<RNTesterModuleExample>,
+};

--- a/packages/rn-tester/js/utils/RNTesterList.android.js
+++ b/packages/rn-tester/js/utils/RNTesterList.android.js
@@ -284,6 +284,10 @@ const APIs: Array<RNTesterModuleInfo> = (
         .default,
     },
     {
+      key: 'FocusEnterLeaveExample',
+      module: require('../examples/FocusEventsExample/FocusEnterLeaveExample'),
+    },
+    {
       key: 'InvalidPropsExample',
       module: require('../examples/InvalidProps/InvalidPropsExample'),
     },

--- a/packages/rn-tester/js/utils/RNTesterList.ios.js
+++ b/packages/rn-tester/js/utils/RNTesterList.ios.js
@@ -208,6 +208,12 @@ const APIs: Array<RNTesterModuleInfo> = (
       supportsTVOS: true,
     },
     {
+      key: 'TVFocusEnterLeaveExample',
+      category: 'TV',
+      module: require('../examples/FocusEventsExample/FocusEnterLeaveExample'),
+      supportsTVOS: true,
+    },
+    {
       key: 'AccessibilityExample',
       module: require('../examples/Accessibility/AccessibilityExample'),
     },


### PR DESCRIPTION
TV `onFocus`/`onBlur` bubble, so a container fires them for every descendant focus change, including focus moving between two children inside it. There was no clean way to know "focus entered this subtree" / "focus left this subtree" without counting events yourself. These two props on `TVFocusGuideView` do exactly that.

`onFocusEnter` fires once when focus crosses into the guide's subtree, `onFocusLeave` once when it fully leaves. Moving focus between descendants doesn't re-fire either. Same boundary-crossing idea as `onMouseEnter`/`onMouseLeave` vs `onMouseOver`/`onMouseOut`. New prop names because `onFocus`/`onBlur`/`onFocusCapture`/`onBlurCapture` are all taken.

Scoped to `TVFocusGuideView` on purpose: it's the focus container, so that's where this belongs, and it keeps plain `View` untouched (no extra hooks/handlers on the most-instantiated component in the app).

## How it works
- Pure JS, no native changes. Works on tvOS and Android TV since both already bubble these events.
- A small `useFocusEnterLeave` hook hooks the **capture** phase (`onFocusCapture`/`onBlurCapture`) on the guide's inner View, not bubble, so a descendant calling `stopPropagation` can't desync it. Any `onFocus`/`onBlur`/`onFocusCapture`/`onBlurCapture` you pass through still work.
- Enter/leave is tracked with a boolean plus a deferred leave: a child to child move fires blur then focus back to back, and the incoming focus cancels the pending leave, so nothing fires. State resets on unmount.

## What's here
- `useFocusEnterLeave` hook + wiring in `TVFocusGuideView`
- `onFocusEnter`/`onFocusLeave` on `TVFocusGuideView`'s Flow and TS types
- rn-tester example (Focus Enter / Leave) showing bubbled counts spiking on every move vs enter/leave firing once
- Unit tests for the hook (enter-once, leave-once, child to child coalescing, re-fire after a real leave, user handlers chained, unmount reset)

## Verified
jest (5/5), flow, eslint, and tsc all clean (no net-new errors; `View` is back to untouched).
