### PR TITLE
fix(tvos): resolve nextFocus* destinations set before the view was attached

### DIFF
--- a/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
+++ b/packages/react-native/React/Fabric/Mounting/ComponentViews/View/RCTViewComponentView.mm
@@ -514,6 +514,34 @@ static BOOL RCTLayerTransformCollapsesAxis(CALayer *layer)
 #endif
 }
 
+// Directional focus destinations are looked up in the containing root view when
+// `updateProps` runs. A destination set while this view is not attached yet --
+// e.g. a nextFocus* value delivered together with the view's creation -- resolves
+// to nil there, and `updateProps` never retries because the prop value does not
+// change. Re-resolve pending destinations lazily: `enableDirectionalFocusGuides`
+// only does work while the view is focused, at which point the hierarchy is
+// guaranteed to be attached.
+- (void)resolvePendingNextFocusTargets
+{
+  UIView *rootView = [self containingRootView];
+
+  if (rootView == nil) {
+    return;
+  }
+  if (_nextFocusUp == nil && _props->nextFocusUp.has_value()) {
+    _nextFocusUp = [rootView viewWithTag:_props->nextFocusUp.value()];
+  }
+  if (_nextFocusDown == nil && _props->nextFocusDown.has_value()) {
+    _nextFocusDown = [rootView viewWithTag:_props->nextFocusDown.value()];
+  }
+  if (_nextFocusLeft == nil && _props->nextFocusLeft.has_value()) {
+    _nextFocusLeft = [rootView viewWithTag:_props->nextFocusLeft.value()];
+  }
+  if (_nextFocusRight == nil && _props->nextFocusRight.has_value()) {
+    _nextFocusRight = [rootView viewWithTag:_props->nextFocusRight.value()];
+  }
+}
+
 // In tvOS, to support directional focus APIs, we add a UIFocusGuide for each
 // side of the view where a nextFocus has been set. Set layout constraints to
 // make the guide 1 px thick, and set the destination to the nextFocus object.
@@ -525,6 +553,8 @@ static BOOL RCTLayerTransformCollapsesAxis(CALayer *layer)
   if (!self.isFocused) {
     return;
   }
+
+  [self resolvePendingNextFocusTargets];
   if (self->_nextFocusUp != nil) {
     if (self.focusGuideUp == nil) {
       self.focusGuideUp = [UIFocusGuide new];


### PR DESCRIPTION
## Summary:

In `RCTViewComponentView.mm`, `updateProps` resolves `nextFocusUp/Down/Left/Right` as soon as the prop changes:

```objc
UIView *rootView = [self containingRootView];
_nextFocusDown = [rootView viewWithTag:newViewProps.nextFocusDown.value()];
```

If the prop is already set on the first `updateProps` call, the view is not attached yet, `containingRootView` is nil, and `_nextFocusDown` resolves to nil. It is never retried: the value never changes again, and `enableDirectionalFocusGuides` only consumes the ivar. The UIFocusGuide is never created, so any view that *mounts* with a `nextFocus*` value silently loses directional focus — while siblings that received the value as a later prop update work, which makes this very confusing to debug. Deferring the prop one commit from JS is not a reliable workaround either, since commit coalescing can merge the follow-up update into the creating transaction.

Same root cause as #1054 (`requestTVFocus`, tvOS) and #1137 (Android). Fix: `enableDirectionalFocusGuides` now calls `resolvePendingNextFocusTargets`, which re-runs the lookup for any direction whose ivar is nil but whose prop has a value. It runs while the view is focused, so the whole hierarchy is guaranteed to be attached and the lookup succeeds. Eagerly-resolved views and views without `nextFocus*` props are unaffected.

## Changelog:

[IOS] [FIXED] - Resolve nextFocus* destinations that were set before the view was attached to the window (tvOS)

## Test Plan:

```jsx
<View style={styles.toolbarTopRight}>
  {editMode && <Pressable nextFocusDown={target} />}                        {/* B: mounts with prop set — broken */}
  <Pressable nextFocusDown={target} onPress={() => setEditMode(true)} />    {/* A: got prop later — works */}
</View>
<Pressable ref={setTarget} style={styles.itemBottomLeft} />
```

The item must be outside the downward focus beam of the buttons (buttons top-right, item bottom-left), so only the `nextFocusDown` guide can redirect.

On tvOS simulator: focus A → select (mounts B) → focus B → press down.

- **Before:** down from A jumps to the item; down from B does nothing.
- **After:** down from both buttons jumps to the item. Up navigation unaffected.