### PR TITLE
feat(android): configurable scroll animation duration and easing

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ class Game2048 extends React.Component {
   </ScrollView>
   ```
 
-  - _ScrollView animation timing (Android TV)_: The `scrollAnimationDuration` and `scrollAnimationEasing` props tune the animated scroll that runs when focus moves to another item. Both are Android TV only; on tvOS the focus engine owns this animation. When either prop is unset, the platform defaults are used, so behavior is unchanged.
+  - _ScrollView animation timing (Android TV)_: The `scrollAnimationDuration` and `scrollAnimationEasing` props tune the animated scroll that runs when focus moves to another item. They apply to the snap scroll (`snapToAlignment="item"` with per-item `scrollSnapAlign`/`scrollSnapOffset` markers) and to animated `scrollTo` commands; other focus scrolls are instant. Both are Android TV only; on tvOS the focus engine owns this animation. When either prop is unset, the platform defaults are used, so behavior is unchanged.
 
   | Prop (ScrollView) | Value | Description |
   |---|---|---|

--- a/README.md
+++ b/README.md
@@ -316,6 +316,20 @@ class Game2048 extends React.Component {
   </ScrollView>
   ```
 
+  - _ScrollView animation timing (Android TV)_: The `scrollAnimationDuration` and `scrollAnimationEasing` props tune the animated scroll that runs when focus moves to another item. Both are Android TV only; on tvOS the focus engine owns this animation. When either prop is unset, the platform defaults are used, so behavior is unchanged.
+
+  | Prop (ScrollView) | Value | Description |
+  |---|---|---|
+  | scrollAnimationDuration | number? | Duration of the scroll animation in milliseconds. Unset or `<= 0` uses the platform default (~250ms). Android TV only. |
+  | scrollAnimationEasing | `'linear' \| 'ease' \| 'ease-in' \| 'ease-out' \| 'ease-in-out' \| [number, number, number, number]`? | Easing curve, as a CSS easing keyword or cubic-bezier control points `[x1, y1, x2, y2]`. Unset uses the platform default `AccelerateDecelerateInterpolator`. Android TV only. |
+
+  ```jsx
+  <ScrollView horizontal scrollAnimationDuration={500} scrollAnimationEasing="ease-out">
+    <Pressable style={{width: 300}}><Text>Item 1</Text></Pressable>
+    <Pressable style={{width: 300}}><Text>Item 2</Text></Pressable>
+  </ScrollView>
+  ```
+
   - _Interaction with existing ScrollView props_: The TV scroll props build on top of existing React Native ScrollView behavior. Here is how they interact:
 
     - `snapToAlignment="item"` does not require `snapToInterval` to be set. It works as a standalone snapping mode where each child's `scrollSnapAlign` or `scrollSnapOffset` determines the snap position. If `snapToInterval` is also set, the interval is applied as an additional constraint after the item offset is computed.
@@ -325,6 +339,7 @@ class Game2048 extends React.Component {
     - `scrollAnimationEnabled={false}` disables all scroll animations, including programmatic `scrollTo({animated: true})` calls. When disabled, all scrolling is instant.
     - `decelerationRate` has no effect when `scrollAnimationEnabled={false}`, since there is no animation to decelerate.
     - `scrollAnimationEnabled` and `snapToAlignment="item"` work well together. Snapping still occurs, but instantly instead of animated.
+    - `scrollAnimationDuration` and `scrollAnimationEasing` have no effect when `scrollAnimationEnabled={false}`, since there is no animation left to time.
 
   - _VirtualizedList_: We extend `VirtualizedList` to make virtualization work well with focus management in mind. All of the improvements that we made are automatically available to all the VirtualizedList based components such as `FlatList`.
     - Defaults: VirtualizeList contents are automatically wrapped with a `TVFocusGuideView` with `trapFocus*` properties enabled depending on the orientation of the list. This default makes sure that focus doesn't leave the list accidentally due to a virtualization issue etc. until reaching the beginning or the end of the list.

--- a/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/AndroidHorizontalScrollViewNativeComponent.js
@@ -55,6 +55,8 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig = {
     borderLeftColor: colorAttribute,
     snapToItemPadding: true,
     scrollAnimationEnabled: true,
+    scrollAnimationDuration: true,
+    scrollAnimationEasing: true,
     pointerEvents: true,
     scrollsChildToFocus: true,
   },

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -740,6 +740,30 @@ export interface ScrollViewProps
   scrollAnimationEnabled?: boolean | undefined;
 
   /**
+   * (Android TV only)
+   * Duration in milliseconds of the animated scroll that runs when focus moves to
+   * another item. When unset or <= 0, the platform default (~250ms) is used.
+   * On tvOS the focus engine owns this animation and the prop has no effect.
+   */
+  scrollAnimationDuration?: number | undefined;
+
+  /**
+   * (Android TV only)
+   * Easing curve of that animation, either a CSS easing keyword or explicit
+   * cubic-bezier control points `[x1, y1, x2, y2]`. When unset, the platform
+   * default curve (`AccelerateDecelerateInterpolator`) is used.
+   * On tvOS the focus engine owns this animation and the prop has no effect.
+   */
+  scrollAnimationEasing?:
+    | 'linear'
+    | 'ease'
+    | 'ease-in'
+    | 'ease-out'
+    | 'ease-in-out'
+    | [number, number, number, number]
+    | undefined;
+
+  /**
    * When true, shows a horizontal scroll indicator.
    */
   showsHorizontalScrollIndicator?: boolean | undefined;

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.d.ts
@@ -742,7 +742,9 @@ export interface ScrollViewProps
   /**
    * (Android TV only)
    * Duration in milliseconds of the animated scroll that runs when focus moves to
-   * another item. When unset or <= 0, the platform default (~250ms) is used.
+   * another item. Applies to the snap scroll (`snapToAlignment="item"` with
+   * per-item `scrollSnapAlign`/`scrollSnapOffset` markers) and to animated
+   * `scrollTo` commands; other focus scrolls are instant. When unset or <= 0, the platform default (~250ms) is used.
    * On tvOS the focus engine owns this animation and the prop has no effect.
    */
   scrollAnimationDuration?: number | undefined;

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -788,7 +788,9 @@ type ScrollViewBaseProps = Readonly<{
   /**
    * (Android TV only)
    * Duration in milliseconds of the animated scroll that runs when focus moves to
-   * another item. When unset or <= 0, the platform default (~250ms) is used.
+   * another item. Applies to the snap scroll (`snapToAlignment="item"` with
+   * per-item `scrollSnapAlign`/`scrollSnapOffset` markers) and to animated
+   * `scrollTo` commands; other focus scrolls are instant. When unset or <= 0, the platform default (~250ms) is used.
    * On tvOS the focus engine owns this animation and the prop has no effect.
    */
   scrollAnimationDuration?: ?number,

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -196,6 +196,13 @@ export interface ScrollViewImperativeMethods {
 }
 
 export type DecelerationRateType = 'fast' | 'normal' | number;
+export type ScrollAnimationEasing =
+  | 'linear'
+  | 'ease'
+  | 'ease-in'
+  | 'ease-out'
+  | 'ease-in-out'
+  | ReadonlyArray<number>;
 export type ScrollResponderType = ScrollViewImperativeMethods;
 
 export interface ScrollViewInstance
@@ -778,6 +785,21 @@ type ScrollViewBaseProps = Readonly<{
    */
   scrollAnimationEnabled?: ?boolean,
   /**
+   * (Android TV only)
+   * Duration in milliseconds of the animated scroll that runs when focus moves to
+   * another item. When unset or <= 0, the platform default (~250ms) is used.
+   * On tvOS the focus engine owns this animation and the prop has no effect.
+   */
+  scrollAnimationDuration?: ?number,
+  /**
+   * (Android TV only)
+   * Easing curve of that animation, either a CSS easing keyword or explicit
+   * cubic-bezier control points `[x1, y1, x2, y2]`. When unset, the platform
+   * default curve (`AccelerateDecelerateInterpolator`) is used.
+   * On tvOS the focus engine owns this animation and the prop has no effect.
+   */
+  scrollAnimationEasing?: ?ScrollAnimationEasing,
+  /**
    * A RefreshControl component, used to provide pull-to-refresh
    * functionality for the ScrollView. Only works for vertical ScrollViews
    * (`horizontal` prop must be `false`).
@@ -814,6 +836,33 @@ type ScrollViewState = {
 };
 
 const IS_ANIMATING_TOUCH_START_THRESHOLD_MS = 16;
+
+// The native side only understands cubic-bezier control points, so the CSS easing keywords are
+// resolved here to the control points those keywords are defined as.
+const SCROLL_ANIMATION_EASING_KEYWORDS: Readonly<{
+  linear: ReadonlyArray<number>,
+  ease: ReadonlyArray<number>,
+  'ease-in': ReadonlyArray<number>,
+  'ease-out': ReadonlyArray<number>,
+  'ease-in-out': ReadonlyArray<number>,
+}> = {
+  linear: [0, 0, 1, 1],
+  ease: [0.25, 0.1, 0.25, 1],
+  'ease-in': [0.42, 0, 1, 1],
+  'ease-out': [0, 0, 0.58, 1],
+  'ease-in-out': [0.42, 0, 0.58, 1],
+};
+
+function resolveScrollAnimationEasing(
+  easing: ?ScrollAnimationEasing,
+): ?ReadonlyArray<number> {
+  if (easing == null) {
+    return undefined;
+  }
+  return typeof easing === 'string'
+    ? SCROLL_ANIMATION_EASING_KEYWORDS[easing]
+    : easing;
+}
 
 export type ScrollViewComponentStatics = Readonly<{
   Context: typeof ScrollViewContext,
@@ -1916,6 +1965,9 @@ class ScrollView extends React.Component<ScrollViewProps, ScrollViewState> {
       snapToEnd: this.props.snapToEnd !== false,
       // default to true
       showsScrollIndex: this.props.showsScrollIndex !== false,
+      scrollAnimationEasing: resolveScrollAnimationEasing(
+        this.props.scrollAnimationEasing,
+      ),
       // pagingEnabled is overridden by snapToInterval / snapToOffsets
       pagingEnabled: Platform.select({
         // on iOS, pagingEnabled must be set to false to have snapToInterval / snapToOffsets work

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollView.js
@@ -45,6 +45,7 @@ import Keyboard from '../Keyboard/Keyboard';
 import TextInputState from '../TextInput/TextInputState';
 import View from '../View/View';
 import processDecelerationRate from './processDecelerationRate';
+import processScrollAnimationEasing from './processScrollAnimationEasing';
 import Commands from './ScrollViewCommands';
 import ScrollViewContext, {HORIZONTAL, VERTICAL} from './ScrollViewContext';
 import ScrollViewStickyHeader from './ScrollViewStickyHeader';
@@ -202,7 +203,7 @@ export type ScrollAnimationEasing =
   | 'ease-in'
   | 'ease-out'
   | 'ease-in-out'
-  | ReadonlyArray<number>;
+  | [number, number, number, number];
 export type ScrollResponderType = ScrollViewImperativeMethods;
 
 export interface ScrollViewInstance
@@ -836,33 +837,6 @@ type ScrollViewState = {
 };
 
 const IS_ANIMATING_TOUCH_START_THRESHOLD_MS = 16;
-
-// The native side only understands cubic-bezier control points, so the CSS easing keywords are
-// resolved here to the control points those keywords are defined as.
-const SCROLL_ANIMATION_EASING_KEYWORDS: Readonly<{
-  linear: ReadonlyArray<number>,
-  ease: ReadonlyArray<number>,
-  'ease-in': ReadonlyArray<number>,
-  'ease-out': ReadonlyArray<number>,
-  'ease-in-out': ReadonlyArray<number>,
-}> = {
-  linear: [0, 0, 1, 1],
-  ease: [0.25, 0.1, 0.25, 1],
-  'ease-in': [0.42, 0, 1, 1],
-  'ease-out': [0, 0, 0.58, 1],
-  'ease-in-out': [0.42, 0, 0.58, 1],
-};
-
-function resolveScrollAnimationEasing(
-  easing: ?ScrollAnimationEasing,
-): ?ReadonlyArray<number> {
-  if (easing == null) {
-    return undefined;
-  }
-  return typeof easing === 'string'
-    ? SCROLL_ANIMATION_EASING_KEYWORDS[easing]
-    : easing;
-}
 
 export type ScrollViewComponentStatics = Readonly<{
   Context: typeof ScrollViewContext,
@@ -1965,9 +1939,6 @@ class ScrollView extends React.Component<ScrollViewProps, ScrollViewState> {
       snapToEnd: this.props.snapToEnd !== false,
       // default to true
       showsScrollIndex: this.props.showsScrollIndex !== false,
-      scrollAnimationEasing: resolveScrollAnimationEasing(
-        this.props.scrollAnimationEasing,
-      ),
       // pagingEnabled is overridden by snapToInterval / snapToOffsets
       pagingEnabled: Platform.select({
         // on iOS, pagingEnabled must be set to false to have snapToInterval / snapToOffsets work
@@ -1986,6 +1957,13 @@ class ScrollView extends React.Component<ScrollViewProps, ScrollViewState> {
     const {decelerationRate} = this.props;
     if (decelerationRate != null) {
       props.decelerationRate = processDecelerationRate(decelerationRate);
+    }
+
+    const {scrollAnimationEasing} = this.props;
+    if (scrollAnimationEasing != null) {
+      props.scrollAnimationEasing = processScrollAnimationEasing(
+        scrollAnimationEasing,
+      );
     }
 
     const refreshControl = this.props.refreshControl;

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponent.js
@@ -77,6 +77,8 @@ export const __INTERNAL_VIEW_CONFIG: PartialViewConfig =
           borderLeftColor: colorAttribute,
           snapToItemPadding: true,
           scrollAnimationEnabled: true,
+          scrollAnimationDuration: true,
+          scrollAnimationEasing: true,
           pointerEvents: true,
           isInvertedVirtualizedList: true,
           scrollsChildToFocus: true,

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
@@ -71,6 +71,9 @@ export type ScrollViewNativeProps = Readonly<{
   sendMomentumEvents?: ?boolean,
   showsHorizontalScrollIndicator?: ?boolean,
   scrollAnimationEnabled?: ?boolean,
+  scrollAnimationDuration?: ?number,
+  // Keyword easings are resolved to cubic-bezier control points in ScrollView.js.
+  scrollAnimationEasing?: ?ReadonlyArray<number>,
   showsScrollIndex?: ?boolean,
   showsVerticalScrollIndicator?: ?boolean,
   snapToAlignment?: ?('start' | 'center' | 'end' | 'item'),

--- a/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
+++ b/packages/react-native/Libraries/Components/ScrollView/ScrollViewNativeComponentType.js
@@ -72,8 +72,16 @@ export type ScrollViewNativeProps = Readonly<{
   showsHorizontalScrollIndicator?: ?boolean,
   scrollAnimationEnabled?: ?boolean,
   scrollAnimationDuration?: ?number,
-  // Keyword easings are resolved to cubic-bezier control points in ScrollView.js.
-  scrollAnimationEasing?: ?ReadonlyArray<number>,
+  // Accepts the unresolved prop value; ScrollView passes it through
+  // processScrollAnimationEasing, so native only sees control points.
+  scrollAnimationEasing?: ?(
+    | 'linear'
+    | 'ease'
+    | 'ease-in'
+    | 'ease-out'
+    | 'ease-in-out'
+    | [number, number, number, number]
+  ),
   showsScrollIndex?: ?boolean,
   showsVerticalScrollIndicator?: ?boolean,
   snapToAlignment?: ?('start' | 'center' | 'end' | 'item'),

--- a/packages/react-native/Libraries/Components/ScrollView/processScrollAnimationEasing.js
+++ b/packages/react-native/Libraries/Components/ScrollView/processScrollAnimationEasing.js
@@ -1,0 +1,40 @@
+/**
+ * Copyright (c) Meta Platforms, Inc. and affiliates.
+ *
+ * This source code is licensed under the MIT license found in the
+ * LICENSE file in the root directory of this source tree.
+ *
+ * @flow strict-local
+ * @format
+ */
+
+import type {ScrollAnimationEasing} from './ScrollView';
+
+type CubicBezierControlPoints = [number, number, number, number];
+
+// The native side only understands cubic-bezier control points, so the CSS easing
+// keywords are resolved to the control points those keywords are defined as.
+const SCROLL_ANIMATION_EASING_KEYWORDS: Readonly<{
+  linear: CubicBezierControlPoints,
+  ease: CubicBezierControlPoints,
+  'ease-in': CubicBezierControlPoints,
+  'ease-out': CubicBezierControlPoints,
+  'ease-in-out': CubicBezierControlPoints,
+}> = {
+  linear: [0, 0, 1, 1],
+  ease: [0.25, 0.1, 0.25, 1],
+  'ease-in': [0.42, 0, 1, 1],
+  'ease-out': [0, 0, 0.58, 1],
+  'ease-in-out': [0.42, 0, 0.58, 1],
+};
+
+function processScrollAnimationEasing(
+  easing: ScrollAnimationEasing,
+): CubicBezierControlPoints {
+  if (typeof easing === 'string') {
+    return SCROLL_ANIMATION_EASING_KEYWORDS[easing];
+  }
+  return easing;
+}
+
+export default processScrollAnimationEasing;

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.views.scroll
 
 import android.animation.ObjectAnimator
+import android.animation.TimeInterpolator
 import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Canvas
@@ -203,6 +204,10 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
   private var scrollsChildToFocus = true
   internal var snapToItemPadding: Int = 0
   internal var scrollAnimationEnabled: Boolean = true
+  /** Values <= 0 keep the platform default duration. */
+  internal var scrollAnimationDuration: Int = 0
+  /** `null` keeps the platform default curve. */
+  internal var scrollAnimationInterpolator: TimeInterpolator? = null
   private var blockScrollDelta: Boolean = false
 
   // Interface property overrides
@@ -301,6 +306,8 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     scrollsChildToFocus = true
     snapToItemPadding = 0
     scrollAnimationEnabled = true
+    scrollAnimationDuration = 0
+    scrollAnimationInterpolator = null
     blockScrollDelta = false
   }
 
@@ -1709,8 +1716,13 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     // not animated at all.
     defaultFlingAnimator.cancel()
 
-    // Update the fling animator with new values
-    val duration = ReactScrollViewHelper.getDefaultScrollAnimationDuration(context)
+    // Update the fling animator with new values. The animator is reused, so the interpolator must
+    // be re-applied on every call to undo whatever a previous `scrollAnimationEasing` left on it.
+    val duration =
+        if (scrollAnimationDuration > 0) scrollAnimationDuration
+        else ReactScrollViewHelper.getDefaultScrollAnimationDuration(context)
+    defaultFlingAnimator.interpolator =
+        scrollAnimationInterpolator ?: ReactScrollViewHelper.getDefaultScrollAnimationInterpolator()
     defaultFlingAnimator.setDuration(duration.toLong()).setIntValues(start, end)
 
     // Start the animator

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollViewManager.kt
@@ -42,6 +42,7 @@ import com.facebook.react.views.scroll.ReactScrollViewCommandHelper.Companion.re
 import com.facebook.react.views.scroll.ReactScrollViewCommandHelper.ScrollCommandHandler
 import com.facebook.react.views.scroll.ReactScrollViewCommandHelper.ScrollToCommandData
 import com.facebook.react.views.scroll.ReactScrollViewCommandHelper.ScrollToEndCommandData
+import com.facebook.react.views.scroll.ReactScrollViewHelper.createScrollAnimationInterpolator
 import com.facebook.react.views.scroll.ReactScrollViewHelper.parseOverScrollMode
 import com.facebook.react.views.scroll.ReactScrollViewHelper.parseSnapToAlignment
 
@@ -172,6 +173,18 @@ constructor(private val fpsListener: FpsListener? = null) :
   @ReactProp(name = "scrollAnimationEnabled", defaultBoolean = true)
   public fun setScrollAnimationEnabled(view: ReactHorizontalScrollView, value: Boolean) {
     view.scrollAnimationEnabled = value
+  }
+
+  @ReactProp(name = "scrollAnimationDuration")
+  public fun setScrollAnimationDuration(view: ReactHorizontalScrollView, value: Float) {
+    // Exposed as a float because of the JavaScript interface, see `snapToInterval`.
+    view.scrollAnimationDuration = value.toInt()
+  }
+
+  @ReactProp(name = "scrollAnimationEasing")
+  public fun setScrollAnimationEasing(view: ReactHorizontalScrollView, value: ReadableArray?) {
+    // Resolved here rather than per frame: the curve only changes when the prop does.
+    view.scrollAnimationInterpolator = createScrollAnimationInterpolator(value)
   }
 
   @ReactProp(name = ReactClippingViewGroupHelper.PROP_REMOVE_CLIPPED_SUBVIEWS)

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.views.scroll
 
 import android.animation.ObjectAnimator
+import android.animation.TimeInterpolator
 import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Canvas
@@ -212,6 +213,10 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
   private var scrollsChildToFocus = true
   internal var snapToItemPadding: Int = 0
   internal var scrollAnimationEnabled: Boolean = true
+  /** Values <= 0 keep the platform default duration. */
+  internal var scrollAnimationDuration: Int = 0
+  /** `null` keeps the platform default curve. */
+  internal var scrollAnimationInterpolator: TimeInterpolator? = null
   private var blockScrollDelta: Boolean = false
 
   init {
@@ -269,6 +274,8 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
     scrollsChildToFocus = true
     snapToItemPadding = 0
     scrollAnimationEnabled = true
+    scrollAnimationDuration = 0
+    scrollAnimationInterpolator = null
     blockScrollDelta = false
   }
 
@@ -1381,7 +1388,13 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
 
   override fun startFlingAnimator(start: Int, end: Int) {
     defaultFlingAnimator.cancel()
-    val duration = ReactScrollViewHelper.getDefaultScrollAnimationDuration(context)
+    // The animator is reused, so the interpolator must be re-applied on every call to undo whatever
+    // a previous `scrollAnimationEasing` left on it.
+    val duration =
+        if (scrollAnimationDuration > 0) scrollAnimationDuration
+        else ReactScrollViewHelper.getDefaultScrollAnimationDuration(context)
+    defaultFlingAnimator.interpolator =
+        scrollAnimationInterpolator ?: ReactScrollViewHelper.getDefaultScrollAnimationInterpolator()
     defaultFlingAnimator.setDuration(duration.toLong()).setIntValues(start, end)
     defaultFlingAnimator.start()
 

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -8,6 +8,7 @@
 package com.facebook.react.views.scroll
 
 import android.animation.Animator
+import android.animation.TimeInterpolator
 import android.animation.ValueAnimator
 import android.content.Context
 import android.graphics.Point
@@ -15,12 +16,15 @@ import android.graphics.Rect
 import android.os.Build
 import android.view.View
 import android.view.ViewGroup
+import android.view.animation.AccelerateDecelerateInterpolator
+import android.view.animation.PathInterpolator
 import android.widget.OverScroller
 import androidx.annotation.RequiresApi
 import androidx.core.view.ViewCompat.FocusDirection
 import androidx.core.view.ViewCompat.FocusRealDirection
 import com.facebook.common.logging.FLog
 import com.facebook.react.bridge.ReactContext
+import com.facebook.react.bridge.ReadableArray
 import com.facebook.react.bridge.WritableMap
 import com.facebook.react.bridge.WritableNativeMap
 import com.facebook.react.common.ReactConstants
@@ -66,6 +70,11 @@ public object ReactScrollViewHelper {
   // https://android.googlesource.com/platform/frameworks/base/+/ae5bcf23b5f0875e455790d6af387184dbd009c1/core/java/android/widget/OverScroller.java#44
   private var SMOOTH_SCROLL_DURATION = 250
   private var smoothScrollDurationInitialized = false
+
+  // The curve `ValueAnimator` applies when no interpolator is set, kept here so the reused fling
+  // animator can be reset to it once a custom `scrollAnimationEasing` is cleared.
+  private val defaultScrollAnimationInterpolator: TimeInterpolator =
+      AccelerateDecelerateInterpolator()
 
   /** Shared by [ReactScrollView] and [ReactHorizontalScrollView]. */
   @JvmStatic
@@ -235,6 +244,35 @@ public object ReactScrollViewHelper {
       } catch (e: Throwable) {}
     }
     return SMOOTH_SCROLL_DURATION
+  }
+
+  /** Curve used by the fling animator when `scrollAnimationEasing` is not set. */
+  @JvmStatic
+  public fun getDefaultScrollAnimationInterpolator(): TimeInterpolator =
+      defaultScrollAnimationInterpolator
+
+  /**
+   * Builds the `scrollAnimationEasing` curve from the CSS cubic-bezier control points `[x1, y1, x2,
+   * y2]` sent by JS. Returns `null` when the value is missing or does not describe a usable curve,
+   * so callers fall back to [getDefaultScrollAnimationInterpolator].
+   */
+  @JvmStatic
+  public fun createScrollAnimationInterpolator(controlPoints: ReadableArray?): TimeInterpolator? {
+    if (controlPoints == null || controlPoints.size() != 4) {
+      return null
+    }
+    return try {
+      PathInterpolator(
+          controlPoints.getDouble(0).toFloat(),
+          controlPoints.getDouble(1).toFloat(),
+          controlPoints.getDouble(2).toFloat(),
+          controlPoints.getDouble(3).toFloat(),
+      )
+    } catch (e: IllegalArgumentException) {
+      // PathInterpolator rejects curves that leave 0..1 on x or loop back on themselves.
+      FLog.w(ReactConstants.TAG, e, "Invalid scrollAnimationEasing control points")
+      null
+    }
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewManager.kt
@@ -41,6 +41,7 @@ import com.facebook.react.views.scroll.ReactScrollViewCommandHelper.Companion.re
 import com.facebook.react.views.scroll.ReactScrollViewCommandHelper.ScrollCommandHandler
 import com.facebook.react.views.scroll.ReactScrollViewCommandHelper.ScrollToCommandData
 import com.facebook.react.views.scroll.ReactScrollViewCommandHelper.ScrollToEndCommandData
+import com.facebook.react.views.scroll.ReactScrollViewHelper.createScrollAnimationInterpolator
 import com.facebook.react.views.scroll.ReactScrollViewHelper.parseOverScrollMode
 import com.facebook.react.views.scroll.ReactScrollViewHelper.parseSnapToAlignment
 import com.facebook.react.views.scroll.ScrollEventType.Companion.getJSEventName
@@ -156,6 +157,18 @@ constructor(private val fpsListener: FpsListener? = null) :
   @ReactProp(name = "scrollAnimationEnabled", defaultBoolean = true)
   public fun setScrollAnimationEnabled(view: ReactScrollView, value: Boolean) {
     view.scrollAnimationEnabled = value
+  }
+
+  @ReactProp(name = "scrollAnimationDuration")
+  public fun setScrollAnimationDuration(view: ReactScrollView, value: Float) {
+    // Exposed as a float because of the JavaScript interface, see `snapToInterval`.
+    view.scrollAnimationDuration = value.toInt()
+  }
+
+  @ReactProp(name = "scrollAnimationEasing")
+  public fun setScrollAnimationEasing(view: ReactScrollView, value: ReadableArray?) {
+    // Resolved here rather than per frame: the curve only changes when the prop does.
+    view.scrollAnimationInterpolator = createScrollAnimationInterpolator(value)
   }
 
   @ReactProp(name = ReactClippingViewGroupHelper.PROP_REMOVE_CLIPPED_SUBVIEWS)

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.cpp
@@ -55,6 +55,18 @@ HostPlatformScrollViewProps::HostPlatformScrollViewProps(
           rawProps,
           "snapToItemPadding",
           sourceProps.snapToItemPadding,
+          {})),
+      scrollAnimationDuration(convertRawProp(
+          context,
+          rawProps,
+          "scrollAnimationDuration",
+          sourceProps.scrollAnimationDuration,
+          {})),
+      scrollAnimationEasing(convertRawProp(
+          context,
+          rawProps,
+          "scrollAnimationEasing",
+          sourceProps.scrollAnimationEasing,
           {})) {}
 
 void HostPlatformScrollViewProps::setProp(
@@ -76,6 +88,8 @@ void HostPlatformScrollViewProps::setProp(
     RAW_SET_PROP_SWITCH_CASE_BASIC(overScrollMode);
     RAW_SET_PROP_SWITCH_CASE_BASIC(endFillColor);
     RAW_SET_PROP_SWITCH_CASE_BASIC(snapToItemPadding);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollAnimationDuration);
+    RAW_SET_PROP_SWITCH_CASE_BASIC(scrollAnimationEasing);
   }
 }
 
@@ -392,6 +406,18 @@ folly::dynamic HostPlatformScrollViewProps::getDiffProps(
 
   if (snapToItemPadding != oldProps->snapToItemPadding) {
     result["snapToItemPadding"] = snapToItemPadding;
+  }
+
+  if (scrollAnimationDuration != oldProps->scrollAnimationDuration) {
+    result["scrollAnimationDuration"] = scrollAnimationDuration;
+  }
+
+  if (scrollAnimationEasing != oldProps->scrollAnimationEasing) {
+    auto scrollAnimationEasingArray = folly::dynamic::array();
+    for (const auto& controlPoint : scrollAnimationEasing) {
+      scrollAnimationEasingArray.push_back(controlPoint);
+    }
+    result["scrollAnimationEasing"] = scrollAnimationEasingArray;
   }
 
   return result;

--- a/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
+++ b/packages/react-native/ReactCommon/react/renderer/components/scrollview/platform/android/react/renderer/components/scrollview/HostPlatformScrollViewProps.h
@@ -35,6 +35,9 @@ class HostPlatformScrollViewProps : public BaseScrollViewProps {
 
   Float snapToItemPadding{0};
 
+  Float scrollAnimationDuration{0};
+  std::vector<Float> scrollAnimationEasing{};
+
 #pragma mark - DebugStringConvertible
 
 #if RN_DEBUG_STRING_CONVERTIBLE

--- a/packages/react-native/types/public/ReactNativeTVTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTVTypes.d.ts
@@ -19,6 +19,32 @@ declare module 'react-native' {
      * @platform tv
      */
     scrollAnimationEnabled?: boolean | undefined;
+
+    /**
+     * Duration in milliseconds of the animated scroll that runs when focus moves to
+     * another item. When unset or <= 0, the platform default (~250ms) is used.
+     * On tvOS the focus engine owns this animation and the prop has no effect.
+     *
+     * @platform android
+     */
+    scrollAnimationDuration?: number | undefined;
+
+    /**
+     * Easing curve of that animation, either a CSS easing keyword or explicit
+     * cubic-bezier control points `[x1, y1, x2, y2]`. When unset, the platform
+     * default curve (`AccelerateDecelerateInterpolator`) is used.
+     * On tvOS the focus engine owns this animation and the prop has no effect.
+     *
+     * @platform android
+     */
+    scrollAnimationEasing?:
+      | 'linear'
+      | 'ease'
+      | 'ease-in'
+      | 'ease-out'
+      | 'ease-in-out'
+      | [number, number, number, number]
+      | undefined;
   }
 
   interface ViewProps {

--- a/packages/react-native/types/public/ReactNativeTVTypes.d.ts
+++ b/packages/react-native/types/public/ReactNativeTVTypes.d.ts
@@ -22,7 +22,9 @@ declare module 'react-native' {
 
     /**
      * Duration in milliseconds of the animated scroll that runs when focus moves to
-     * another item. When unset or <= 0, the platform default (~250ms) is used.
+     * another item. Applies to the snap scroll (`snapToAlignment="item"` with
+     * per-item `scrollSnapAlign`/`scrollSnapOffset` markers) and to animated
+     * `scrollTo` commands; other focus scrolls are instant. When unset or <= 0, the platform default (~250ms) is used.
      * On tvOS the focus engine owns this animation and the prop has no effect.
      *
      * @platform android

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewTVScrollAnimationExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewTVScrollAnimationExample.js
@@ -82,6 +82,85 @@ const SectionHeader = ({title}: {title: string}) => (
   </View>
 );
 
+const TimingRow = ({
+  title,
+  colorOffset,
+  scrollAnimationDuration,
+  scrollAnimationEasing,
+}: {
+  title: string,
+  colorOffset: number,
+  scrollAnimationDuration?: number,
+  scrollAnimationEasing?:
+    | 'linear'
+    | 'ease'
+    | 'ease-in'
+    | 'ease-out'
+    | 'ease-in-out'
+    | [number, number, number, number],
+}) => (
+  <View>
+    <SectionHeader title={title} />
+    <ScrollView
+      horizontal
+      scrollAnimationDuration={scrollAnimationDuration}
+      scrollAnimationEasing={scrollAnimationEasing}
+      showsHorizontalScrollIndicator={false}>
+      {Array.from({length: 15}, (_, i) => (
+        <View key={i} style={{marginRight: px(20)}}>
+          <Card
+            label={`Item ${i + 1}`}
+            width={280}
+            height={160}
+            colorIndex={i + colorOffset}
+          />
+        </View>
+      ))}
+    </ScrollView>
+  </View>
+);
+
+const ScrollViewTVScrollAnimationTimingExample = (): any => {
+  return (
+    <View
+      style={{
+        flex: 1,
+        backgroundColor: '#1a1a2e',
+        paddingTop: px(60),
+        paddingHorizontal: px(40),
+      }}>
+      <Text
+        style={{
+          fontSize: px(42),
+          fontWeight: '700',
+          color: '#ffffff',
+          marginBottom: px(32),
+        }}>
+        scrollAnimationDuration / scrollAnimationEasing Demo
+      </Text>
+
+      <View style={{gap: px(40)}}>
+        <TimingRow
+          title="Default — no props (~250ms, accelerate/decelerate)"
+          colorOffset={0}
+        />
+        <TimingRow
+          title="500ms — scrollAnimationEasing: 'ease-out'"
+          colorOffset={3}
+          scrollAnimationDuration={500}
+          scrollAnimationEasing="ease-out"
+        />
+        <TimingRow
+          title="500ms — scrollAnimationEasing: [0.26, 0.86, 0.44, 0.985]"
+          colorOffset={6}
+          scrollAnimationDuration={500}
+          scrollAnimationEasing={[0.26, 0.86, 0.44, 0.985]}
+        />
+      </View>
+    </View>
+  );
+};
+
 const ScrollViewTVScrollAnimationExample = (): any => {
   return (
     <View
@@ -146,14 +225,23 @@ const ScrollViewTVScrollAnimationExample = (): any => {
 
 exports.title = 'ScrollViewTVScrollAnimationExample';
 exports.category = 'TV';
-exports.description =
-  'Demonstrates scrollAnimationEnabled prop on TV platforms';
+exports.description = 'Demonstrates the scroll animation props on TV platforms';
 
 exports.examples = [
   {
     title: 'scrollAnimationEnabled example for TV',
     render(): React.MixedElement {
       return <ScrollViewTVScrollAnimationExample />;
+    },
+  },
+  {
+    title: 'scrollAnimationDuration / scrollAnimationEasing example for TV',
+    description:
+      'Android TV only. D-pad through each row and compare how the scroll ' +
+      'animation feels: the platform default, a slower ease-out, and a ' +
+      'custom cubic-bezier.',
+    render(): React.MixedElement {
+      return <ScrollViewTVScrollAnimationTimingExample />;
     },
   },
 ] as Array<RNTesterModuleExample>;

--- a/packages/rn-tester/js/examples/ScrollView/ScrollViewTVScrollAnimationExample.js
+++ b/packages/rn-tester/js/examples/ScrollView/ScrollViewTVScrollAnimationExample.js
@@ -105,9 +105,10 @@ const TimingRow = ({
       horizontal
       scrollAnimationDuration={scrollAnimationDuration}
       scrollAnimationEasing={scrollAnimationEasing}
-      showsHorizontalScrollIndicator={false}>
+      showsHorizontalScrollIndicator={false}
+      snapToAlignment="item">
       {Array.from({length: 15}, (_, i) => (
-        <View key={i} style={{marginRight: px(20)}}>
+        <View key={i} scrollSnapAlign="start" style={{marginRight: px(20)}}>
           <Card
             label={`Item ${i + 1}`}
             width={280}


### PR DESCRIPTION
**Problem**
- TV apps design their browse experience around the scroll feel, but on Android TV the snap scroll animation is fixed: the OverScroller default duration (~250ms) with the default `AccelerateDecelerateInterpolator`. The only lever is `scrollAnimationEnabled`. Matching a design language's scroll feel is impossible from JS.

**Cause**
- On tvOS the focus engine performs the snap scroll, so timing and easing are the platform's own (#1068, #1118). On Android the snap scroll is driven by the fork itself — `startFlingAnimator` runs an `ObjectAnimator` with a hardcoded duration and never sets an interpolator — so the platform never gets a say, and neither does the app.

**Fix**
- Add two ScrollView props, Android TV only, additive: `scrollAnimationDuration` (ms) and `scrollAnimationEasing` (CSS easing keyword or cubic-bezier `[x1, y1, x2, y2]`). Keywords resolve to their CSS bezier values in JS; native always receives four numbers and builds a `PathInterpolator`. Unset props keep today's behavior exactly.
- The interpolator is re-applied on every `startFlingAnimator` call (the animator instance is reused), and both props reset in `initView()` so recycled views don't inherit another view's timing.
- The RNTester TV scroll-animation example now shows rows with contrasting settings side by side. tvOS unchanged: the focus engine keeps owning the animation there.

**Changelog**

[ANDROID] [ADDED] - `scrollAnimationDuration` and `scrollAnimationEasing` props on ScrollView for Android TV

**AI usage**

Investigation, the change, and the RNTester example were produced with AI assistance (Claude Code), then human-reviewed and tested.


https://github.com/user-attachments/assets/ee88c899-4d01-4463-be1d-0795953b8ad8
