### PR TITLE
fix(android): play focus navigation sound when scroll views move focus

### DIFF
--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactHorizontalScrollView.kt
@@ -761,7 +761,9 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
       val currentFocused = findFocus()
       val nextFocused = FocusFinder.getInstance().findNextFocus(this, currentFocused, direction)
       if (nextFocused != null && nextFocused !== currentFocused && nextFocused !== this) {
-        nextFocused.requestFocus(direction)
+        if (nextFocused.requestFocus(direction)) {
+          ReactScrollViewHelper.playFocusNavigationSoundEffect(this, direction)
+        }
         handled = true
       }
     } else if (pagingEnabled) {
@@ -772,16 +774,20 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
         val nextFocused = FocusFinder.getInstance().findNextFocus(this, currentFocused, direction)
         val rootChild = getContentView()
         if (nextFocused != null && isDescendantOf(rootChild, nextFocused)) {
-          if (snapToAlignment == SNAP_ALIGNMENT_ITEM) {
-            // When snapToAlignment is "item", don't use smoothScrollToNextPage (which scrolls
-            // by full page width and ignores snapToItemPadding). Just request focus —
-            // requestChildFocus → tryScrollSnapToChild handles scrolling with correct padding.
-            nextFocused.requestFocus()
-          } else {
-            if (!isScrolledInView(nextFocused) && !isMostlyScrolledInView(nextFocused)) {
-              smoothScrollToNextPage(direction)
-            }
-            nextFocused.requestFocus()
+          val focusMoved =
+              if (snapToAlignment == SNAP_ALIGNMENT_ITEM) {
+                // When snapToAlignment is "item", don't use smoothScrollToNextPage (which scrolls
+                // by full page width and ignores snapToItemPadding). Just request focus —
+                // requestChildFocus → tryScrollSnapToChild handles scrolling with correct padding.
+                nextFocused.requestFocus()
+              } else {
+                if (!isScrolledInView(nextFocused) && !isMostlyScrolledInView(nextFocused)) {
+                  smoothScrollToNextPage(direction)
+                }
+                nextFocused.requestFocus()
+              }
+          if (focusMoved) {
+            ReactScrollViewHelper.playFocusNavigationSoundEffect(this, direction)
           }
           handled = true
         } else {
@@ -794,7 +800,12 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
 
       pagedArrowScrolling = false
     } else {
+      val focusedBeforeScroll = findFocus()
       handled = super.arrowScroll(direction)
+      // super.arrowScroll() can scroll without moving focus, so only click when focus moved.
+      if (handled && findFocus() !== focusedBeforeScroll) {
+        ReactScrollViewHelper.playFocusNavigationSoundEffect(this, direction)
+      }
     }
 
     return handled

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollView.kt
@@ -502,12 +502,21 @@ constructor(context: Context, private val fpsListener: FpsListener? = null) :
       val currentFocused = findFocus()
       val nextFocused = FocusFinder.getInstance().findNextFocus(this, currentFocused, direction)
       if (nextFocused != null && nextFocused !== currentFocused && nextFocused !== this) {
-        nextFocused.requestFocus(direction)
+        if (nextFocused.requestFocus(direction)) {
+          ReactScrollViewHelper.playFocusNavigationSoundEffect(this, direction)
+        }
         return true
       }
       return false
     }
-    return super.arrowScroll(direction)
+
+    val focusedBeforeScroll = findFocus()
+    val handled = super.arrowScroll(direction)
+    // super.arrowScroll() can scroll without moving focus, so only click when focus moved.
+    if (handled && findFocus() !== focusedBeforeScroll) {
+      ReactScrollViewHelper.playFocusNavigationSoundEffect(this, direction)
+    }
+    return handled
   }
 
   /**

--- a/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
+++ b/packages/react-native/ReactAndroid/src/main/java/com/facebook/react/views/scroll/ReactScrollViewHelper.kt
@@ -13,6 +13,7 @@ import android.content.Context
 import android.graphics.Point
 import android.graphics.Rect
 import android.os.Build
+import android.view.SoundEffectConstants
 import android.view.View
 import android.view.ViewGroup
 import android.widget.OverScroller
@@ -572,6 +573,29 @@ public object ReactScrollViewHelper {
     host.updateClippingRect(ancestorIdList)
 
     return host.findViewById(nextFocusableViewId)
+  }
+
+  /**
+   * Plays the system focus navigation sound for a D-pad move the scroll view handled itself.
+   *
+   * ViewRootImpl only sonifies focus moves it performs, so any key event a scroll view consumes
+   * (which it does as soon as its content is scrollable) navigates silently. Call this after a
+   * successful requestFocus to keep the click consistent. It is a no-op when the user has system
+   * sounds off.
+   */
+  @JvmStatic
+  public fun playFocusNavigationSoundEffect(view: View, @FocusDirection direction: Int) {
+    val soundConstant =
+        when (direction) {
+          View.FOCUS_UP,
+          View.FOCUS_BACKWARD -> SoundEffectConstants.NAVIGATION_UP
+          View.FOCUS_DOWN,
+          View.FOCUS_FORWARD -> SoundEffectConstants.NAVIGATION_DOWN
+          View.FOCUS_LEFT -> SoundEffectConstants.NAVIGATION_LEFT
+          View.FOCUS_RIGHT -> SoundEffectConstants.NAVIGATION_RIGHT
+          else -> return
+        }
+    view.playSoundEffect(soundConstant)
   }
 
   /**


### PR DESCRIPTION
## Summary

Android only plays the focus navigation click when `ViewRootImpl` moves focus itself, and it only gets the chance when nothing consumed the key event. A scroll view consumes D-pad keys as soon as its content is scrollable and then moves focus with `requestFocus()`, so that click never happens.

On TV that means navigation sounds come and go depending on content length. A row short enough to fit on screen clicks, the same row with one more item in it goes quiet. Same story for a settings list once it grows past the viewport, which makes it look random from the outside.

This plays the matching `SoundEffectConstants.NAVIGATION_*` effect after any `requestFocus()` that actually succeeded, in both `ReactScrollView` and `ReactHorizontalScrollView`, including the `snapToAlignment="item"` paths from #1106 that bypass `super.arrowScroll()` entirely.

- New `ReactScrollViewHelper.playFocusNavigationSoundEffect(view, direction)`
- Called from both `arrowScroll()` overrides, only when focus actually moved
- In the `super.arrowScroll()` fallback the focused view is compared before and after, since it can scroll without moving focus
- No new sound assets. It's the same `View.playSoundEffect` the framework calls, so it stays a no-op when the user has system touch sounds off

The two sources can't double up: the framework only sonifies moves it performs (key unconsumed), and this only fires where the scroll view consumed the key. Nesting is fine too, since `ScrollView.dispatchKeyEvent` stops at the first consumer.

Caveat: on long press this plays the plain click per key event. The framework would use its randomized fast scroll variants on API 34+, but `arrowScroll()` never sees the `KeyEvent` and `getConstantForFocusDirection(direction, repeating)` needs an API level branch, so I left it out for now.

## Test plan

- [ ] Horizontal row wider than the screen: left/right clicks on every focus move
- [ ] Horizontal row that fits on screen: still one click per move, not two
- [ ] Vertical list long enough to scroll: up/down clicks
- [ ] `snapToAlignment="item"` on both axes
- [ ] At the edge of a list where focus doesn't move: no click
- [ ] System touch sounds off in Android settings: silent everywhere
- [ ] `pagingEnabled` horizontal scroll view
